### PR TITLE
Several copy edits in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Not at all. The above example, as well as the samples, keep everything in a sing
 Since the commands (`Cmd<Msg>`) returned by `update` and `init` are just lists of functions, they are not particularly testable. A general pattern you can use to get around this, is to replace the commands with pure data that are transformed to the actual commands elsewhere:
 
 * Create a a `CmdMsg` union type with cases for each command you want to execute in the app
-* Make `update` and `init` return `model * CmdMsg list`  instead of `model * Cmd<Msg>`. Since `update` and `init` now returns just data, they are much easier to test.
+* Make `update` and `init` return `model * CmdMsg list`  instead of `model * Cmd<Msg>`. Since `update` and `init` now return just data, they are much easier to test.
 * Create a trivial/too-boring-to-test `cmdMsgToCmd` function that transforms a `CmdMsg` to the corresponding `Cmd`.
 * Finally, create “normal” versions of `init` and `update` that you can use when creating `Program`. Elmish.WPF provides `Program.mkProgramWpfWithCmdMsg` that does this for you (but there’s no magic going on – it’s really easy to do yourself).
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Not at all. The above example, as well as the samples, keep everything in a sing
 Since the commands (`Cmd<Msg>`) returned by `update` and `init` are just lists of functions, they are not particularly testable. A general pattern you can use to get around this, is to replace the commands with pure data that are transformed to the actual commands elsewhere:
 
 * Create a a `CmdMsg` union type with cases for each command you want to execute in the app
-* Make `update` and `init` return `model * CmdMsg list`  instead of `model * Cmd<Msg>`. Since `update` and `function` now returns just data, they are much easier to test.
+* Make `update` and `init` return `model * CmdMsg list`  instead of `model * Cmd<Msg>`. Since `update` and `init` now returns just data, they are much easier to test.
 * Create a trivial/too-boring-to-test `cmdMsgToCmd` function that transforms a `CmdMsg` to the corresponding `Cmd`.
 * Finally, create “normal” versions of `init` and `update` that you can use when creating `Program`. Elmish.WPF provides `Program.mkProgramWpfWithCmdMsg` that does this for you (but there’s no magic going on – it’s really easy to do yourself).
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Not at all. The above example, as well as the samples, keep everything in a sing
 Since the commands (`Cmd<Msg>`) returned by `update` and `init` are lists of functions, they are not particularly testable. A general pattern to get around this is to replace the commands with pure data that are transformed to the actual commands elsewhere:
 
 * Create a `CmdMsg` union type with cases for each command you want to execute in the app.
-* Make `update` and `init` return `model * CmdMsg list`  instead of `model * Cmd<Msg>`. Since `update` and `init` now return data, they are much easier to test.
+* Make `update` and `init` return `model * CmdMsg list` instead of `model * Cmd<Msg>`. Since `update` and `init` now return data, they are much easier to test.
 * Create a trivial/too-boring-to-test `cmdMsgToCmd` function that transforms a `CmdMsg` to the corresponding `Cmd`.
 * Finally, create “normal” versions of `init` and `update` that you can use when creating `Program`. Elmish.WPF provides `Program.mkProgramWpfWithCmdMsg` that does this for you (but there’s no magic going on – it’s really easy to do yourself).
 

--- a/README.md
+++ b/README.md
@@ -171,10 +171,10 @@ Not at all. The above example, as well as the samples, keep everything in a sing
 
 #### How can I test commands? What is the CmdMsg pattern?
 
-Since the commands (`Cmd<Msg>`) returned by `update` and `init` are just lists of functions, they are not particularly testable. A general pattern you can use to get around this is to replace the commands with pure data that are transformed to the actual commands elsewhere:
+Since the commands (`Cmd<Msg>`) returned by `update` and `init` are lists of functions, they are not particularly testable. A general pattern to get around this is to replace the commands with pure data that are transformed to the actual commands elsewhere:
 
 * Create a a `CmdMsg` union type with cases for each command you want to execute in the app
-* Make `update` and `init` return `model * CmdMsg list`  instead of `model * Cmd<Msg>`. Since `update` and `init` now return just data, they are much easier to test.
+* Make `update` and `init` return `model * CmdMsg list`  instead of `model * Cmd<Msg>`. Since `update` and `init` now return data, they are much easier to test.
 * Create a trivial/too-boring-to-test `cmdMsgToCmd` function that transforms a `CmdMsg` to the corresponding `Cmd`.
 * Finally, create “normal” versions of `init` and `update` that you can use when creating `Program`. Elmish.WPF provides `Program.mkProgramWpfWithCmdMsg` that does this for you (but there’s no magic going on – it’s really easy to do yourself).
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Not at all. The above example, as well as the samples, keep everything in a sing
 
 #### How can I test commands? What is the CmdMsg pattern?
 
-Since the commands (`Cmd<Msg>`) returned by `update` and `init` are just lists of functions, they are not particularly testable. A general pattern you can use to get around this, is to replace the commands with pure data that are transformed to the actual commands elsewhere:
+Since the commands (`Cmd<Msg>`) returned by `update` and `init` are just lists of functions, they are not particularly testable. A general pattern you can use to get around this is to replace the commands with pure data that are transformed to the actual commands elsewhere:
 
 * Create a a `CmdMsg` union type with cases for each command you want to execute in the app
 * Make `update` and `init` return `model * CmdMsg list`  instead of `model * Cmd<Msg>`. Since `update` and `init` now return just data, they are much easier to test.

--- a/README.md
+++ b/README.md
@@ -171,10 +171,10 @@ Not at all. The above example, as well as the samples, keep everything in a sing
 
 #### How can I test commands? What is the CmdMsg pattern?
 
-Since the commands (`Cmd<Msg>`) returned by `update` and `init` are lists of functions, they are not particularly testable. A general pattern to get around this is to replace the commands with pure data that are transformed to the actual commands elsewhere:
+Since the commands (`Cmd<Msg>`) returned by `init` and `update` are lists of functions, they are not particularly testable. A general pattern to get around this is to replace the commands with pure data that are transformed to the actual commands elsewhere:
 
 * Create a `CmdMsg` union type with cases for each command you want to execute in the app.
-* Make `update` and `init` return `model * CmdMsg list` instead of `model * Cmd<Msg>`. Since `update` and `init` now return data, they are much easier to test.
+* Make `init` and `update` return `model * CmdMsg list` instead of `model * Cmd<Msg>`. Since `init` and `update` now return data, they are much easier to test.
 * Create a trivial/too-boring-to-test `cmdMsgToCmd` function that transforms a `CmdMsg` to the corresponding `Cmd`.
 * Finally, create “normal” versions of `init` and `update` that you can use when creating `Program`. Elmish.WPF provides `Program.mkProgramWpfWithCmdMsg` that does this for you (but there’s no magic going on – it’s really easy to do yourself).
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Not at all. The above example, as well as the samples, keep everything in a sing
 
 Since the commands (`Cmd<Msg>`) returned by `update` and `init` are lists of functions, they are not particularly testable. A general pattern to get around this is to replace the commands with pure data that are transformed to the actual commands elsewhere:
 
-* Create a a `CmdMsg` union type with cases for each command you want to execute in the app.
+* Create a `CmdMsg` union type with cases for each command you want to execute in the app.
 * Make `update` and `init` return `model * CmdMsg list`  instead of `model * Cmd<Msg>`. Since `update` and `init` now return data, they are much easier to test.
 * Create a trivial/too-boring-to-test `cmdMsgToCmd` function that transforms a `CmdMsg` to the corresponding `Cmd`.
 * Finally, create “normal” versions of `init` and `update` that you can use when creating `Program`. Elmish.WPF provides `Program.mkProgramWpfWithCmdMsg` that does this for you (but there’s no magic going on – it’s really easy to do yourself).

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Not at all. The above example, as well as the samples, keep everything in a sing
 
 Since the commands (`Cmd<Msg>`) returned by `update` and `init` are lists of functions, they are not particularly testable. A general pattern to get around this is to replace the commands with pure data that are transformed to the actual commands elsewhere:
 
-* Create a a `CmdMsg` union type with cases for each command you want to execute in the app
+* Create a a `CmdMsg` union type with cases for each command you want to execute in the app.
 * Make `update` and `init` return `model * CmdMsg list`  instead of `model * Cmd<Msg>`. Since `update` and `init` now return data, they are much easier to test.
 * Create a trivial/too-boring-to-test `cmdMsgToCmd` function that transforms a `CmdMsg` to the corresponding `Cmd`.
 * Finally, create “normal” versions of `init` and `update` that you can use when creating `Program`. Elmish.WPF provides `Program.mkProgramWpfWithCmdMsg` that does this for you (but there’s no magic going on – it’s really easy to do yourself).


### PR DESCRIPTION
I think I found some improvements to the documentation in README.md.  I made each type of change in a separate commit.  Feel free to squash to a single commit before merging.