### PR TITLE
#105 logging improvements

### DIFF
--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -5,6 +5,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Logging.fs" />
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="InternalUtils.fs" />
     <Compile Include="InternalTypes.fs" />

--- a/src/Elmish.WPF/Logging.fs
+++ b/src/Elmish.WPF/Logging.fs
@@ -1,60 +1,60 @@
 ﻿module Elmish.WPF.Logging
 
 
-let compositeLogger loggers s =
+let internal compositeLogger loggers s =
   loggers |> Seq.iter (fun logger -> logger s)
 
 
-type PropertyChangedData =
+type internal PropertyChangedData =
   { PropertyNameChain: string
     PropertyName: string }
 
-type ValidationErrorsChangedData =
+type internal ValidationErrorsChangedData =
   { PropertyNameChain: string
     PropertyName: string }  // TODO: add Errors
 
-type TimingData =
+type internal TimingData =
   { PropertyNameChain: string
     PropertyName: string
     BindingDataFunctionName: string
     ElapsedMilliseconds: int64 }
 
-type CreatingHiddenWindowData =
+type internal CreatingHiddenWindowData =
   { PropertyNameChain: string }
 
-type CreatingVisibleWindowData =
+type internal CreatingVisibleWindowData =
   { PropertyNameChain: string }
 
-type InitializingBindingsData =
+type internal InitializingBindingsData =
   { PropertyNameChain: string }
 
-type ClosingWindowData =
+type internal ClosingWindowData =
   { PropertyNameChain: string }
 
-type HindingWindowData =
+type internal HindingWindowData =
   { PropertyNameChain: string }
 
-type ShowingHiddenWindow =
+type internal ShowingHiddenWindow =
   { PropertyNameChain: string }
 
-type NewSubModelSelectedItemSelectionData =
+type internal NewSubModelSelectedItemSelectionData =
   { PropertyNameChain: string
     NewSelection: obj voption }
 
-type TryGetMemberCalledData =
+type internal TryGetMemberCalledData =
   { PropertyNameChain: string
     PropertyName: string }
 
-type TrySetMemberCalledData =
+type internal TrySetMemberCalledData =
   { PropertyNameChain: string
     PropertyName: string }
 
-type GettingErrorsData =
+type internal GettingErrorsData =
   { PropertyNameChain: string
     PropertyName: string option }
 
 
-type TraceLogData =
+type internal TraceLogData =
   | PropertyChangedData of PropertyChangedData
   | ValidationErrorsChangedData of ValidationErrorsChangedData // TODO: Split by adding ValidationErrorsRemovedData
   | TimingData of TimingData
@@ -70,7 +70,7 @@ type TraceLogData =
   | GettingErrorsData of GettingErrorsData
 
 
-let logTraceWith logger data =
+let internal logTraceWith logger data =
   let log fmt = Printf.kprintf logger fmt
   match data with
   | PropertyChangedData d -> log "[%s] PropertyChanged \"%s\"" d.PropertyNameChain d.PropertyName
@@ -88,29 +88,29 @@ let logTraceWith logger data =
   | GettingErrorsData d -> log "[%s] GetErrors %s" d.PropertyNameChain (d.PropertyName |> Option.defaultValue "<null>")
   
 
-type WindowToCloseMissingData =
+type internal WindowToCloseMissingData =
   { PropertyNameChain: string }
 
-type WindowToHideMissingData =
+type internal WindowToHideMissingData =
   { PropertyNameChain: string }
 
-type WindowToShowMissingData =
+type internal WindowToShowMissingData =
   { PropertyNameChain: string }
 
-type TryGetMemberMissingBindingData =
+type internal TryGetMemberMissingBindingData =
   { PropertyNameChain: string
     PropertyName: string }
 
-type TrySetMemberMissingBindingData =
+type internal TrySetMemberMissingBindingData =
   { PropertyNameChain: string
     PropertyName: string }
 
-type TrySetMemberReadOnlyBindingData =
+type internal TrySetMemberReadOnlyBindingData =
   { PropertyNameChain: string
     PropertyName: string }
 
 
-type ErrorLogData =
+type internal ErrorLogData =
   | WindowToCloseMissingData of WindowToCloseMissingData
   | WindowToHideMissingData of WindowToHideMissingData
   | WindowToShowMissingData of WindowToShowMissingData
@@ -119,7 +119,7 @@ type ErrorLogData =
   | TrySetMemberReadOnlyBindingData of TrySetMemberReadOnlyBindingData
 
 
-let logErrorWith logger data =
+let internal logErrorWith logger data =
   let log fmt = Printf.kprintf logger fmt
   match data with
   | WindowToCloseMissingData d -> log "[%s] Attempted to close window, but did not find window reference" d.PropertyNameChain

--- a/src/Elmish.WPF/Logging.fs
+++ b/src/Elmish.WPF/Logging.fs
@@ -37,7 +37,7 @@ type HidingWindowData =
 type ShowingHiddenWindow =
   { PropertyNameChain: string }
 
-type NewSubModelSelectedItemSelectionData =
+type NewSubModelSelectedData =
   { PropertyNameChain: string
     NewSelection: obj voption }
 
@@ -64,7 +64,7 @@ type TraceLogData =
   | ClosingWindow of ClosingWindowData
   | HidingWindow of HidingWindowData
   | ShowingHiddenWindow of ShowingHiddenWindow
-  | NewSubModelSelectedItemSelection of NewSubModelSelectedItemSelectionData
+  | NewSubModelSelected of NewSubModelSelectedData
   | TryGetMemberCalled of TryGetMemberCalledData
   | TrySetMemberCalled of TrySetMemberCalledData
   | GettingErrors of GettingErrorsData
@@ -82,7 +82,7 @@ let logTraceWith logger data =
   | ClosingWindow d -> log "[%s] Closing window" d.PropertyNameChain
   | HidingWindow d -> log "[%s] Hiding window" d.PropertyNameChain
   | ShowingHiddenWindow d -> log "[%s] Showing existing hidden window" d.PropertyNameChain
-  | NewSubModelSelectedItemSelection d -> log "[%s] Setting selected VM to %A" d.PropertyNameChain d.NewSelection
+  | NewSubModelSelected d -> log "[%s] Setting selected VM to %A" d.PropertyNameChain d.NewSelection
   | TryGetMemberCalled d -> log "[%s] TryGetMember %s" d.PropertyNameChain d.PropertyName
   | TrySetMemberCalled d -> log "[%s] TrySetMember %s" d.PropertyNameChain d.PropertyName
   | GettingErrors d -> log "[%s] GetErrors %s" d.PropertyNameChain (d.PropertyName |> Option.defaultValue "<null>")

--- a/src/Elmish.WPF/Logging.fs
+++ b/src/Elmish.WPF/Logging.fs
@@ -1,0 +1,130 @@
+﻿module Elmish.WPF.Logging
+
+
+let compositeLogger loggers s =
+  loggers |> Seq.iter (fun logger -> logger s)
+
+
+type PropertyChangedData =
+  { PropertyNameChain: string
+    PropertyName: string }
+
+type ValidationErrorsChangedData =
+  { PropertyNameChain: string
+    PropertyName: string }  // TODO: add Errors
+
+type TimingData =
+  { PropertyNameChain: string
+    PropertyName: string
+    BindingDataFunctionName: string
+    ElapsedMilliseconds: int64 }
+
+type CreatingHiddenWindowData =
+  { PropertyNameChain: string }
+
+type CreatingVisibleWindowData =
+  { PropertyNameChain: string }
+
+type InitializingBindingsData =
+  { PropertyNameChain: string }
+
+type ClosingWindowData =
+  { PropertyNameChain: string }
+
+type HindingWindowData =
+  { PropertyNameChain: string }
+
+type ShowingHiddenWindow =
+  { PropertyNameChain: string }
+
+type NewSubModelSelectedItemSelectionData =
+  { PropertyNameChain: string
+    NewSelection: obj voption }
+
+type TryGetMemberCalledData =
+  { PropertyNameChain: string
+    PropertyName: string }
+
+type TrySetMemberCalledData =
+  { PropertyNameChain: string
+    PropertyName: string }
+
+type GettingErrorsData =
+  { PropertyNameChain: string
+    PropertyName: string option }
+
+
+type TraceLogData =
+  | PropertyChangedData of PropertyChangedData
+  | ValidationErrorsChangedData of ValidationErrorsChangedData // TODO: Split by adding ValidationErrorsRemovedData
+  | TimingData of TimingData
+  | CreatingHiddenWindowData of CreatingHiddenWindowData
+  | CreatingVisibleWindowData of CreatingVisibleWindowData
+  | InitializingBindingsData of InitializingBindingsData
+  | ClosingWindowData of ClosingWindowData
+  | HindingWindowData of HindingWindowData
+  | ShowingHiddenWindow of ShowingHiddenWindow
+  | NewSubModelSelectedItemSelectionData of NewSubModelSelectedItemSelectionData
+  | TryGetMemberCalledData of TryGetMemberCalledData
+  | TrySetMemberCalledData of TrySetMemberCalledData
+  | GettingErrorsData of GettingErrorsData
+
+
+let logTraceWith logger data =
+  let log fmt = Printf.kprintf logger fmt
+  match data with
+  | PropertyChangedData d -> log "[%s] PropertyChanged \"%s\"" d.PropertyNameChain d.PropertyName
+  | ValidationErrorsChangedData d -> log "[%s] ErrorsChanged \"%s\"" d.PropertyNameChain d.PropertyName
+  | TimingData d -> log "[%s] %s (%ims): %s" d.PropertyNameChain d.BindingDataFunctionName d.ElapsedMilliseconds d.PropertyName
+  | CreatingHiddenWindowData d -> log "[%s] Creating hidden window" d.PropertyNameChain
+  | CreatingVisibleWindowData d -> log "[%s] Creating and opening window" d.PropertyNameChain
+  | InitializingBindingsData d -> log "[%s] Initializing bindings" d.PropertyNameChain
+  | ClosingWindowData d -> log "[%s] Closing window" d.PropertyNameChain
+  | HindingWindowData d -> log "[%s] Hiding window" d.PropertyNameChain
+  | ShowingHiddenWindow d -> log "[%s] Showing existing hidden window" d.PropertyNameChain
+  | NewSubModelSelectedItemSelectionData d -> log "[%s] Setting selected VM to %A" d.PropertyNameChain d.NewSelection
+  | TryGetMemberCalledData d -> log "[%s] TryGetMember %s" d.PropertyNameChain d.PropertyName
+  | TrySetMemberCalledData d -> log "[%s] TrySetMember %s" d.PropertyNameChain d.PropertyName
+  | GettingErrorsData d -> log "[%s] GetErrors %s" d.PropertyNameChain (d.PropertyName |> Option.defaultValue "<null>")
+  
+
+type WindowToCloseMissingData =
+  { PropertyNameChain: string }
+
+type WindowToHideMissingData =
+  { PropertyNameChain: string }
+
+type WindowToShowMissingData =
+  { PropertyNameChain: string }
+
+type TryGetMemberMissingBindingData =
+  { PropertyNameChain: string
+    PropertyName: string }
+
+type TrySetMemberMissingBindingData =
+  { PropertyNameChain: string
+    PropertyName: string }
+
+type TrySetMemberReadOnlyBindingData =
+  { PropertyNameChain: string
+    PropertyName: string }
+
+
+type ErrorLogData =
+  | WindowToCloseMissingData of WindowToCloseMissingData
+  | WindowToHideMissingData of WindowToHideMissingData
+  | WindowToShowMissingData of WindowToShowMissingData
+  | TryGetMemberMissingBindingData of TryGetMemberMissingBindingData
+  | TrySetMemberMissingBindingData of TrySetMemberMissingBindingData
+  | TrySetMemberReadOnlyBindingData of TrySetMemberReadOnlyBindingData
+
+
+let logErrorWith logger data =
+  let log fmt = Printf.kprintf logger fmt
+  match data with
+  | WindowToCloseMissingData d -> log "[%s] Attempted to close window, but did not find window reference" d.PropertyNameChain
+  | WindowToHideMissingData d -> log "[%s] Attempted to hide window, but did not find window reference" d.PropertyNameChain
+  | WindowToShowMissingData d -> log "[%s] Attempted to show existing hidden window, but did not find window reference" d.PropertyNameChain
+  | TryGetMemberMissingBindingData d -> log "[%s] TryGetMember FAILED: Property %s doesn't exist" d.PropertyNameChain d.PropertyName
+  | TrySetMemberMissingBindingData d -> log "[%s] TrySetMember FAILED: Property %s doesn't exist" d.PropertyNameChain d.PropertyName
+  | TrySetMemberReadOnlyBindingData d -> log "[%s] TrySetMember FAILED: Binding %s is read-only" d.PropertyNameChain d.PropertyName

--- a/src/Elmish.WPF/Logging.fs
+++ b/src/Elmish.WPF/Logging.fs
@@ -1,60 +1,60 @@
-﻿module Elmish.WPF.Logging
+﻿module internal Elmish.WPF.Logging
 
 
-let internal compositeLogger loggers s =
+let compositeLogger loggers s =
   loggers |> Seq.iter (fun logger -> logger s)
 
 
-type internal PropertyChangedData =
+type PropertyChangedData =
   { PropertyNameChain: string
     PropertyName: string }
 
-type internal ValidationErrorsChangedData =
+type ValidationErrorsChangedData =
   { PropertyNameChain: string
     PropertyName: string }  // TODO: add Errors
 
-type internal TimingData =
+type TimingData =
   { PropertyNameChain: string
     PropertyName: string
     BindingDataFunctionName: string
     ElapsedMilliseconds: int64 }
 
-type internal CreatingHiddenWindowData =
+type CreatingHiddenWindowData =
   { PropertyNameChain: string }
 
-type internal CreatingVisibleWindowData =
+type CreatingVisibleWindowData =
   { PropertyNameChain: string }
 
-type internal InitializingBindingsData =
+type InitializingBindingsData =
   { PropertyNameChain: string }
 
-type internal ClosingWindowData =
+type ClosingWindowData =
   { PropertyNameChain: string }
 
-type internal HindingWindowData =
+type HindingWindowData =
   { PropertyNameChain: string }
 
-type internal ShowingHiddenWindow =
+type ShowingHiddenWindow =
   { PropertyNameChain: string }
 
-type internal NewSubModelSelectedItemSelectionData =
+type NewSubModelSelectedItemSelectionData =
   { PropertyNameChain: string
     NewSelection: obj voption }
 
-type internal TryGetMemberCalledData =
+type TryGetMemberCalledData =
   { PropertyNameChain: string
     PropertyName: string }
 
-type internal TrySetMemberCalledData =
+type TrySetMemberCalledData =
   { PropertyNameChain: string
     PropertyName: string }
 
-type internal GettingErrorsData =
+type GettingErrorsData =
   { PropertyNameChain: string
     PropertyName: string option }
 
 
-type internal TraceLogData =
+type TraceLogData =
   | PropertyChangedData of PropertyChangedData
   | ValidationErrorsChangedData of ValidationErrorsChangedData // TODO: Split by adding ValidationErrorsRemovedData
   | TimingData of TimingData
@@ -70,7 +70,7 @@ type internal TraceLogData =
   | GettingErrorsData of GettingErrorsData
 
 
-let internal logTraceWith logger data =
+let logTraceWith logger data =
   let log fmt = Printf.kprintf logger fmt
   match data with
   | PropertyChangedData d -> log "[%s] PropertyChanged \"%s\"" d.PropertyNameChain d.PropertyName
@@ -88,29 +88,29 @@ let internal logTraceWith logger data =
   | GettingErrorsData d -> log "[%s] GetErrors %s" d.PropertyNameChain (d.PropertyName |> Option.defaultValue "<null>")
   
 
-type internal WindowToCloseMissingData =
+type WindowToCloseMissingData =
   { PropertyNameChain: string }
 
-type internal WindowToHideMissingData =
+type WindowToHideMissingData =
   { PropertyNameChain: string }
 
-type internal WindowToShowMissingData =
+type WindowToShowMissingData =
   { PropertyNameChain: string }
 
-type internal TryGetMemberMissingBindingData =
+type TryGetMemberMissingBindingData =
   { PropertyNameChain: string
     PropertyName: string }
 
-type internal TrySetMemberMissingBindingData =
+type TrySetMemberMissingBindingData =
   { PropertyNameChain: string
     PropertyName: string }
 
-type internal TrySetMemberReadOnlyBindingData =
+type TrySetMemberReadOnlyBindingData =
   { PropertyNameChain: string
     PropertyName: string }
 
 
-type internal ErrorLogData =
+type ErrorLogData =
   | WindowToCloseMissingData of WindowToCloseMissingData
   | WindowToHideMissingData of WindowToHideMissingData
   | WindowToShowMissingData of WindowToShowMissingData
@@ -119,7 +119,7 @@ type internal ErrorLogData =
   | TrySetMemberReadOnlyBindingData of TrySetMemberReadOnlyBindingData
 
 
-let internal logErrorWith logger data =
+let logErrorWith logger data =
   let log fmt = Printf.kprintf logger fmt
   match data with
   | WindowToCloseMissingData d -> log "[%s] Attempted to close window, but did not find window reference" d.PropertyNameChain

--- a/src/Elmish.WPF/Logging.fs
+++ b/src/Elmish.WPF/Logging.fs
@@ -31,7 +31,7 @@ type InitializingBindingsData =
 type ClosingWindowData =
   { PropertyNameChain: string }
 
-type HindingWindowData =
+type HidingWindowData =
   { PropertyNameChain: string }
 
 type ShowingHiddenWindow =
@@ -62,7 +62,7 @@ type TraceLogData =
   | CreatingVisibleWindow of CreatingVisibleWindowData
   | InitializingBindings of InitializingBindingsData
   | ClosingWindow of ClosingWindowData
-  | HindingWindow of HindingWindowData
+  | HidingWindow of HidingWindowData
   | ShowingHiddenWindow of ShowingHiddenWindow
   | NewSubModelSelectedItemSelection of NewSubModelSelectedItemSelectionData
   | TryGetMemberCalled of TryGetMemberCalledData
@@ -80,7 +80,7 @@ let logTraceWith logger data =
   | CreatingVisibleWindow d -> log "[%s] Creating and opening window" d.PropertyNameChain
   | InitializingBindings d -> log "[%s] Initializing bindings" d.PropertyNameChain
   | ClosingWindow d -> log "[%s] Closing window" d.PropertyNameChain
-  | HindingWindow d -> log "[%s] Hiding window" d.PropertyNameChain
+  | HidingWindow d -> log "[%s] Hiding window" d.PropertyNameChain
   | ShowingHiddenWindow d -> log "[%s] Showing existing hidden window" d.PropertyNameChain
   | NewSubModelSelectedItemSelection d -> log "[%s] Setting selected VM to %A" d.PropertyNameChain d.NewSelection
   | TryGetMemberCalled d -> log "[%s] TryGetMember %s" d.PropertyNameChain d.PropertyName

--- a/src/Elmish.WPF/Logging.fs
+++ b/src/Elmish.WPF/Logging.fs
@@ -55,37 +55,37 @@ type GettingErrorsData =
 
 
 type TraceLogData =
-  | PropertyChangedData of PropertyChangedData
-  | ValidationErrorsChangedData of ValidationErrorsChangedData // TODO: Split by adding ValidationErrorsRemovedData
-  | TimingData of TimingData
-  | CreatingHiddenWindowData of CreatingHiddenWindowData
-  | CreatingVisibleWindowData of CreatingVisibleWindowData
-  | InitializingBindingsData of InitializingBindingsData
-  | ClosingWindowData of ClosingWindowData
-  | HindingWindowData of HindingWindowData
+  | PropertyChanged of PropertyChangedData
+  | ValidationErrorsChanged of ValidationErrorsChangedData // TODO: Split by adding ValidationErrorsRemovedData
+  | Timing of TimingData
+  | CreatingHiddenWindow of CreatingHiddenWindowData
+  | CreatingVisibleWindow of CreatingVisibleWindowData
+  | InitializingBindings of InitializingBindingsData
+  | ClosingWindow of ClosingWindowData
+  | HindingWindow of HindingWindowData
   | ShowingHiddenWindow of ShowingHiddenWindow
-  | NewSubModelSelectedItemSelectionData of NewSubModelSelectedItemSelectionData
-  | TryGetMemberCalledData of TryGetMemberCalledData
-  | TrySetMemberCalledData of TrySetMemberCalledData
-  | GettingErrorsData of GettingErrorsData
+  | NewSubModelSelectedItemSelection of NewSubModelSelectedItemSelectionData
+  | TryGetMemberCalled of TryGetMemberCalledData
+  | TrySetMemberCalled of TrySetMemberCalledData
+  | GettingErrors of GettingErrorsData
 
 
 let logTraceWith logger data =
   let log fmt = Printf.kprintf logger fmt
   match data with
-  | PropertyChangedData d -> log "[%s] PropertyChanged \"%s\"" d.PropertyNameChain d.PropertyName
-  | ValidationErrorsChangedData d -> log "[%s] ErrorsChanged \"%s\"" d.PropertyNameChain d.PropertyName
-  | TimingData d -> log "[%s] %s (%ims): %s" d.PropertyNameChain d.BindingDataFunctionName d.ElapsedMilliseconds d.PropertyName
-  | CreatingHiddenWindowData d -> log "[%s] Creating hidden window" d.PropertyNameChain
-  | CreatingVisibleWindowData d -> log "[%s] Creating and opening window" d.PropertyNameChain
-  | InitializingBindingsData d -> log "[%s] Initializing bindings" d.PropertyNameChain
-  | ClosingWindowData d -> log "[%s] Closing window" d.PropertyNameChain
-  | HindingWindowData d -> log "[%s] Hiding window" d.PropertyNameChain
+  | PropertyChanged d -> log "[%s] PropertyChanged \"%s\"" d.PropertyNameChain d.PropertyName
+  | ValidationErrorsChanged d -> log "[%s] ErrorsChanged \"%s\"" d.PropertyNameChain d.PropertyName
+  | Timing d -> log "[%s] %s (%ims): %s" d.PropertyNameChain d.BindingDataFunctionName d.ElapsedMilliseconds d.PropertyName
+  | CreatingHiddenWindow d -> log "[%s] Creating hidden window" d.PropertyNameChain
+  | CreatingVisibleWindow d -> log "[%s] Creating and opening window" d.PropertyNameChain
+  | InitializingBindings d -> log "[%s] Initializing bindings" d.PropertyNameChain
+  | ClosingWindow d -> log "[%s] Closing window" d.PropertyNameChain
+  | HindingWindow d -> log "[%s] Hiding window" d.PropertyNameChain
   | ShowingHiddenWindow d -> log "[%s] Showing existing hidden window" d.PropertyNameChain
-  | NewSubModelSelectedItemSelectionData d -> log "[%s] Setting selected VM to %A" d.PropertyNameChain d.NewSelection
-  | TryGetMemberCalledData d -> log "[%s] TryGetMember %s" d.PropertyNameChain d.PropertyName
-  | TrySetMemberCalledData d -> log "[%s] TrySetMember %s" d.PropertyNameChain d.PropertyName
-  | GettingErrorsData d -> log "[%s] GetErrors %s" d.PropertyNameChain (d.PropertyName |> Option.defaultValue "<null>")
+  | NewSubModelSelectedItemSelection d -> log "[%s] Setting selected VM to %A" d.PropertyNameChain d.NewSelection
+  | TryGetMemberCalled d -> log "[%s] TryGetMember %s" d.PropertyNameChain d.PropertyName
+  | TrySetMemberCalled d -> log "[%s] TrySetMember %s" d.PropertyNameChain d.PropertyName
+  | GettingErrors d -> log "[%s] GetErrors %s" d.PropertyNameChain (d.PropertyName |> Option.defaultValue "<null>")
   
 
 type WindowToCloseMissingData =
@@ -111,20 +111,20 @@ type TrySetMemberReadOnlyBindingData =
 
 
 type ErrorLogData =
-  | WindowToCloseMissingData of WindowToCloseMissingData
-  | WindowToHideMissingData of WindowToHideMissingData
-  | WindowToShowMissingData of WindowToShowMissingData
-  | TryGetMemberMissingBindingData of TryGetMemberMissingBindingData
-  | TrySetMemberMissingBindingData of TrySetMemberMissingBindingData
-  | TrySetMemberReadOnlyBindingData of TrySetMemberReadOnlyBindingData
+  | WindowToCloseMissing of WindowToCloseMissingData
+  | WindowToHideMissing of WindowToHideMissingData
+  | WindowToShowMissing of WindowToShowMissingData
+  | TryGetMemberMissingBinding of TryGetMemberMissingBindingData
+  | TrySetMemberMissingBinding of TrySetMemberMissingBindingData
+  | TrySetMemberReadOnlyBinding of TrySetMemberReadOnlyBindingData
 
 
 let logErrorWith logger data =
   let log fmt = Printf.kprintf logger fmt
   match data with
-  | WindowToCloseMissingData d -> log "[%s] Attempted to close window, but did not find window reference" d.PropertyNameChain
-  | WindowToHideMissingData d -> log "[%s] Attempted to hide window, but did not find window reference" d.PropertyNameChain
-  | WindowToShowMissingData d -> log "[%s] Attempted to show existing hidden window, but did not find window reference" d.PropertyNameChain
-  | TryGetMemberMissingBindingData d -> log "[%s] TryGetMember FAILED: Property %s doesn't exist" d.PropertyNameChain d.PropertyName
-  | TrySetMemberMissingBindingData d -> log "[%s] TrySetMember FAILED: Property %s doesn't exist" d.PropertyNameChain d.PropertyName
-  | TrySetMemberReadOnlyBindingData d -> log "[%s] TrySetMember FAILED: Binding %s is read-only" d.PropertyNameChain d.PropertyName
+  | WindowToCloseMissing d -> log "[%s] Attempted to close window, but did not find window reference" d.PropertyNameChain
+  | WindowToHideMissing d -> log "[%s] Attempted to hide window, but did not find window reference" d.PropertyNameChain
+  | WindowToShowMissing d -> log "[%s] Attempted to show existing hidden window, but did not find window reference" d.PropertyNameChain
+  | TryGetMemberMissingBinding d -> log "[%s] TryGetMember FAILED: Property %s doesn't exist" d.PropertyNameChain d.PropertyName
+  | TrySetMemberMissingBinding d -> log "[%s] TrySetMember FAILED: Property %s doesn't exist" d.PropertyNameChain d.PropertyName
+  | TrySetMemberReadOnlyBinding d -> log "[%s] TrySetMember FAILED: Binding %s is read-only" d.PropertyNameChain d.PropertyName

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -76,7 +76,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
 
   let logger =
     seq {
-      if config.LogConsole then yield (fun (s:string) -> Console.WriteLine s)
+      if config.LogConsole then yield (fun (s: string) -> Console.WriteLine s)
       if config.LogTrace then yield Diagnostics.Trace.WriteLine
     } |> compositeLogger
 

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -501,7 +501,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
         match bindings.TryGetValue name with
         | true, SubModelSeq (vms, _, getSubModelId, _, _) ->
             let v = getSelectedSubModel newModel vms getSelectedId getSubModelId
-            logTrace <| NewSubModelSelectedItemSelection {
+            logTrace <| NewSubModelSelected {
               PropertyNameChain = propNameChain
               NewSelection = (v |> ValueOption.map (fun v -> getSubModelId v.CurrentModel))
             }

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -413,7 +413,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
           | false, _ ->
               logError <| WindowToHideMissing { PropertyNameChain = winPropChain }
           | true, w ->
-              logTrace <| HindingWindow { PropertyNameChain = winPropChain }
+              logTrace <| HidingWindow { PropertyNameChain = winPropChain }
               w.Visibility <- Visibility.Hidden
 
         let showHidden () =

--- a/src/Samples/SubModelSeq/Program.fs
+++ b/src/Samples/SubModelSeq/Program.fs
@@ -128,7 +128,7 @@ module App =
     | ToggleGlobalState -> { m with SomeGlobalState = not m.SomeGlobalState }
 
     | AddCounter pid ->
-        let f (n:Tree.Node<Counter>) =
+        let f (n: Tree.Node<Counter>) =
           if n.Data.Id = pid
           then { n with Children = (Counter.create () |> Tree.asLeaf) :: n.Children}
           else n
@@ -143,19 +143,19 @@ module App =
     | Reset id -> { m with DummyRoot = m.DummyRoot |> Tree.mapData (resetCounter id ) }
 
     | Remove id ->
-        let f (n:Tree.Node<Counter>) =
+        let f (n: Tree.Node<Counter>) =
           { n with Children = n.Children |> List.filter (fun n -> n.Data.Id <> id) }
         { m with DummyRoot = m.DummyRoot |> Tree.map f }
 
     | MoveUp id ->
-      let f (n:Tree.Node<Counter>) =
+      let f (n: Tree.Node<Counter>) =
         match n.Children |> List.tryFindIndex (fun nn -> nn.Data.Id = id) with
         | Some i -> { n with Children = n.Children |> List.swap i (i - 1) }
         | None -> n
       { m with DummyRoot = m.DummyRoot |> Tree.map f }
 
     | MoveDown id ->
-      let f (n:Tree.Node<Counter>) =
+      let f (n: Tree.Node<Counter>) =
         match n.Children |> List.tryFindIndex (fun nn -> nn.Data.Id = id) with
         | Some i -> { n with Children = n.Children |> List.swap i (i + 1) }
         | None -> n


### PR DESCRIPTION
As requested in https://github.com/elmish/Elmish.WPF/issues/105#issuecomment-529382678, [this branch](https://github.com/bender2k14/Elmish.WPF/tree/%23105_example_use) contains an example usage of what the final product could look like.  (For simplicity, I exposed the new behavior though the `ElmConfig` record type.)

Here are screenshots of what the Serilog [Console](https://github.com/serilog/serilog-sinks-console) and [Seq](https://github.com/serilog/serilog-sinks-seq) sinks look like.

![Screenshot 2019-09-09 10 02 13](https://user-images.githubusercontent.com/34664007/64547508-4d299480-d2f2-11e9-9ff3-0ecaded34120.png)
![Screenshot 2019-09-09 10 03 28](https://user-images.githubusercontent.com/34664007/64547510-4e5ac180-d2f2-11e9-8a2a-65705b695e86.png)
