### PR TITLE
memoize mapper in oneWayMap

### DIFF
--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -57,6 +57,7 @@
       <Paket>True</Paket>
       <Link>elmish/src/program.fs</Link>
     </Compile>
+    <Compile Include="Utils.fs" />
     <Compile Include="Binding.fs" />
     <Compile Include="ViewModel.fs" />
     <Compile Include="Cmd.fs" />

--- a/src/Elmish.WPF/Utils.fs
+++ b/src/Elmish.WPF/Utils.fs
@@ -1,0 +1,21 @@
+﻿[<AutoOpen>]
+module Elmish.WPF.Utils
+
+open System.Collections.Generic
+
+/// Wrapper for dictionary keys to support null/None keys
+[<Struct>]
+type private DictKey = K of obj
+
+/// Memoizes the last return value of the function
+let memoizeSingle f =
+    let cache = Dictionary<_, _>()
+    fun x ->
+        let key = K x
+        match cache.TryGetValue key with
+        | true, v -> v
+        | false, _ ->
+            cache.Clear()
+            let res = f x
+            cache.[key] <- res
+            res

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -62,7 +62,7 @@ and ViewModelBase<'model, 'msg>(m:'model, dispatch, propMap: ViewBindings<'model
                 | BindTwoWayValidation (getter,setter) -> name, GetSetValidate (getter,setter)
                 | BindCmd (exec,canExec) -> name, Cmd <| toCommand (exec,canExec)
                 | BindModel (_, propMap) -> name, Model <| toSubView propMap
-                | BindMap (getter,mapper) -> name, Map <| (getter,mapper)
+                | BindMap (getter,mapper) -> name, Map <| (getter, memoizeSingle mapper)
             )
         
         convert propMap |> List.iter (fun (n,a) -> props.Add(n,a))


### PR DESCRIPTION
Fixes #43

Briefly tested, seems to work fine. `mapper` now remembers the return value of its previous argument. (I chose to limit it to a single value since that fixes #43 and avoids memory usage concerns from remembering an unlimited number of return values.)