### PR TITLE
Use existing application instance if it exists

### DIFF
--- a/src/Elmish.WPF/Program.fs
+++ b/src/Elmish.WPF/Program.fs
@@ -27,7 +27,7 @@ let private _run debug (window:Window) (programRun:Program<'t, 'model, 'msg, Vie
     |> programRun
     
     // Start WPF dispatch loop
-    let app = Application()
+    let app = if isNull Application.Current then Application() else Application.Current
     app.Run(window) //blocking
 
 /// Blocking function.


### PR DESCRIPTION
Fixes #41 

Turned out to be a devilishly simple fix. Simply use the existing application instance if it exists. AFAIK this is non-breaking, since there can only be one `Application` instance per AppDomain, so existing users have not been able to instantiate their own `Application` instance until now, ensuring that this is an opt-in feature.

With this simple change, users that need application-wide resources or otherwise need to specify an application instance can simply instantiate it before calling the `Program` functions. For example:

```f#
[<EntryPoint;STAThread>]
let main _argv =
  App() |> ignore
  Program.mkSimple init update view
  |> Program.runWindow (MainWindow())
```

Something like this should probably be added to the documentation and/or a sample.