### PR TITLE
List to seq in UpdateModel

### DIFF
--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -369,7 +369,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
       let binding = initializeBinding b.Name b.Data dict
       dict.Add(b.Name, binding)
       setInitialError b.Name binding
-    dict
+    dict :> IReadOnlyDictionary<string, VmBinding<'model, 'msg>>
 
   let getSelectedSubModel model vms getSelectedId getSubModelId =
       vms

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -579,13 +579,13 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
   member __.UpdateModel (newModel: 'model) : unit =
     let propsToNotify =
       bindings
+      |> Seq.filter (fun (Kvp (name, binding)) -> updateValue name newModel binding)
+      |> Seq.map Kvp.key
       |> Seq.toList
-      |> List.filter (fun (Kvp (name, binding)) -> updateValue name newModel binding)
-      |> List.map Kvp.key
     let cmdsToNotify =
       bindings
+      |> Seq.choose (Kvp.value >> getCmdIfCanExecChanged newModel)
       |> Seq.toList
-      |> List.choose (Kvp.value >> getCmdIfCanExecChanged newModel)
     currentModel <- newModel
     propsToNotify |> List.iter notifyPropertyChanged
     cmdsToNotify |> List.iter raiseCanExecuteChanged


### PR DESCRIPTION
https://github.com/elmish/Elmish.WPF/blob/4c8d85c58a6adbd7db1158be4fb3e9525f7be45c/src/Elmish.WPF/ViewModel.fs#L580-L591

I think the reason that `propsToNotify` and `cmdsToNotify` are `list`s instead of `seq`s is so that they are eagerly computed before the mutation on line 589.  However, I don't see any reason why `bindings` needs to be converted to a `list` ASAP (via lines 582 and 587).  In particular, after all bindings are initialized (in the same scope where the dictionary was instantiated), the `bindings` dictionary is only ever read (i.e. it is never mutated).  I made this clear by exposing the `bindings` dictionary as read only.

Therefore, I think it is a behavior preserving transformation to delay the calls to `Seq.toList` until the end of those expressions.