### PR TITLE
Recursive cached binding

### DIFF
--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -388,6 +388,7 @@ module OneWayLazy =
 
       let binding = oneWayLazy name get equals map
       let vm = TestVm(m1, binding)
+      vm.Get name |> ignore  // populate cache
       vm.UpdateModel m2
 
       test <@ vm.Get name = (m1 |> get |> map) @>

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -671,7 +671,9 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
           b.SubModelSeqBinding.Vms 
           |> Seq.tryFind (fun (vm: ViewModel<obj, obj>) ->
             selectedId = ValueSome (b.SubModelSeqBinding.GetId vm.CurrentModel))
-        log "[%s] Setting selected VM to %A" propNameChain (selected |> Option.map (fun vm -> b.SubModelSeqBinding.GetId vm.CurrentModel))
+        log "[%s] Setting selected VM to %A"
+          propNameChain
+          (selected |> Option.map (fun vm -> b.SubModelSeqBinding.GetId vm.CurrentModel))
         selected |> Option.toObj |> box
     | Cached b ->
         match !b.Cache with

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -671,9 +671,8 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
           b.SubModelSeqBinding.Vms 
           |> Seq.tryFind (fun (vm: ViewModel<obj, obj>) ->
             selectedId = ValueSome (b.SubModelSeqBinding.GetId vm.CurrentModel))
-          |> ValueOption.ofOption
-        log "[%s] Setting selected VM to %A" propNameChain (selected |> ValueOption.map (fun vm -> b.SubModelSeqBinding.GetId vm.CurrentModel))
-        selected |> ValueOption.toObj |> box
+        log "[%s] Setting selected VM to %A" propNameChain (selected |> Option.map (fun vm -> b.SubModelSeqBinding.GetId vm.CurrentModel))
+        selected |> Option.toObj |> box
     | Cached b ->
         match !b.Cache with
         | Some v -> v

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -216,13 +216,6 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
       } |> Async.StartImmediate
     )
 
-  let getSelectedSubViewModel vms getSubModelId getSelectedId model =
-    let selectedId = getSelectedId model
-    vms
-    |> Seq.tryFind (fun (vm: ViewModel<obj, obj>) ->
-      selectedId = ValueSome (getSubModelId vm.CurrentModel))
-    |> ValueOption.ofOption
-
   let initializeBinding name bindingData getInitializedBindingByName =
     match bindingData with
     | OneWayData d ->
@@ -673,7 +666,12 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
         | WindowState.Hidden vm | WindowState.Visible vm -> box vm
     | SubModelSeq { Vms = vms } -> box vms
     | SubModelSelectedItem b ->
-        let selected = getSelectedSubViewModel b.SubModelSeqBinding.Vms b.SubModelSeqBinding.GetId b.Get model
+        let selectedId = b.Get model
+        let selected =
+          b.SubModelSeqBinding.Vms 
+          |> Seq.tryFind (fun (vm: ViewModel<obj, obj>) ->
+            selectedId = ValueSome (b.SubModelSeqBinding.GetId vm.CurrentModel))
+          |> ValueOption.ofOption
         log "[%s] Setting selected VM to %A" propNameChain (selected |> ValueOption.map (fun vm -> b.SubModelSeqBinding.GetId vm.CurrentModel))
         selected |> ValueOption.toObj |> box
     | Cached b ->


### PR DESCRIPTION
Fixes #181 

Creates a recursive binding type called `CachedBinding<'model, 'msg>`.  The caching in the `OneWayLazy` and `SubModelSelectedItem` cases are removed and now use this cached binding instead.

All the tests pass, and there is an existing test for `OneWayLazy` that ensures that caching is working.

I left one comment in the code to make sure we have a conversation about it.  I will create a comment in this PR on that line next.