### PR TITLE
now using extension of ObservableCollection with RemoveAll method

### DIFF
--- a/src/Elmish.WPF/InternalTypes.fs
+++ b/src/Elmish.WPF/InternalTypes.fs
@@ -4,6 +4,7 @@ module internal Elmish.WPF.InternalTypes
 open System
 open System.Windows.Input
 
+
 /// A command that optionally hooks into CommandManager.RequerySuggested to
 /// automatically trigger CanExecuteChanged whenever the CommandManager detects
 /// conditions that might change the output of canExecute. It's necessary to use
@@ -27,3 +28,35 @@ type Command(execute, canExecute, autoRequery) as this =
     member x.CanExecuteChanged = canExecuteChanged.Publish
     member x.CanExecute p = canExecute p
     member x.Execute p = execute p
+
+
+    
+open System.Collections.ObjectModel
+open System.ComponentModel
+open System.Collections.Specialized
+
+
+type EnhancedObservableCollection<'a> (seq: 'a seq) =
+  inherit ObservableCollection<'a>(seq)
+
+  let items = base.Items :?> System.Collections.Generic.List<'a> // hack
+
+  let PropertyChangedEventArgsCount = "Count" |> PropertyChangedEventArgs
+  let PropertyChangedEventArgsIndexer = "Item[]" |> PropertyChangedEventArgs
+  
+
+  member _.OnPropertyChangedCount () = base.OnPropertyChanged PropertyChangedEventArgsCount
+  member _.OnPropertyChangedIndexer () = base.OnPropertyChanged PropertyChangedEventArgsIndexer
+  member _.OnCollectionChangedItemRemoved nccea = base.OnCollectionChanged nccea
+
+  member this.RemoveAll (predicate: 'a -> int option) =
+    let predicateFunc a =
+      let index = predicate a
+      index |> Option.iter (fun i ->
+        this.OnPropertyChangedCount ()
+        this.OnPropertyChangedIndexer ()
+        this.OnCollectionChangedItemRemoved <| NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, a, i)
+      )
+      index.IsSome
+    let predicate = Predicate<'a>(predicateFunc)
+    items.RemoveAll predicate |> ignore


### PR DESCRIPTION
Partially addresses #137.

This needs a bit of polish, but I think it works.

`ObservableCollection<>` is extended and a method called `RemoveAll` is added.  Then in only the `SubModelSeq` case (I will do the `OneWaySeq` case too, just haven't yet), removals are now done in 
(worst case) linear time instead of (worst case) quadratic time (such as if all but one element is removed).

However, I only tested removing a single item at a time.  I want to test removing many (but not all) items at once.

This case of removals is less urgent than the case of sorting, but it is also easier, so I am working on it first.