### PR TITLE
now using single instead of double underscore per new F# 4.7 feature

### DIFF
--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -46,25 +46,25 @@ type internal TestVm<'model, 'msg>(model, bindings) as this =
 
   new(model, binding) = TestVm(model, [binding])
 
-  member private __.Dispatch x =
+  member private _.Dispatch x =
     dispatchMsgs.Add x
 
-  member __.NumPcTriggersFor propName =
+  member _.NumPcTriggersFor propName =
     pcTriggers.TryGetValue propName |> snd
 
-  member __.NumEcTriggersFor propName =
+  member _.NumEcTriggersFor propName =
     ecTriggers.TryGetValue propName |> snd
 
-  member __.NumCcTriggersFor propName =
+  member _.NumCcTriggersFor propName =
     ccTriggers.GetOrAdd(propName, []).Length
 
-  member __.NumCecTriggersFor propName =
+  member _.NumCecTriggersFor propName =
     cecTriggers.TryGetValue propName |> snd
 
-  member __.Dispatches =
+  member _.Dispatches =
     dispatchMsgs |> Seq.toList
 
-  member __.CcTriggersFor propName =
+  member _.CcTriggersFor propName =
     ccTriggers.TryGetValue propName |> snd |> Seq.toList
 
   /// Starts tracking CollectionChanged triggers for the specified prop.
@@ -101,11 +101,11 @@ type InvokeTesterVal<'a, 'b>(initialRet: 'b) =
     count <- count + 1
     values <- values @ [x]
     retVal
-  member __.Fn = wrapped
-  member __.Count = count
-  member __.Values = values
-  member __.SetRetVal ret = retVal <- ret
-  member __.Reset () =
+  member _.Fn = wrapped
+  member _.Count = count
+  member _.Values = values
+  member _.SetRetVal ret = retVal <- ret
+  member _.Reset () =
     count <- 0
     values <- []
     retVal <- initialRet
@@ -119,11 +119,11 @@ type InvokeTesterVal2<'a, 'b, 'c>(initialRet: 'c) =
     count <- count + 1
     values <- values @ [(x, y)]
     retVal
-  member __.Fn : 'a -> 'b -> 'c = wrapped
-  member __.Count = count
-  member __.Values = values
-  member __.SetRetVal ret = retVal <- ret
-  member __.Reset () =
+  member _.Fn : 'a -> 'b -> 'c = wrapped
+  member _.Count = count
+  member _.Values = values
+  member _.SetRetVal ret = retVal <- ret
+  member _.Reset () =
     count <- 0
     values <- []
     retVal <- initialRet
@@ -136,10 +136,10 @@ type InvokeTester<'a, 'b>(f: 'a -> 'b) =
     count <- count + 1
     values <- values @ [x]
     f x
-  member __.Fn = wrapped
-  member __.Count = count
-  member __.Values = values
-  member __.Reset () =
+  member _.Fn = wrapped
+  member _.Count = count
+  member _.Values = values
+  member _.Reset () =
     count <- 0
     values <- []
 
@@ -151,10 +151,10 @@ type InvokeTester2<'a, 'b, 'c>(f: 'a -> 'b -> 'c) =
     count <- count + 1
     values <- values @ [x, y]
     f x
-  member __.Fn = wrapped
-  member __.Count = count
-  member __.Values = values
-  member __.Reset () =
+  member _.Fn = wrapped
+  member _.Count = count
+  member _.Values = values
+  member _.Reset () =
     count <- 0
     values <- []
 
@@ -818,8 +818,8 @@ module OneWaySeqLazy =
   type TestClass (id: int, data: string) =
     member _.Id = id
     member _.Data = data
-    override __.GetHashCode() = 0
-    override __.Equals that =
+    override _.GetHashCode() = 0
+    override _.Equals that =
       // All instances of TestClass are considered equal.
       // Not very helpful, but a valid implementation.
       that :? TestClass

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -603,9 +603,9 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
         | ValueSome err -> setError err name
     | _ -> ()
 
-  member __.CurrentModel : 'model = currentModel
+  member _.CurrentModel : 'model = currentModel
 
-  member __.UpdateModel (newModel: 'model) : unit =
+  member _.UpdateModel (newModel: 'model) : unit =
     let propsToNotify =
       bindings
       |> Seq.filter (fun (Kvp (name, binding)) -> updateValue name newModel binding)
@@ -621,7 +621,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
     for Kvp (name, binding) in bindings do
       updateValidationStatus name binding
 
-  override __.TryGetMember (binder, result) =
+  override _.TryGetMember (binder, result) =
     log "[%s] TryGetMember %s" propNameChain binder.Name
     match bindings.TryGetValue binder.Name with
     | false, _ ->
@@ -657,7 +657,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
                   selected |> ValueOption.toObj |> box
         true
 
-  override __.TrySetMember (binder, value) =
+  override _.TrySetMember (binder, value) =
     log "[%s] TrySetMember %s" propNameChain binder.Name
     match bindings.TryGetValue binder.Name with
     | false, _ ->
@@ -689,14 +689,14 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
 
   interface INotifyPropertyChanged with
     [<CLIEvent>]
-    member __.PropertyChanged = propertyChanged.Publish
+    member _.PropertyChanged = propertyChanged.Publish
 
   interface INotifyDataErrorInfo with
     [<CLIEvent>]
-    member __.ErrorsChanged = errorsChanged.Publish
-    member __.HasErrors =
+    member _.ErrorsChanged = errorsChanged.Publish
+    member _.HasErrors =
       errors.Count > 0
-    member __.GetErrors propName =
+    member _.GetErrors propName =
       log "[%s] GetErrors %s" propNameChain (propName |> Option.ofObj |> Option.defaultValue "<null>")
       match errors.TryGetValue propName with
       | true, err -> upcast [err]


### PR DESCRIPTION
One of the [new features of F# 4.7](https://devblogs.microsoft.com/dotnet/announcing-f-4-7/) is the ability to use a single underscore as an (ignored) instance identifier in method definitions.  This PR replaces all of our double underscores with single underscores.