### PR TITLE
Code clean up 2019-09-20

### DIFF
--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -32,33 +32,33 @@ module WindowState =
     | ValueNone -> WindowState.Closed
 
 
-type internal OneWayData<'model> = {
-  Get: 'model -> obj
+type internal OneWayData<'model, 'a> = {
+  Get: 'model -> 'a
 }
 
-type internal OneWayLazyData<'model> = {
-  Get: 'model -> obj
-  Map: obj -> obj
-  Equals: obj -> obj -> bool
+type internal OneWayLazyData<'model, 'a, 'b> = {
+  Get: 'model -> 'a
+  Map: 'a -> 'b
+  Equals: 'a -> 'a -> bool
 }
 
-type internal OneWaySeqLazyData<'model> = {
-  Get: 'model -> obj
-  Map: obj -> obj seq
-  Equals: obj -> obj -> bool
-  GetId: obj -> obj
-  ItemEquals: obj -> obj -> bool
+type internal OneWaySeqLazyData<'model, 'a, 'b, 'id> = {
+  Get: 'model -> 'a
+  Map: 'a -> 'b seq
+  Equals: 'a -> 'a -> bool
+  GetId: 'a -> 'id
+  ItemEquals: 'b -> 'b -> bool
 }
 
-type internal TwoWayData<'model, 'msg> = {
-  Get: 'model -> obj
-  Set: obj -> 'model -> 'msg
+type internal TwoWayData<'model, 'msg, 'a> = {
+  Get: 'model -> 'a
+  Set: 'a -> 'model -> 'msg
   WrapDispatch: Dispatch<'msg> -> Dispatch<'msg>
 }
 
-type internal TwoWayValidateData<'model, 'msg> = {
-  Get: 'model -> obj
-  Set: obj -> 'model -> 'msg
+type internal TwoWayValidateData<'model, 'msg, 'a> = {
+  Get: 'model -> 'a
+  Set: 'a -> 'model -> 'msg
   Validate: 'model -> string voption
   WrapDispatch: Dispatch<'msg> -> Dispatch<'msg>
 }
@@ -76,50 +76,50 @@ type internal CmdParamData<'model, 'msg> = {
   WrapDispatch: Dispatch<'msg> -> Dispatch<'msg>
 }
 
-type internal SubModelSelectedItemData<'model, 'msg> = {
-  Get: 'model -> obj voption
-  Set: obj voption -> 'model -> 'msg
+type internal SubModelSelectedItemData<'model, 'msg, 'id> = {
+  Get: 'model -> 'id voption
+  Set: 'id voption -> 'model -> 'msg
   SubModelSeqBindingName: string
   WrapDispatch: Dispatch<'msg> -> Dispatch<'msg>
 }
 
-type internal SubModelData<'model, 'msg> = {
-  GetModel: 'model -> obj voption
-  GetBindings: unit -> Binding<obj, obj> list
-  ToMsg: obj -> 'msg
+type internal SubModelData<'model, 'msg, 'bindingModel, 'bindingMsg> = {
+  GetModel: 'model -> 'bindingModel voption
+  GetBindings: unit -> Binding<'bindingModel, 'bindingMsg> list
+  ToMsg: 'bindingMsg -> 'msg
   Sticky: bool
 }
 
-and internal SubModelWinData<'model, 'msg> = {
-  GetState: 'model -> WindowState<obj>
-  GetBindings: unit -> Binding<obj, obj> list
-  ToMsg: obj -> 'msg
+and internal SubModelWinData<'model, 'msg, 'bindingModel, 'bindingMsg> = {
+  GetState: 'model -> WindowState<'bindingModel>
+  GetBindings: unit -> Binding<'bindingModel, 'bindingMsg> list
+  ToMsg: 'bindingMsg -> 'msg
   GetWindow: unit -> Window
   IsModal: bool
   OnCloseRequested: 'msg voption
 }
 
-and internal SubModelSeqData<'model, 'msg> = {
-  GetModels: 'model -> obj seq
-  GetId: obj -> obj
-  GetBindings: unit -> Binding<obj, obj> list
-  ToMsg: obj * obj -> 'msg
+and internal SubModelSeqData<'model, 'msg, 'bindingModel, 'bindingMsg, 'id> = {
+  GetModels: 'model -> 'bindingModel seq
+  GetId: 'bindingModel -> 'id
+  GetBindings: unit -> Binding<'bindingModel, 'bindingMsg> list
+  ToMsg: 'id * 'bindingMsg -> 'msg
 }
 
 
 /// Represents all necessary data used to create the different binding types.
 and internal BindingData<'model, 'msg> =
-  | OneWayData of OneWayData<'model>
-  | OneWayLazyData of OneWayLazyData<'model>
-  | OneWaySeqLazyData of OneWaySeqLazyData<'model>
-  | TwoWayData of TwoWayData<'model, 'msg>
-  | TwoWayValidateData of TwoWayValidateData<'model, 'msg>
+  | OneWayData of OneWayData<'model, obj>
+  | OneWayLazyData of OneWayLazyData<'model, obj, obj>
+  | OneWaySeqLazyData of OneWaySeqLazyData<'model, obj, obj, obj>
+  | TwoWayData of TwoWayData<'model, 'msg, obj>
+  | TwoWayValidateData of TwoWayValidateData<'model, 'msg, obj>
   | CmdData of CmdData<'model, 'msg>
   | CmdParamData of CmdParamData<'model, 'msg>
-  | SubModelData of SubModelData<'model, 'msg>
-  | SubModelWinData of SubModelWinData<'model, 'msg>
-  | SubModelSeqData of SubModelSeqData<'model, 'msg>
-  | SubModelSelectedItemData of SubModelSelectedItemData<'model, 'msg>
+  | SubModelData of SubModelData<'model, 'msg, obj, obj>
+  | SubModelWinData of SubModelWinData<'model, 'msg, obj, obj>
+  | SubModelSeqData of SubModelSeqData<'model, 'msg, obj, obj, obj>
+  | SubModelSelectedItemData of SubModelSelectedItemData<'model, 'msg, obj>
 
 
 /// Represents all necessary data used to create a binding.

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -138,8 +138,7 @@ module internal BindingData =
     box >> weakDispatch
 
   let boxWrapDispatch (strongWrapDispatch: Dispatch<'msg> -> Dispatch<'msg>) : Dispatch<obj> -> Dispatch<obj> =
-    fun (weakDispatch: Dispatch<obj>) ->
-      weakDispatch |> unboxDispatch |> strongWrapDispatch |> boxDispatch
+    unboxDispatch >> strongWrapDispatch >> boxDispatch
 
   let box : BindingData<'model, 'msg> -> BindingData<obj, obj> = function
     | OneWayData d -> OneWayData {

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -264,7 +264,7 @@ type Binding private () =
 
   /// <summary>
   ///   Creates a lazily evaluated one-way binding. <paramref name="map" />
-  //    will be called only when the output of <paramref name="get" /> changes,
+  ///   will be called only when the output of <paramref name="get" /> changes,
   ///   as determined by <paramref name="equals" />. This may have better
   ///   performance than <see cref="oneWay" /> for expensive computations
   ///   (but may be less performant for non-expensive functions due to additional overhead).

--- a/src/Samples/SubModelSeq/Program.fs
+++ b/src/Samples/SubModelSeq/Program.fs
@@ -40,6 +40,9 @@ module Domain =
     let setStepSize step c =
       { c with StepSize = step }
 
+    let canReset c =
+      c.CounterValue <> 0 || c.StepSize <> 1
+
     let reset c =
       { create () with Id = c.Id }
 
@@ -181,7 +184,7 @@ module Bindings =
       (fun (_, c) -> float c.StepSize),
       (fun v (_, c) -> SetStepSize (c.Id, int v)))
 
-    "Reset" |> Binding.cmd(fun (_, c) -> Reset c.Id)
+    "Reset" |> Binding.cmdIf((fun (_, c) -> Reset c.Id), (fun (_, c) -> Counter.canReset c))
 
     "Remove" |> Binding.cmd(fun (_, c) -> Remove c.Id)
 


### PR DESCRIPTION
I made the following small improvements while reading the code today.

The code compiles, all tests pass, and I tried all the features in all the samples.

The most important change was adding additional type parameters to the binding data records, which is related to #116.  This is helpful for two specific reasons.
1. It is now possible to understand how the functions in each binding data record are related by looking at the definition of the record.  Without this change, I constantly had to go look at the arguments of the various overloaded methods (where the types were still as strong as possible) to see how the functions are related.  (Of course, that is also how I figured out what the type parameters should be in order to make this change.)
2. We are closer to my goal of separating (1) the lifting from simpler to more complex cases (such as lifting from [`oneWaySeq`](https://github.com/elmish/Elmish.WPF/blob/0f3887480b77358fc50a15c7ab5a1fe1c51603b6/src/Elmish.WPF/Binding.fs#L362-L373) to [`oneWaySeqLazy`](https://github.com/elmish/Elmish.WPF/blob/0f3887480b77358fc50a15c7ab5a1fe1c51603b6/src/Elmish.WPF/Binding.fs#L396-L409)) from (2) the boxing of those (most complex) cases.  Intuitively, I would like the flow to look like
```
   simpleBindingData     // expressed as arguments to an overloaded method
=> complexBindingData<'model, 'msg, 'a, ..., 'z>   // lifiting
=> complexBindingData<'model, 'msg, obj, ..., obj> // partial boxing
=> complexBindingData<obj, obj, obj, ..., obj>     // remaining boxing
```