### PR TITLE
#114 wrap dispatch in bindings

### DIFF
--- a/src/Elmish.WPF.Tests/BindingTests.fs
+++ b/src/Elmish.WPF.Tests/BindingTests.fs
@@ -2119,7 +2119,7 @@ module cmdIf =
     let ``sets the correct binding name`` () =
       Property.check <| property {
         let! bindingName = GenX.auto<string>
-        let binding = bindingName |> Binding.cmdIf(fail, fail)
+        let binding = bindingName |> Binding.cmdIf(fail, fail, id)
         test <@ binding.Name = bindingName @>
       }
 
@@ -2476,7 +2476,7 @@ module cmdParamIf =
     let ``final autoRequery equals original uiBoundCmdParam`` () =
       Property.check <| property {
         let! uiBoundCmdParam = GenX.auto<bool>
-        let d = Binding.cmdParamIf(fail, fail, uiBoundCmdParam = uiBoundCmdParam) |> getCmdParamData
+        let d = Binding.cmdParamIf(fail, fail, uiBoundCmdParam = uiBoundCmdParam, wrapDispatch = id) |> getCmdParamData
         test <@ d.AutoRequery = uiBoundCmdParam @>
       }
 

--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -215,6 +215,7 @@ module Helpers =
     name |> createBinding (TwoWayData {
       Get = get >> box
       Set = unbox<'a> >> set
+      WrapDispatch = id
     })
 
 
@@ -227,6 +228,7 @@ module Helpers =
       Get = get >> box
       Set = unbox<'a> >> set
       Validate = validate
+      WrapDispatch = id
     })
 
 
@@ -237,6 +239,7 @@ module Helpers =
     name |> createBinding (CmdData {
       Exec = exec
       CanExec = canExec
+      WrapDispatch = id
     })
 
 
@@ -249,6 +252,7 @@ module Helpers =
       Exec = unbox >> exec
       CanExec = unbox >> canExec
       AutoRequery = autoRequery
+      WrapDispatch = id
     })
 
 
@@ -289,6 +293,7 @@ module Helpers =
       Get = get >> ValueOption.map box
       Set = ValueOption.map unbox<'id> >> set
       SubModelSeqBindingName = subModelSeqBindingName
+      WrapDispatch = id
     })
 
 


### PR DESCRIPTION
Exposes optional dispatch wrapping for `TwoWay`, `TwoWayValidate`, `SubModelSelectedItem`, `Cmd` and `CmdParam`, which is enough to enable users to throttle, debounce, or rate limit each message source #114.  In a future PR, we can make it easy for users to do those three things.