### PR TITLE
Improve samples

### DIFF
--- a/src/Samples/EventBindingsAndBehaviors/Program.fs
+++ b/src/Samples/EventBindingsAndBehaviors/Program.fs
@@ -54,9 +54,9 @@ let bindings () : Binding<Model, Msg> list = [
 
 
 [<EntryPoint; STAThread>]
-let main argv =
+let main _ =
   Program.mkSimpleWpf init update bindings
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
-      { ElmConfig.Default with LogConsole = true; Measure = true }
-      (MainWindow())
+     { ElmConfig.Default with LogConsole = true; Measure = true }
+     (MainWindow())

--- a/src/Samples/NewWindow/Program.fs
+++ b/src/Samples/NewWindow/Program.fs
@@ -26,8 +26,7 @@ module App =
   let init () =
     { Win1State = WindowState.Closed
       Win1Input = ""
-      Win2 = None },
-    Cmd.none
+      Win2 = None }
 
   type Msg =
     | ShowWin1
@@ -43,48 +42,40 @@ module App =
 
   let update msg m =
     match msg with
-    | ShowWin1 -> { m with Win1State = WindowState.Visible "" }, Cmd.none
-    | HideWin1 -> { m with Win1State = WindowState.Hidden "" }, Cmd.none
-    | CloseWin1 -> { m with Win1State = WindowState.Closed }, Cmd.none
+    | ShowWin1 -> { m with Win1State = WindowState.Visible "" }
+    | HideWin1 -> { m with Win1State = WindowState.Hidden "" }
+    | CloseWin1 -> { m with Win1State = WindowState.Closed }
     | ShowWin2 ->
         let win2 = { Input1 = ""; Input2 = ""; ConfirmState = None }
-        { m with Win2 = Some win2 }, Cmd.none
-    | Win1Input s -> { m with Win1Input = s }, Cmd.none
+        { m with Win2 = Some win2 }
+    | Win1Input s -> { m with Win1Input = s }
     | Win2Input1 s ->
         { m with
             Win2 =
               m.Win2
               |> Option.map (fun m' -> { m' with Input1 = s })
-          },
-        Cmd.none
+          }
     | Win2Input2 s ->
         { m with
             Win2 =
               m.Win2
               |> Option.map (fun m' -> { m' with Input2 = s })
-            },
-        Cmd.none
+            }
     | Win2Submit ->
-        let newM =
-          match m.Win2 with
-          | Some { ConfirmState = Some SubmitClicked } -> { m with Win2 = None }
-          | Some win2 -> { m with Win2 = Some { win2 with ConfirmState = Some SubmitClicked } }
-          | None -> m
-        newM, Cmd.none
+        match m.Win2 with
+        | Some { ConfirmState = Some SubmitClicked } -> { m with Win2 = None }
+        | Some win2 -> { m with Win2 = Some { win2 with ConfirmState = Some SubmitClicked } }
+        | None -> m
     | Win2ButtonCancel ->
-        let newM =
-          match m.Win2 with
-          | Some { ConfirmState = Some CancelClicked } -> { m with Win2 = None }
-          | Some win2 -> { m with Win2 = Some { win2 with ConfirmState = Some CancelClicked } }
-          | None -> m
-        newM, Cmd.none
+        match m.Win2 with
+        | Some { ConfirmState = Some CancelClicked } -> { m with Win2 = None }
+        | Some win2 -> { m with Win2 = Some { win2 with ConfirmState = Some CancelClicked } }
+        | None -> m
     | Win2CloseRequested -> 
-        let newM =
-          match m.Win2 with
-          | Some { ConfirmState = Some CloseRequested } -> { m with Win2 = None }
-          | Some win2 -> { m with Win2 = Some { win2 with ConfirmState = Some CloseRequested } }
-          | None -> m
-        newM, Cmd.none
+        match m.Win2 with
+        | Some { ConfirmState = Some CloseRequested } -> { m with Win2 = None }
+        | Some win2 -> { m with Win2 = Some { win2 with ConfirmState = Some CloseRequested } }
+        | None -> m
 
 
   let bindings () : Binding<Model, Msg> list = [
@@ -118,9 +109,9 @@ module App =
 
 
 [<EntryPoint; STAThread>]
-let main argv =
-  Program.mkProgramWpf App.init App.update App.bindings
+let main _ =
+  Program.mkSimpleWpf App.init App.update App.bindings
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
-      { ElmConfig.Default with LogConsole = true; Measure = true }
-      (MainWindow())
+    { ElmConfig.Default with LogConsole = true; Measure = true }
+    (MainWindow())

--- a/src/Samples/OneWaySeq/Program.fs
+++ b/src/Samples/OneWaySeq/Program.fs
@@ -31,9 +31,9 @@ let bindings () : Binding<Model, Msg> list = [
 
 
 [<EntryPoint; STAThread>]
-let main argv =
+let main _ =
   Program.mkSimpleWpf init update bindings
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
-      { ElmConfig.Default with LogConsole = true }
-      (MainWindow())
+    { ElmConfig.Default with LogConsole = true }
+    (MainWindow())

--- a/src/Samples/SingleCounter/Program.fs
+++ b/src/Samples/SingleCounter/Program.fs
@@ -8,7 +8,7 @@ type Model =
   { Count: int
     StepSize: int }
 
-let init () =
+let init =
   { Count = 0
     StepSize = 1 }
 
@@ -23,7 +23,7 @@ let update msg m =
   | Increment -> { m with Count = m.Count + m.StepSize }
   | Decrement -> { m with Count = m.Count - m.StepSize }
   | SetStepSize x -> { m with StepSize = x }
-  | Reset -> init ()
+  | Reset -> init
 
 let bindings () : Binding<Model, Msg> list = [
   "CounterValue" |> Binding.oneWay (fun m -> m.Count)
@@ -32,14 +32,14 @@ let bindings () : Binding<Model, Msg> list = [
   "StepSize" |> Binding.twoWay(
     (fun m -> float m.StepSize),
     int >> SetStepSize)
-  "Reset" |> Binding.cmdIf(Reset, (<>) (init ()))
+  "Reset" |> Binding.cmdIf(Reset, (<>) init)
 ]
 
 
 [<EntryPoint; STAThread>]
 let main argv =
-  Program.mkSimpleWpf init update bindings
+  Program.mkSimpleWpf (fun () -> init) update bindings
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
-      { ElmConfig.Default with LogConsole = true; Measure = true }
-      (MainWindow())
+    { ElmConfig.Default with LogConsole = true; Measure = true }
+    (MainWindow())

--- a/src/Samples/SubModel/Program.fs
+++ b/src/Samples/SubModel/Program.fs
@@ -10,7 +10,7 @@ module Counter =
     { Count: int
       StepSize: int }
   
-  let init () =
+  let init =
     { Count = 0
       StepSize = 1 }
   
@@ -25,7 +25,7 @@ module Counter =
     | Increment -> { m with Count = m.Count + m.StepSize }
     | Decrement -> { m with Count = m.Count - m.StepSize }
     | SetStepSize x -> { m with StepSize = x }
-    | Reset -> init ()
+    | Reset -> init
   
   let bindings () : Binding<Model, Msg> list = [
     "CounterValue" |> Binding.oneWay (fun m -> m.Count)
@@ -34,7 +34,7 @@ module Counter =
     "StepSize" |> Binding.twoWay(
       (fun m -> float m.StepSize),
       int >> SetStepSize)
-    "Reset" |> Binding.cmdIf(Reset, (<>) (init ()))
+    "Reset" |> Binding.cmdIf(Reset, (<>) init)
   ]
 
 
@@ -73,7 +73,7 @@ module CounterWithClock =
       Clock: Clock.Model }
 
   let init =
-    { Counter = Counter.init ()
+    { Counter = Counter.init
       Clock = Clock.init () }
 
   type Msg =
@@ -146,5 +146,5 @@ let main argv =
   |> Program.withSubscription (fun m -> Cmd.ofSub timerTick)
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
-      { ElmConfig.Default with LogConsole = true; Measure = true }
-      (MainWindow())
+    { ElmConfig.Default with LogConsole = true; Measure = true }
+    (MainWindow())

--- a/src/Samples/SubModelOpt/Program.fs
+++ b/src/Samples/SubModelOpt/Program.fs
@@ -117,9 +117,9 @@ module App =
 
 
 [<EntryPoint; STAThread>]
-let main argv =
+let main _ =
   Program.mkSimpleWpf App.init App.update App.bindings
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
-      { ElmConfig.Default with LogConsole = true; Measure = true }
-      (MainWindow())
+    { ElmConfig.Default with LogConsole = true; Measure = true }
+    (MainWindow())

--- a/src/Samples/SubModelSelectedItem/Program.fs
+++ b/src/Samples/SubModelSelectedItem/Program.fs
@@ -42,9 +42,9 @@ let bindings () : Binding<Model, Msg> list = [
 
 
 [<EntryPoint; STAThread>]
-let main argv =
+let main _ =
   Program.mkSimpleWpf init update bindings
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
-      { ElmConfig.Default with LogConsole = true; Measure = true }
-      (MainWindow())
+    { ElmConfig.Default with LogConsole = true; Measure = true }
+    (MainWindow())

--- a/src/Samples/SubModelSeq/Program.fs
+++ b/src/Samples/SubModelSeq/Program.fs
@@ -9,9 +9,9 @@ module List =
   let swap i j =
     List.permute
       (function
-       | a when a = i -> j
-       | a when a = j -> i
-       | a -> a)
+        | a when a = i -> j
+        | a when a = j -> i
+        | a -> a)
 
 
 [<AutoOpen>]
@@ -102,8 +102,8 @@ module App =
     |> List.find (fun n -> n |> Tree.dataOfChildren |> List.map (fun d -> d.Id) |> List.contains cid)
 
   /// Returns the sibling counters of the specified counter ID.
-  let childrenCountersOfParentOf cid m =
-    m |> parentOf cid |> Tree.dataOfChildren
+  let childrenCountersOfParentOf cid =
+    parentOf cid >> Tree.dataOfChildren
 
   type Msg =
     | ToggleGlobalState
@@ -131,7 +131,7 @@ module App =
     | ToggleGlobalState -> { m with SomeGlobalState = not m.SomeGlobalState }
 
     | AddCounter pid ->
-        let f (n:Tree.Node<Counter>) =
+        let f (n: Tree.Node<Counter>) =
           if n.Data.Id = pid
           then { n with Children = (Counter.create () |> Tree.asLeaf) :: n.Children}
           else n
@@ -146,19 +146,19 @@ module App =
     | Reset id -> { m with DummyRoot = m.DummyRoot |> Tree.mapData (resetCounter id ) }
 
     | Remove id ->
-        let f (n:Tree.Node<Counter>) =
+        let f (n: Tree.Node<Counter>) =
           { n with Children = n.Children |> List.filter (fun n -> n.Data.Id <> id) }
         { m with DummyRoot = m.DummyRoot |> Tree.map f }
 
     | MoveUp id ->
-      let f (n:Tree.Node<Counter>) =
+      let f (n: Tree.Node<Counter>) =
         match n.Children |> List.tryFindIndex (fun nn -> nn.Data.Id = id) with
         | Some i -> { n with Children = n.Children |> List.swap i (i - 1) }
         | None -> n
       { m with DummyRoot = m.DummyRoot |> Tree.map f }
 
     | MoveDown id ->
-      let f (n:Tree.Node<Counter>) =
+      let f (n: Tree.Node<Counter>) =
         match n.Children |> List.tryFindIndex (fun nn -> nn.Data.Id = id) with
         | Some i -> { n with Children = n.Children |> List.swap i (i + 1) }
         | None -> n
@@ -171,8 +171,6 @@ module Bindings =
 
   let rec counterBindings () : Binding<Model * Counter, Msg> list = [
     "CounterIdText" |> Binding.oneWay(fun (_, { Id = CounterId id }) -> id)
-
-    "CounterId" |> Binding.oneWay(fun (_, c) -> c.Id)
 
     "CounterValue" |> Binding.oneWay(fun (_, c) -> c.CounterValue)
 
@@ -226,5 +224,5 @@ let main _ =
   Program.mkSimpleWpf App.init App.update Bindings.rootBindings
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
-      { ElmConfig.Default with LogConsole = true; Measure = true }
-      (MainWindow())
+    { ElmConfig.Default with LogConsole = true; Measure = true }
+    (MainWindow())

--- a/src/Samples/UiBoundCmdParam/Program.fs
+++ b/src/Samples/UiBoundCmdParam/Program.fs
@@ -33,9 +33,9 @@ let bindings () : Binding<Model, Msg> list = [
 
 
 [<EntryPoint; STAThread>]
-let main argv =
+let main _ =
   Program.mkSimpleWpf init update bindings
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
-      { ElmConfig.Default with LogConsole = true; Measure = true }
-      (MainWindow())
+    { ElmConfig.Default with LogConsole = true; Measure = true }
+    (MainWindow())

--- a/src/Samples/Validation/Program.fs
+++ b/src/Samples/Validation/Program.fs
@@ -48,9 +48,9 @@ let bindings () : Binding<Model, Msg> list = [
 
 
 [<EntryPoint; STAThread>]
-let main argv =
+let main _ =
   Program.mkSimpleWpf init update bindings
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
-      { ElmConfig.Default with LogConsole = true; Measure = true }
-      (MainWindow())
+    { ElmConfig.Default with LogConsole = true; Measure = true }
+    (MainWindow())


### PR DESCRIPTION
In some issue (which I was unable to find last time I looked), we discussed simplifying `init` from a function to a value in the Counter samples.  I did this for the SimpleCounter and SubModel samples.

Then I tried to make a similar change to the SubModelSeq sample.  I tried to extract the Counter code so that it looks essentially identical to the other two samples.  That didn't work.  It seems difficult to have a `SubModel` binding within a `SubModelSeq` binding.  Included some code clean up for the SubModelSeq sample anyway.  There was an unused binding.

I noticed that the NewWindow sample used `mkProgramWpf` even though it always returned `Cmd.None` for the command, so I simplified that to `mkSimpleWpf`.

Lastly is minor code clean up in all other samples.

I didn't test anything yet.  I can test tonight.