### PR TITLE
Properly dispose of Command instances

### DIFF
--- a/src/Elmish.WPF.sln
+++ b/src/Elmish.WPF.sln
@@ -57,6 +57,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FileDialogs.CmdMsg.Views", 
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FileDialogs.CmdMsg", "Samples\FileDialogs.CmdMsg\FileDialogs.CmdMsg.fsproj", "{F095E7E4-28ED-4223-A92F-4E86922E34EF}"
 EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "SubModelSeqMemory", "Samples\SubModelSeqMemory\SubModelSeqMemory.fsproj", "{97CAA5E1-B059-474B-9530-3CD7ECAC9675}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SubModelSeqMemory.Views", "Samples\SubModelSeqMemory.Views\SubModelSeqMemory.Views.csproj", "{E1527FE8-E653-40FD-9ADD-8CC54EF2C3D1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -167,6 +171,14 @@ Global
 		{F095E7E4-28ED-4223-A92F-4E86922E34EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F095E7E4-28ED-4223-A92F-4E86922E34EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F095E7E4-28ED-4223-A92F-4E86922E34EF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{97CAA5E1-B059-474B-9530-3CD7ECAC9675}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97CAA5E1-B059-474B-9530-3CD7ECAC9675}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{97CAA5E1-B059-474B-9530-3CD7ECAC9675}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97CAA5E1-B059-474B-9530-3CD7ECAC9675}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E1527FE8-E653-40FD-9ADD-8CC54EF2C3D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1527FE8-E653-40FD-9ADD-8CC54EF2C3D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E1527FE8-E653-40FD-9ADD-8CC54EF2C3D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E1527FE8-E653-40FD-9ADD-8CC54EF2C3D1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -196,6 +208,8 @@ Global
 		{36A4AEAF-8282-47EC-B751-BB3D16AB1A20} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
 		{F66F6E21-357E-4CE8-9807-042C5171AB06} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
 		{F095E7E4-28ED-4223-A92F-4E86922E34EF} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
+		{97CAA5E1-B059-474B-9530-3CD7ECAC9675} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
+		{E1527FE8-E653-40FD-9ADD-8CC54EF2C3D1} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3125D461-08F4-4071-AAE5-1038EF84A360}

--- a/src/Elmish.WPF/InternalTypes.fs
+++ b/src/Elmish.WPF/InternalTypes.fs
@@ -4,26 +4,39 @@ module internal Elmish.WPF.InternalTypes
 open System
 open System.Windows.Input
 
+module Option =
+  let apply a = Option.map (fun f -> f a)
+
 /// A command that optionally hooks into CommandManager.RequerySuggested to
 /// automatically trigger CanExecuteChanged whenever the CommandManager detects
 /// conditions that might change the output of canExecute. It's necessary to use
 /// this feature for command bindings where the CommandParameter is bound to
 /// another UI control (e.g. a ListView.SelectedItem).
-type Command(execute, canExecute, autoRequery) as this =
+type Command(execute: obj -> unit, canExecute: obj -> bool, autoRequery) as this =
 
-  let canExecuteChanged = Event<EventHandler,EventArgs>()
-  let handler = EventHandler(fun _ _ -> this.RaiseCanExecuteChanged())
+  let mutable _execute = Some execute
 
-  do if autoRequery then CommandManager.RequerySuggested.AddHandler(handler)
+  let mutable _canExecute = Some canExecute
+
+  let mutable _canExecuteChanged = new Event<EventHandler,EventArgs>()
+
+  let mutable _handler = EventHandler(fun _ _ -> this.RaiseCanExecuteChanged())
+
+  do if autoRequery then CommandManager.RequerySuggested.AddHandler(_handler)
 
   // CommandManager only keeps a weak reference to the event handler, so a
   // strong handler must be maintained
-  member private x._Handler = handler
+  member private x._Handler with get () = _handler and set v = _handler <- v
 
-  member x.RaiseCanExecuteChanged () = canExecuteChanged.Trigger(x,EventArgs.Empty)
+  member x.RaiseCanExecuteChanged () = _canExecuteChanged.Trigger(x,EventArgs.Empty)
+
+  interface IDisposable with
+    member x.Dispose () =
+      _execute <- None
+      _canExecute <- None
 
   interface ICommand with
     [<CLIEvent>]
-    member x.CanExecuteChanged = canExecuteChanged.Publish
-    member x.CanExecute p = canExecute p
-    member x.Execute p = execute p
+    member x.CanExecuteChanged = _canExecuteChanged.Publish
+    member x.CanExecute p = _canExecute |> Option.apply p |> Option.defaultValue false
+    member x.Execute p = _execute |> Option.apply p |> Option.defaultValue ()

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -591,44 +591,44 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
           else oldSubViewModelIdxPairsById.Add(id, (oldIdx, vm))
 
         if newSubModelIdxPairsById.Count = newSubModels.Length && oldSubViewModelIdxPairsById.Count = b.Vms.Count then
-            // Update existing models
-            for Kvp (oldId, (_, vm)) in oldSubViewModelIdxPairsById do
-              match newSubModelIdxPairsById.TryGetValue oldId with
-              | true, (_, m) -> vm.UpdateModel m
-              | _ -> ()
+          // Update existing models
+          for Kvp (oldId, (_, vm)) in oldSubViewModelIdxPairsById do
+            match newSubModelIdxPairsById.TryGetValue oldId with
+            | true, (_, m) -> vm.UpdateModel m
+            | _ -> ()
 
-            // Remove old view models that no longer exist
-            if b.Vms.Count <> 0 && newSubModels.Length = 0
-            then
-              b.Vms |> Seq.iter (fun vm -> BindingManager.disposeBindings vm)
-              b.Vms.Clear ()
-            else
-              for i in b.Vms.Count - 1..-1..0 do
-                let oldId = b.GetId b.Vms.[i].CurrentModel
-                if oldId |> newSubModelIdxPairsById.ContainsKey |> not then
-                  let (oldIdx, _) = oldSubViewModelIdxPairsById.[oldId]
-                  log "[%s] Removing model at %O" propNameChain oldId
-                  b.Vms.[oldIdx] |> BindingManager.disposeBindings
-                  b.Vms.RemoveAt oldIdx
+          // Remove old view models that no longer exist
+          if b.Vms.Count <> 0 && newSubModels.Length = 0
+          then
+            b.Vms |> Seq.iter (fun vm -> BindingManager.disposeBindings vm)
+            b.Vms.Clear ()
+          else
+            for i in b.Vms.Count - 1..-1..0 do
+              let oldId = b.GetId b.Vms.[i].CurrentModel
+              if oldId |> newSubModelIdxPairsById.ContainsKey |> not then
+                let (oldIdx, _) = oldSubViewModelIdxPairsById.[oldId]
+                log "[%s] Removing model at %O" propNameChain oldId
+                b.Vms.[oldIdx] |> BindingManager.disposeBindings
+                b.Vms.RemoveAt oldIdx
 
-            // Add new models that don't currently exist
-            let create (Kvp (id, (_, m))) =
-              let chain = getPropChainForItem bindingName (id |> string)
-              log "[%s] Adding model at %O" propNameChain id
-              ViewModel(m, (fun msg -> b.ToMsg (id, msg) |> dispatch), b.GetBindings (), config, chain)
-            newSubModelIdxPairsById
-            |> Seq.filter (Kvp.key >> oldSubViewModelIdxPairsById.ContainsKey >> not)
-            |> Seq.map create
-            |> Seq.iter b.Vms.Add
+          // Add new models that don't currently exist
+          let create (Kvp (id, (_, m))) =
+            let chain = getPropChainForItem bindingName (id |> string)
+            log "[%s] Adding model at %O" propNameChain id
+            ViewModel(m, (fun msg -> b.ToMsg (id, msg) |> dispatch), b.GetBindings (), config, chain)
+          newSubModelIdxPairsById
+          |> Seq.filter (Kvp.key >> oldSubViewModelIdxPairsById.ContainsKey >> not)
+          |> Seq.map create
+          |> Seq.iter b.Vms.Add
 
-            // Reorder according to new model list
-            for Kvp (newId, (newIdx, _)) in newSubModelIdxPairsById do
-              let oldIdx =
-                b.Vms
-                |> Seq.indexed
-                |> Seq.find (fun (_, vm) -> newId = b.GetId vm.CurrentModel)
-                |> fst
-              if oldIdx <> newIdx then b.Vms.Move(oldIdx, newIdx)
+          // Reorder according to new model list
+          for Kvp (newId, (newIdx, _)) in newSubModelIdxPairsById do
+            let oldIdx =
+              b.Vms
+              |> Seq.indexed
+              |> Seq.find (fun (_, vm) -> newId = b.GetId vm.CurrentModel)
+              |> fst
+            if oldIdx <> newIdx then b.Vms.Move(oldIdx, newIdx)
         false
     | SubModelSelectedItem b ->
         if b.Get newModel = b.Get currentModel then false

--- a/src/Samples/SubModelSeqMemory.Views/MainWindow.xaml
+++ b/src/Samples/SubModelSeqMemory.Views/MainWindow.xaml
@@ -1,0 +1,46 @@
+﻿<Window
+    x:Class="Elmish.WPF.Samples.SubModelSeqMemory.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="SubModelSeqMemory" Height="800" Width="1100"
+    WindowStartupLocation="CenterScreen">
+  <StackPanel Margin="0,20,0,10">
+    <GroupBox Header="Without Command">
+      <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+        <Button Command="{Binding AddSubModel}" Content="Add sub model" Width="150" Margin="10,0,10,20" />
+        <Button Command="{Binding RemoveFirst}" Content="Remove sub model" Width="150" Margin="10,0,10,20" />
+      </StackPanel>
+    </GroupBox>
+    <GroupBox Header="With Command">
+      <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+        <Button Command="{Binding AddCmdSubModel}" Content="Add sub model" Width="150" Margin="10,0,10,20" />
+        <Button Command="{Binding RemoveFirstCmd}" Content="Remove sub model" Width="150" Margin="10,0,10,20" />
+      </StackPanel>
+    </GroupBox>
+    <GroupBox Header="Without Command">
+      <ListView ItemsSource="{Binding SubModels}">
+        <ListView.ItemTemplate>
+          <DataTemplate>
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+              <TextBlock Text="{Binding Id}" Margin="15"/>
+              <TextBlock Text="{Binding Num}" Margin="15"/>
+            </StackPanel>
+          </DataTemplate>
+        </ListView.ItemTemplate>
+      </ListView>
+    </GroupBox>
+    <GroupBox Header="With Command">
+      <ListView ItemsSource="{Binding CmdSubModels}">
+        <ListView.ItemTemplate>
+          <DataTemplate>
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+              <TextBlock Text="{Binding Id}" Margin="15"/>
+              <TextBlock Text="{Binding Num}" Margin="15"/>
+              <Button Content="O" Padding="5" Margin="15" Command="{Binding Regen}"/>
+            </StackPanel>
+          </DataTemplate>
+        </ListView.ItemTemplate>
+      </ListView>
+    </GroupBox>
+  </StackPanel>
+</Window>

--- a/src/Samples/SubModelSeqMemory.Views/MainWindow.xaml.cs
+++ b/src/Samples/SubModelSeqMemory.Views/MainWindow.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows;
+
+namespace Elmish.WPF.Samples.SubModelSeqMemory
+{
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Samples/SubModelSeqMemory.Views/SubModelSeqMemory.Views.csproj
+++ b/src/Samples/SubModelSeqMemory.Views/SubModelSeqMemory.Views.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <UseWpf>true</UseWpf>
+  </PropertyGroup>
+
+</Project>

--- a/src/Samples/SubModelSeqMemory/Program.fs
+++ b/src/Samples/SubModelSeqMemory/Program.fs
@@ -1,0 +1,105 @@
+﻿module Elmish.WPF.Samples.SubModelSeqMemory.Program
+
+open System
+open Elmish
+open Elmish.WPF
+
+let rand = Random()
+
+[<AutoOpen>]
+module Domain =
+
+  type SubModelId = Guid
+
+  type SubModel =
+    { Id: SubModelId
+      Num: float
+      Data: float array }
+    static member create () =
+      { Id = Guid.NewGuid ()
+        Num = 0.0
+        Data = [| 0.0 .. 50000000.0 - 1.0 |] }
+        
+  type SubMsg =
+    | Regen
+
+module App =
+
+  type Model =
+    { SubModels: SubModel list
+      CmdSubModels: SubModel list }
+
+  let init () =
+    { SubModels = []
+      CmdSubModels = [] }
+
+  type Msg =
+    //| SubModelMsg of SubModelId
+    | AddSubModel
+    | AddCmdSubModel
+    | RemoveFirstSubModel
+    | RemoveFirstCmdSubModel
+    | CmdSubModelMsg of SubModelId * SubMsg
+
+  let subUpdate msg model =
+    match msg with
+    | Regen -> { model with Num = rand.NextDouble() } 
+
+  let update msg model =
+    match msg with
+    | AddSubModel -> { model with SubModels = SubModel.create() :: model.SubModels }
+    | AddCmdSubModel -> { model with CmdSubModels = SubModel.create() :: model.CmdSubModels }
+    | RemoveFirstSubModel -> { model with SubModels = if model.SubModels |> List.isEmpty |> not then model.SubModels |> List.tail else [] }
+    | RemoveFirstCmdSubModel -> { model with CmdSubModels = if model.CmdSubModels |> List.isEmpty |> not then model.CmdSubModels |> List.tail else [] }
+    | CmdSubModelMsg (id, msg) ->
+      let updateSubModel sm' = List.map (fun sm -> if sm'.Id = sm.Id then sm' else sm)
+      model.CmdSubModels
+      |> List.tryFind (fun sm -> sm.Id = id)
+      |> Option.map (fun sm ->
+        let sm' = subUpdate msg sm
+        { model with CmdSubModels = model.CmdSubModels |> updateSubModel sm' })
+      |> Option.defaultValue model
+      
+
+
+module Bindings =
+
+  open App
+
+  let subModelBindings () : Binding<SubModel, SubMsg> list = [
+    "Id" |> Binding.oneWay (fun sm -> sm.Id)
+    "Num" |> Binding.oneWay (fun sm -> sm.Num)
+  ]
+
+  let cmdSubModelBindings () : Binding<SubModel, SubMsg> list = [
+    "Id" |> Binding.oneWay (fun sm -> sm.Id)
+    "Num" |> Binding.oneWay (fun sm -> sm.Num)
+
+    "Regen" |> Binding.cmd (fun sm -> Regen)
+    //"Remove" |> Binding.cmd (fun sm -> Remove)
+
+  ]
+
+
+  let rootBindings () : Binding<Model, Msg> list = [
+    "SubModels" |> Binding.subModelSeq ((fun m -> m.SubModels), snd, (fun sm -> sm.Id), CmdSubModelMsg, subModelBindings)
+
+    "CmdSubModels" |> Binding.subModelSeq ((fun m -> m.CmdSubModels), snd, (fun sm -> sm.Id), CmdSubModelMsg, cmdSubModelBindings)
+
+    "AddSubModel" |> Binding.cmd (fun _ -> AddSubModel)
+
+    "AddCmdSubModel" |> Binding.cmd (fun _ -> AddCmdSubModel)
+
+    "RemoveFirst" |> Binding.cmd (fun _ -> RemoveFirstSubModel)
+
+    "RemoveFirstCmd" |> Binding.cmd (fun _ -> RemoveFirstCmdSubModel)
+  ]
+
+
+[<EntryPoint; STAThread>]
+let main _ =
+  Program.mkSimpleWpf App.init App.update Bindings.rootBindings
+  |> Program.withConsoleTrace
+  |> Program.runWindowWithConfig
+    { ElmConfig.Default with LogConsole = true; Measure = true }
+    (MainWindow())

--- a/src/Samples/SubModelSeqMemory/SubModelSeqMemory.fsproj
+++ b/src/Samples/SubModelSeqMemory/SubModelSeqMemory.fsproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <UseWpf>true</UseWpf>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\..\Elmish.WPF\Elmish.WPF.fsproj" />
+    <ProjectReference Include="..\SubModelSeqMemory.Views\SubModelSeqMemory.Views.csproj" />
+  </ItemGroup>
+  
+</Project>


### PR DESCRIPTION
I was noticing a memory leak in cases where sequences of sub-models containing command bindings were being removed. This was reproduced in a sample (included in this MR) where, once a sub-model containing a command binding is dynamically removed, the reference to the `ViewModel<'model,'msg>` instance is still present in memory. This was not the case for sub-models without command bindings.

Using Visual Studio's memory profiler, it appeared to be `execute` and `canExecute` inside the `Command` that were still hanging on the to `ViewModel` reference even after its underlying model had been removed. My solution was to have the `Command` class implement `IDisposable`, in which it removes references to `execute` and `canExecute`. 