### PR TITLE
corrected type parameter of getId in OneWaySeqLazyData

### DIFF
--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -46,7 +46,7 @@ type internal OneWaySeqLazyData<'model, 'a, 'b, 'id> = {
   Get: 'model -> 'a
   Map: 'a -> 'b seq
   Equals: 'a -> 'a -> bool
-  GetId: 'a -> 'id
+  GetId: 'b -> 'id
   ItemEquals: 'b -> 'b -> bool
 }
 


### PR DESCRIPTION
I made a small mistake in #123.  As clearly seen here...
https://github.com/elmish/Elmish.WPF/blob/10b4deb160cbe1808e4d2f68ebd9c772e48d0ecc/src/Elmish.WPF/Binding.fs#L396-L401

...the type of `getId` in `OneWaySeqLazyData` should be `'b -> 'id`, not `'a -> 'id`.