### PR TITLE
simplified type check syntax

### DIFF
--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -822,9 +822,7 @@ module OneWaySeqLazy =
     override __.Equals that =
       // All instances of TestClass are considered equal.
       // Not very helpful, but a valid implementation.
-      match that with
-      | :? TestClass as x -> true
-      | _ -> false
+      that :? TestClass
 
   [<Fact>]
   let ``when equals returns false and element removed from model, should trigger CC.Remove for removed element`` () =


### PR DESCRIPTION
This syntax is strictly better:
1. It is shorter.
2. It is idiomatic.
3. It doesn't have a warning.  The previous code had a warning because `x` was unused (and we are using `--warnon:1182`) and [`x` can't be replaced by `_`](https://github.com/dotnet/fsharp/issues/7740).