### PR TITLE
Documentation: Fixed a typo in the Program.fs open statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ See the [SingleCounter](https://github.com/elmish/Elmish.WPF/tree/master/src/Sam
 
    ```F#
    open System
-   open Elmish
+   open Elmish.WPF
    
    [<EntryPoint; STAThread>]
    let main argv =


### PR DESCRIPTION
Fixed an issue withe the code example that tripped me up when I was trying to get started and didn't want others to have the same initial experience. 

`Program.mkSimpleWpf` is not able to be found unless you've opened `Elmish.WPF` instead of `Elmish`.