### PR TITLE
improves the error handling when getId returns duplicates

### DIFF
--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -295,19 +295,6 @@ module Helpers =
 
 
 
-module General =
-
-
-  [<Fact>]
-  let ``throws during instantiation if two bindings have the same name`` () =
-    Property.check <| property {
-      let! name = GenX.auto<string>
-      let! m = GenX.auto<int>
-      raises<exn> <@ TestVm(m, [oneWay name id; oneWay name id]) @>
-  }
-
-
-
 module OneWay =
 
 


### PR DESCRIPTION
Fixes #150 

I am very open to suggestions for improvement on this code.  My primary goal was to quickly give us something concrete to discuss.

I didn't try to deduplicate anything, and I am not jazzed about how I used `if-then` to skip over the happy path in `updateValue`.  However, I think this behavior is ideal.  Otherwise, no other bindings are updated after encountering this issue.