### PR TITLE
Unused values as warnings

### DIFF
--- a/src/Elmish.WPF.Tests/BindingTests.fs
+++ b/src/Elmish.WPF.Tests/BindingTests.fs
@@ -120,7 +120,7 @@ module oneWayOpt =
       Property.check <| property {
         let! x = GenX.auto<int>
 
-        let get m = None
+        let get _ = None
         let d = Binding.oneWayOpt(get) |> getOneWayData
 
         test <@ isNull (d.Get x) @>
@@ -601,7 +601,7 @@ module twoWayOpt =
       Property.check <| property {
         let! x = GenX.auto<int>
 
-        let get m = None
+        let get _ = None
         let d = Binding.twoWayOpt(get, fail2) |> getTwoWayData
 
         test <@ isNull (d.Get x) @>
@@ -663,7 +663,7 @@ module twoWayOpt =
       Property.check <| property {
         let! x = GenX.auto<int>
 
-        let get m = ValueNone
+        let get _ = ValueNone
         let d = Binding.twoWayOpt(get, fail2) |> getTwoWayData
 
         test <@ isNull (d.Get x) @>
@@ -725,7 +725,7 @@ module twoWayOpt =
       Property.check <| property {
         let! x = GenX.auto<int>
 
-        let get m = None
+        let get _ = None
         let d = Binding.twoWayOpt(get, (fail: _ option -> int)) |> getTwoWayData
 
         test <@ isNull (d.Get x) @>
@@ -787,7 +787,7 @@ module twoWayOpt =
       Property.check <| property {
         let! x = GenX.auto<int>
 
-        let get m = ValueNone
+        let get _ = ValueNone
         let d = Binding.twoWayOpt(get, (fail: _ voption -> int)) |> getTwoWayData
 
         test <@ isNull (d.Get x) @>
@@ -1163,7 +1163,7 @@ module twoWayOptValidate =
       Property.check <| property {
         let! x = GenX.auto<int>
 
-        let get m = ValueNone
+        let get _ = ValueNone
         let d = Binding.twoWayOptValidate(get, fail2, (fail: _ -> _ voption)) |> getTwoWayValidateData
 
         test <@ isNull (d.Get x) @>
@@ -1238,7 +1238,7 @@ module twoWayOptValidate =
       Property.check <| property {
         let! x = GenX.auto<int>
 
-        let get m = ValueNone
+        let get _ = ValueNone
         let d = Binding.twoWayOptValidate(get, fail2, (fail: _ -> _ option)) |> getTwoWayValidateData
 
         test <@ isNull (d.Get x) @>
@@ -1313,7 +1313,7 @@ module twoWayOptValidate =
       Property.check <| property {
         let! x = GenX.auto<int>
 
-        let get m = ValueNone
+        let get _ = ValueNone
         let d = Binding.twoWayOptValidate(get, fail2, (fail: _ -> Result<_,_>)) |> getTwoWayValidateData
 
         test <@ isNull (d.Get x) @>
@@ -1389,7 +1389,7 @@ module twoWayOptValidate =
       Property.check <| property {
         let! x = GenX.auto<int>
 
-        let get m = None
+        let get _ = None
         let d = Binding.twoWayOptValidate(get, fail2, (fail: _ -> _ voption)) |> getTwoWayValidateData
 
         test <@ isNull (d.Get x) @>
@@ -1464,7 +1464,7 @@ module twoWayOptValidate =
       Property.check <| property {
         let! x = GenX.auto<int>
 
-        let get m = None
+        let get _ = None
         let d = Binding.twoWayOptValidate(get, fail2, (fail: _ -> _ option)) |> getTwoWayValidateData
 
         test <@ isNull (d.Get x) @>
@@ -1539,7 +1539,7 @@ module twoWayOptValidate =
       Property.check <| property {
         let! x = GenX.auto<int>
 
-        let get m = None
+        let get _ = None
         let d = Binding.twoWayOptValidate(get, fail2, (fail: _ -> Result<_,_>)) |> getTwoWayValidateData
 
         test <@ isNull (d.Get x) @>
@@ -1615,7 +1615,7 @@ module twoWayOptValidate =
       Property.check <| property {
         let! x = GenX.auto<int>
 
-        let get m = ValueNone
+        let get _ = ValueNone
         let d = Binding.twoWayOptValidate(get, (fail: _ -> int), (fail: _ -> _ voption)) |> getTwoWayValidateData
 
         test <@ isNull (d.Get x) @>
@@ -1690,7 +1690,7 @@ module twoWayOptValidate =
       Property.check <| property {
         let! x = GenX.auto<int>
 
-        let get m = ValueNone
+        let get _ = ValueNone
         let d = Binding.twoWayOptValidate(get, (fail: _ -> int), (fail: _ -> _ option)) |> getTwoWayValidateData
 
         test <@ isNull (d.Get x) @>
@@ -1765,7 +1765,7 @@ module twoWayOptValidate =
       Property.check <| property {
         let! x = GenX.auto<int>
 
-        let get m = ValueNone
+        let get _ = ValueNone
         let d = Binding.twoWayOptValidate(get, (fail: _ -> int), (fail: _ -> Result<_,_>)) |> getTwoWayValidateData
 
         test <@ isNull (d.Get x) @>
@@ -1841,7 +1841,7 @@ module twoWayOptValidate =
       Property.check <| property {
         let! x = GenX.auto<int>
 
-        let get m = None
+        let get _ = None
         let d = Binding.twoWayOptValidate(get, (fail: _ -> int), (fail: _ -> _ voption)) |> getTwoWayValidateData
 
         test <@ isNull (d.Get x) @>
@@ -1916,7 +1916,7 @@ module twoWayOptValidate =
       Property.check <| property {
         let! x = GenX.auto<int>
 
-        let get m = None
+        let get _ = None
         let d = Binding.twoWayOptValidate(get, (fail: _ -> int), (fail: _ -> _ option)) |> getTwoWayValidateData
 
         test <@ isNull (d.Get x) @>
@@ -1991,7 +1991,7 @@ module twoWayOptValidate =
       Property.check <| property {
         let! x = GenX.auto<int>
 
-        let get m = None
+        let get _ = None
         let d = Binding.twoWayOptValidate(get, (fail: _ -> int), (fail: _ -> Result<_,_>)) |> getTwoWayValidateData
 
         test <@ isNull (d.Get x) @>
@@ -2226,7 +2226,7 @@ module cmdIf =
       Property.check <| property {
         let! x = GenX.auto<int>
 
-        let exec x = ValueNone
+        let exec _ = ValueNone
         let d = Binding.cmdIf(exec) |> getCmdData
 
         test <@ d.CanExec x = false @>
@@ -2275,7 +2275,7 @@ module cmdIf =
       Property.check <| property {
         let! x = GenX.auto<int>
 
-        let exec x = None
+        let exec _ = None
         let d = Binding.cmdIf(exec) |> getCmdData
 
         test <@ d.CanExec x = false @>
@@ -2525,7 +2525,7 @@ module cmdParamIf =
         let! m = GenX.auto<int>
         let! p = GenX.auto<string>
 
-        let exec (p: obj) m = ValueNone
+        let exec (_: obj) _ = ValueNone
         let d = Binding.cmdParamIf(exec) |> getCmdParamData
 
         test <@ d.CanExec (box p) m = false @>
@@ -2594,7 +2594,7 @@ module cmdParamIf =
         let! m = GenX.auto<int>
         let! p = GenX.auto<string>
 
-        let exec (p: obj) m = None
+        let exec (_: obj) _ = None
         let d = Binding.cmdParamIf(exec) |> getCmdParamData
 
         test <@ d.CanExec (box p) m = false @>
@@ -2666,7 +2666,7 @@ module cmdParamIf =
         let! p = GenX.auto<string>
         let! err = GenX.auto<byte>
 
-        let exec (p: obj) m = Error err
+        let exec (_: obj) _ = Error err
         let d = Binding.cmdParamIf(exec) |> getCmdParamData
 
         test <@ d.CanExec (box p) m = false @>
@@ -2790,7 +2790,7 @@ module cmdParamIf =
         let! m = GenX.auto<int>
         let! p = GenX.auto<string>
 
-        let exec (p: obj) = ValueNone
+        let exec (_: obj) = ValueNone
         let d = Binding.cmdParamIf(exec) |> getCmdParamData
 
         test <@ d.CanExec (box p) m = false @>
@@ -2859,7 +2859,7 @@ module cmdParamIf =
         let! m = GenX.auto<int>
         let! p = GenX.auto<string>
 
-        let exec (p: obj) = None
+        let exec (_: obj) = None
         let d = Binding.cmdParamIf(exec) |> getCmdParamData
 
         test <@ d.CanExec (box p) m = false @>
@@ -2931,7 +2931,7 @@ module cmdParamIf =
         let! p = GenX.auto<string>
         let! err = GenX.auto<byte>
 
-        let exec (p: obj) = Error err
+        let exec (_: obj) = Error err
         let d = Binding.cmdParamIf(exec) |> getCmdParamData
 
         test <@ d.CanExec (box p) m = false @>
@@ -3114,7 +3114,7 @@ module subModelOpt =
     let ``final getModel returns ValueNone if getSubModel returns ValueNone`` () =
       Property.check <| property {
         let! x = GenX.auto<int>
-        let getSubModel (m: int) : string voption = ValueNone
+        let getSubModel (_: int) : string voption = ValueNone
         let d = Binding.subModelOpt(getSubModel, fail) |> getSubModelData
         test <@ d.GetModel x = ValueNone @>
       }
@@ -3173,7 +3173,7 @@ module subModelOpt =
     let ``final getModel returns ValueNone if getSubModel returns ValueNone`` () =
       Property.check <| property {
         let! x = GenX.auto<int>
-        let getSubModel (m: int) : string option = None
+        let getSubModel (_: int) : string option = None
         let d = Binding.subModelOpt(getSubModel, fail) |> getSubModelData
         test <@ d.GetModel x = ValueNone @>
       }
@@ -3231,7 +3231,7 @@ module subModelOpt =
     let ``final getModel returns ValueNone if getSubModel returns ValueNone`` () =
       Property.check <| property {
         let! x = GenX.auto<int>
-        let getSubModel (m: int) : string voption = ValueNone
+        let getSubModel (_: int) : string voption = ValueNone
         let d = Binding.subModelOpt(getSubModel, fail, fail) |> getSubModelData
         test <@ d.GetModel x = ValueNone @>
       }
@@ -3293,7 +3293,7 @@ module subModelOpt =
     let ``final getModel returns ValueNone if getSubModel returns ValueNone`` () =
       Property.check <| property {
         let! x = GenX.auto<int>
-        let getSubModel (m: int) : string option = None
+        let getSubModel (_: int) : string option = None
         let d = Binding.subModelOpt(getSubModel, fail, fail) |> getSubModelData
         test <@ d.GetModel x = ValueNone @>
       }
@@ -3355,7 +3355,7 @@ module subModelOpt =
     let ``final getModel returns ValueNone if getSubModel returns ValueNone`` () =
       Property.check <| property {
         let! x = GenX.auto<int>
-        let getSubModel (m: int) : string voption = ValueNone
+        let getSubModel (_: int) : string voption = ValueNone
         let d = Binding.subModelOpt(getSubModel, fail, fail, fail) |> getSubModelData
         test <@ d.GetModel x = ValueNone @>
       }
@@ -3418,7 +3418,7 @@ module subModelOpt =
     let ``final getModel returns ValueNone if getSubModel returns ValueNone`` () =
       Property.check <| property {
         let! x = GenX.auto<int>
-        let getSubModel (m: int) : string option = None
+        let getSubModel (_: int) : string option = None
         let d = Binding.subModelOpt(getSubModel, fail, fail, fail) |> getSubModelData
         test <@ d.GetModel x = ValueNone @>
       }

--- a/src/Elmish.WPF.Tests/Elmish.WPF.Tests.fsproj
+++ b/src/Elmish.WPF.Tests/Elmish.WPF.Tests.fsproj
@@ -2,6 +2,8 @@
   
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
+    <!--Turn on warnings for unused values (arguments and let bindings) -->
+    <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -72,18 +72,18 @@ type internal TestVm<'model, 'msg>(model, bindings) as this =
   /// Will cause the property to be retrieved.
   member this.TrackCcTriggersFor propName =
     try
-      (this.Get propName : ObservableCollection<obj>).CollectionChanged.Add (fun e ->
+      (this.Get propName : ObservableCollection<obj>).CollectionChanged.Add (fun _ ->
         ccTriggers.AddOrUpdate(propName, 1, (fun _ count -> count + 1)) |> ignore
       )
     with _ ->
-      (this.Get propName |> unbox<ObservableCollection<ViewModel<obj, obj>>>).CollectionChanged.Add (fun e ->
+      (this.Get propName |> unbox<ObservableCollection<ViewModel<obj, obj>>>).CollectionChanged.Add (fun _ ->
         ccTriggers.AddOrUpdate(propName, 1, (fun _ count -> count + 1)) |> ignore
       )
 
   /// Starts tracking CanExecuteChanged triggers for the specified prop.
   /// Will cause the property to be retrieved.
   member this.TrackCecTriggersFor propName =
-    (this.Get propName : ICommand).CanExecuteChanged.Add (fun e ->
+    (this.Get propName : ICommand).CanExecuteChanged.Add (fun _ ->
       cecTriggers.AddOrUpdate(propName, 1, (fun _ count -> count + 1)) |> ignore
     )
 

--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -1063,7 +1063,6 @@ module Cmd =
       let! name = GenX.auto<string>
       let! m1 = GenX.auto<int>
       let! m2 = GenX.auto<int>
-      let! p = GenX.auto<obj> |> GenX.withNull
 
       let exec m = if m < 0 then ValueNone else ValueSome (string m)
       let canExec m = m < 0

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -2240,8 +2240,8 @@ module Extensions =
          ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
         : string -> Binding<'model, 'msg> =
       CmdParamData {
-        Exec = fun p m -> exec p
-        CanExec = fun p m -> exec p |> ValueOption.isSome
+        Exec = fun p _ -> exec p
+        CanExec = fun p _ -> exec p |> ValueOption.isSome
         AutoRequery = defaultArg uiBoundCmdParam false
         WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
@@ -2271,8 +2271,8 @@ module Extensions =
          ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
         : string -> Binding<'model, 'msg> =
       CmdParamData {
-        Exec = fun p m -> exec p |> ValueOption.ofOption
-        CanExec = fun p m -> exec p |> Option.isSome
+        Exec = fun p _ -> exec p |> ValueOption.ofOption
+        CanExec = fun p _ -> exec p |> Option.isSome
         AutoRequery = defaultArg uiBoundCmdParam false
         WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
@@ -2305,8 +2305,8 @@ module Extensions =
          ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
         : string -> Binding<'model, 'msg> =
       CmdParamData {
-        Exec = fun p m -> exec p |> ValueOption.ofOk
-        CanExec = fun p m -> exec p |> Result.isOk
+        Exec = fun p _ -> exec p |> ValueOption.ofOk
+        CanExec = fun p _ -> exec p |> Result.isOk
         AutoRequery = defaultArg uiBoundCmdParam false
         WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
@@ -2338,8 +2338,8 @@ module Extensions =
          ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
         : string -> Binding<'model, 'msg> =
       CmdParamData {
-        Exec = fun p m -> exec p |> ValueSome
-        CanExec = fun p m -> canExec p
+        Exec = fun p _ -> exec p |> ValueSome
+        CanExec = fun p _ -> canExec p
         AutoRequery = defaultArg uiBoundCmdParam false
         WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding

--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -15,6 +15,8 @@
     <PackageTags>WPF F# fsharp Elmish Elm</PackageTags>
     <Version>3.5.0</Version>
     <PackageReleaseNotes>Add netcoreapp3.0 target</PackageReleaseNotes>
+    <!--Turn on warnings for unused values (arguments and let bindings) -->
+    <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/src/Samples/SingleCounter/Program.fs
+++ b/src/Samples/SingleCounter/Program.fs
@@ -37,7 +37,7 @@ let bindings () : Binding<Model, Msg> list = [
 
 
 [<EntryPoint; STAThread>]
-let main argv =
+let main _ =
   Program.mkSimpleWpf (fun () -> init) update bindings
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig

--- a/src/Samples/SubModel/Program.fs
+++ b/src/Samples/SubModel/Program.fs
@@ -141,9 +141,9 @@ let timerTick dispatch =
 
 
 [<EntryPoint; STAThread>]
-let main argv =
+let main _ =
   Program.mkSimpleWpf App.init App.update App.bindings
-  |> Program.withSubscription (fun m -> Cmd.ofSub timerTick)
+  |> Program.withSubscription (fun _ -> Cmd.ofSub timerTick)
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
     { ElmConfig.Default with LogConsole = true; Measure = true }

--- a/src/Samples/Validation/Program.fs
+++ b/src/Samples/Validation/Program.fs
@@ -35,7 +35,7 @@ type Msg =
 let update msg m =
   match msg with
   | Input x -> { m with RawValue = x }
-  | Submit x -> m
+  | Submit _ -> m
 
 let bindings () : Binding<Model, Msg> list = [
   "RawValue" |> Binding.twoWayValidate(


### PR DESCRIPTION
First commit modifies `fsproj` files to turn unused values into build warnings.  The second commit deletes one unused line of test code.  The third commit renames all unused values to `_`.