### PR TITLE
Fix reordering bug in tree view sample

### DIFF
--- a/src/Samples/SubModelSeq.Views/MainWindow.xaml
+++ b/src/Samples/SubModelSeq.Views/MainWindow.xaml
@@ -5,9 +5,7 @@
     Title="SubModelSeq" Height="800" Width="1100"
     WindowStartupLocation="CenterScreen">
   <StackPanel Margin="0,20,0,10">
-    <StackPanel
-        Orientation="Horizontal"
-        HorizontalAlignment="Center">
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
       <Button Command="{Binding AddCounter}" Content="Add counter" Width="150" Margin="10,0,10,20" />
       <Button Command="{Binding ToggleGlobalState}" Content="Toggle global state" Width="150" Margin="10,0,10,20" />
     </StackPanel>
@@ -28,20 +26,10 @@
             <TextBlock Text="{Binding StepSize, StringFormat='Step size: {0}'}" Margin="0,5,10,5" />
             <Slider Value="{Binding StepSize}" TickFrequency="1" Maximum="10" Minimum="1" IsSnapToTickEnabled="True" Width="100" Margin="0,5,10,5" />
             <Button Command="{Binding AddChild}" Content="Add child" Margin="0,5,10,5" />
-            <Button
-                Command="{Binding Remove}"
-                Content="×" Margin="0,5,10,5" Width="20" />
-            <Button
-                Command="{Binding MoveUp}"
-                CommandParameter="{Binding CounterId}"
-                Content="↑" Margin="0,5,10,5" Width="20" />
-            <Button
-                Command="{Binding MoveDown}"
-                CommandParameter="{Binding CounterId}"
-                Content="↓" Margin="0,5,10,5" Width="20"/>
-            <TextBlock
-                Text="{Binding GlobalState, StringFormat='Global state: {0}'}"
-                Margin="10,5,10,5" />
+            <Button Command="{Binding Remove}" Content="×" Margin="0,5,10,5" Width="20" />
+            <Button Command="{Binding MoveUp}" CommandParameter="{Binding CounterId}" Content="↑" Margin="0,5,10,5" Width="20" />
+            <Button Command="{Binding MoveDown}" CommandParameter="{Binding CounterId}" Content="↓" Margin="0,5,10,5" Width="20"/>
+            <TextBlock Text="{Binding GlobalState, StringFormat='Global state: {0}'}" Margin="10,5,10,5" />
           </StackPanel>
         </HierarchicalDataTemplate>
       </TreeView.ItemTemplate>

--- a/src/Samples/SubModelSeq/Program.fs
+++ b/src/Samples/SubModelSeq/Program.fs
@@ -4,6 +4,16 @@ open System
 open Elmish
 open Elmish.WPF
 
+module List =
+
+  let swap i j =
+    List.permute
+      (function
+       | a when a = i -> j
+       | a when a = j -> i
+       | a -> a)
+
+
 [<AutoOpen>]
 module Domain =
 
@@ -151,7 +161,7 @@ module App =
       let f (n:Tree.Node<Counter>) =
         let oi = n.Children |> List.tryFindIndex (fun nn -> nn.Data.Id = id)
         match oi with
-        | Some i -> { n with Children = (n.Children |> List.take (i - 1)) @ [n.Children |> List.item i] @ [n.Children |> List.item (i - 1)] @ (n.Children |> List.skip (i + 1)) }
+        | Some i -> { n with Children = n.Children |> List.swap i (i - 1) }
         | None -> n
       { m with DummyRoot = m.DummyRoot |> Tree.map f }
 
@@ -159,7 +169,7 @@ module App =
       let f (n:Tree.Node<Counter>) =
         let oi = n.Children |> List.tryFindIndex (fun nn -> nn.Data.Id = id)
         match oi with
-        | Some i -> { n with Children = (n.Children |> List.take i) @ [n.Children |> List.item (i + 1)] @ [n.Children |> List.item i] @ (n.Children |> List.skip (i + 2)) }
+        | Some i -> { n with Children = n.Children |> List.swap i (i + 1) }
         | None -> n
       { m with DummyRoot = m.DummyRoot |> Tree.map f }
 


### PR DESCRIPTION
Resolves issue #95.

I think this is one way to fix the bug.  I switched the model from representing the graph (abstractly) as a list vertices and a list of edges to representing it directly.  Specifically, I created
```
module Tree =
  type Node<'a> =
    { Data: 'a
      Children: Node<'a> list }
```
which seems to be what Haskell calls a [Rose Tree](https://en.wikipedia.org/wiki/Rose_tree).

I just got it working, so my code might be a bit messy.  I can clean it up still in this PR or in a future one.