### PR TITLE
upgraded Microsoft.Xaml.Behaviors.Wpf to version 1.1.3

### DIFF
--- a/src/Samples/EventBindingsAndBehaviors.Views/EventBindingsAndBehaviors.Views.csproj
+++ b/src/Samples/EventBindingsAndBehaviors.Views/EventBindingsAndBehaviors.Views.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgrades [Microsoft.Xaml.Behaviors.Wpf](https://www.nuget.org/packages/Microsoft.Xaml.Behaviors.Wpf/) to its latest version.  Compared to the previous version that we were using that only targeted .NET Framework, this version also targets .NET Core.  This removes two build warnings for us since we target both of those now.

I tested the `EventBindingsAndBehaviors` sample, which is the only code that depends on this NuGet package.  Everything still works.