### PR TITLE
Improve updateValue for SubModelSelectedItem

### DIFF
--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -30,9 +30,9 @@
     <Compile Include="InternalTypes.fs" />
     <Compile Include="Config.fs" />
     <Compile Include="Binding.fs" />
+    <Compile Include="Utils.fs" />
     <Compile Include="ViewModel.fs" />
     <Compile Include="ViewModelModule.fs" />
-    <Compile Include="Utils.fs" />
     <Compile Include="Cmd.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop" >
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -618,10 +618,21 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
             if oldIdx <> newIdx then b.Vms.Move(oldIdx, newIdx)
         false
     | SubModelSelectedItem b ->
-        let v = getSelectedSubViewModel newModel b.SubModelSeqBinding.Vms b.Get b.SubModelSeqBinding.GetId
-        log "[%s] Setting selected VM to %A" propNameChain (v |> ValueOption.map (fun v -> b.SubModelSeqBinding.GetId v.CurrentModel))
-        b.Selected := ValueSome v
-        true
+        let updateSelected (selected: ViewModel<obj, obj> voption) =
+          log "[%s] Setting selected VM to %A" propNameChain (selected |> ValueOption.map (fun vm -> b.SubModelSeqBinding.GetId vm.CurrentModel))
+          b.Selected := ValueSome selected
+          true
+        match !b.Selected with
+        | ValueNone -> false // never initialized, so no need to notify changed
+        | ValueSome oldSelected ->
+            let newSelected = getSelectedSubViewModel newModel b.SubModelSeqBinding.Vms b.Get b.SubModelSeqBinding.GetId
+            match oldSelected, newSelected with
+            | ValueNone, ValueNone -> false
+            | ValueSome oldVm, ValueSome newVm ->
+                if refEq oldVm newVm then false
+                else updateSelected newSelected
+            | _ -> updateSelected newSelected
+                
 
   /// Returns the command associated with a command binding if the command's
   /// CanExecuteChanged should be triggered.

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -623,7 +623,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
           b.Selected := ValueSome selected
           true
         match !b.Selected with
-        | ValueNone -> false // never initialized, so no need to notify changed
+        | ValueNone -> false  // never initialized, so no need to notify changed
         | ValueSome oldSelected ->
             let newSelected = getSelectedSubViewModel newModel b.SubModelSeqBinding.Vms b.Get b.SubModelSeqBinding.GetId
             match oldSelected, newSelected with


### PR DESCRIPTION
Fixes #175.

Specifically, this PR
1. replaces the eager behavior with the intended lazy behavior (by only calling `getSelectedSubModel` if `!b.Selected` is in the `ValueSome` state and
2. returns `true` if and only if `!b.Selected` is mutated (either one of its `voption`s is in a different state or they are both in the `ValueSome` state and the new view-model is not reference equal to the old one).

I tested the `SubModelSelectedItem` sample, and everything still works.