### PR TITLE
Bug fix 200 current application

### DIFF
--- a/src/Elmish.WPF/Program.fs
+++ b/src/Elmish.WPF/Program.fs
@@ -33,10 +33,13 @@ let startElmishLoop
   |> Program.run
 
 
-/// Instantiates Application if it is not already running, and then runs the
-/// specified window. This is a blocking function.
-let private startApp window =
+/// Instantiates Application if it is not already running.
+let private instantiateApp () =
   if isNull Application.Current then Application () |> ignore
+
+
+/// Runs the specified window. This is a blocking function.
+let private startApp window =
   Application.Current.Run window
 
 
@@ -44,6 +47,7 @@ let private startApp window =
 /// Will instantiate Application if it is not already running, and then run the
 /// specified window. This is a blocking function.
 let runWindowWithConfig config window program =
+  instantiateApp ()
   startElmishLoop config window program
   startApp window
 

--- a/src/Elmish.WPF/Program.fs
+++ b/src/Elmish.WPF/Program.fs
@@ -52,8 +52,7 @@ let runWindowWithConfig config window program =
 /// if it is not already running, and then run the specified window. This is
 /// a blocking function.
 let runWindow window program =
-  startElmishLoop ElmConfig.Default window program
-  startApp window
+  runWindowWithConfig ElmConfig.Default window program
 
 
 /// Same as mkSimple, but with a signature adapted for Elmish.WPF.

--- a/src/Elmish.WPF/Program.fs
+++ b/src/Elmish.WPF/Program.fs
@@ -33,8 +33,8 @@ let startElmishLoop
   |> Program.run
 
 
-/// Starts the WPF dispatch loop. Will instantiate Application if it is not
-/// already running, and then run the specified window. This is a blocking function.
+/// Instantiates Application if it is not already running, and then runs the
+/// specified window. This is a blocking function.
 let private startApp window =
   if isNull Application.Current then Application () |> ignore
   Application.Current.Run window

--- a/src/Elmish.WPF/Program.fs
+++ b/src/Elmish.WPF/Program.fs
@@ -40,19 +40,19 @@ let private startApp window =
   Application.Current.Run window
 
 
-/// Starts the Elmish and WPF dispatch loops. Will instantiate Application
-/// if it is not already running, and then run the specified window. This is
-/// a blocking function.
-let runWindow window program =
-  startElmishLoop ElmConfig.Default window program
-  startApp window
-
-
 /// Starts the Elmish and WPF dispatch loops with the specified configuration.
 /// Will instantiate Application if it is not already running, and then run the
 /// specified window. This is a blocking function.
 let runWindowWithConfig config window program =
   startElmishLoop config window program
+  startApp window
+
+
+/// Starts the Elmish and WPF dispatch loops. Will instantiate Application
+/// if it is not already running, and then run the specified window. This is
+/// a blocking function.
+let runWindow window program =
+  startElmishLoop ElmConfig.Default window program
   startApp window
 
 


### PR DESCRIPTION
Fixes #200

`Application.Current` in
https://github.com/elmish/Elmish.WPF/blob/3f0d3552203dcf3152f1088014ee608f2926f8a9/src/Elmish.WPF/ViewModel.fs#L199
was `null` when processing an initial state as described in #200.  After some clean up of the relevant code, this is a minimal change to fix that bug.

I didn't create an automated test for this bug.  As is, it needs to display one or two windows.  I have created a WPF test before (which needs to execute with a dedicated thread), but I have never tried to display a window in a test before, and I don't feel like trying to do that now.

There is another way to fix this bug that I will suggest in a new issue.