### PR TITLE
added a cast function for CmdParam binding

### DIFF
--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -249,6 +249,7 @@ module Helpers =
       (canExec: 'a -> 'model -> bool)
       (autoRequery: bool) =
     name |> createBinding (CmdParamData {
+      Cast = id
       Exec = unbox >> exec
       CanExec = unbox >> canExec
       AutoRequery = autoRequery

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -239,11 +239,12 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
           Cmd = Command(execute, canExecute, false)
           CanExec = canExec }
     | CmdParamData d ->
+        let cast = measure name "cast" d.Cast
         let exec = measure2 name "exec" d.Exec
         let canExec = measure2 name "canExec" d.CanExec
         let dispatch' = d.WrapDispatch dispatch
-        let execute param = exec param currentModel |> ValueOption.iter dispatch'
-        let canExecute param = canExec param currentModel
+        let execute param = exec (cast param) currentModel |> ValueOption.iter dispatch'
+        let canExecute param = canExec (cast param) currentModel
         CmdParam <| Command(execute, canExecute, d.AutoRequery)
     | SubModelData d ->
         let getModel = measure name "getSubModel" d.GetModel

--- a/src/Samples/UiBoundCmdParam/Program.fs
+++ b/src/Samples/UiBoundCmdParam/Program.fs
@@ -26,8 +26,11 @@ let bindings () : Binding<Model, Msg> list = [
   "Numbers" |> Binding.oneWay(fun m -> m.Numbers)
   "Limit" |> Binding.twoWay((fun m -> float m.EnabledMaxLimit), int >> SetLimit)
   "Command" |> Binding.cmdParamIf(
-    (fun p m -> Command),
-    (fun p m -> not (isNull p) && p :?> int <= m.EnabledMaxLimit),
+    (function
+      | :? int as i -> Some i
+      | _ -> None),
+    (fun _ _ -> Command),
+    (fun oi m -> oi |> Option.map (fun i -> i <= m.EnabledMaxLimit) |> Option.defaultValue false),
     true)
 ]
 


### PR DESCRIPTION
Adds a `cast` function to `CmdParam` so that the parameter can be of type `'param` instead of type `obj`.