### PR TITLE
Use window dispatcher

### DIFF
--- a/src/Elmish.WPF/Program.fs
+++ b/src/Elmish.WPF/Program.fs
@@ -33,13 +33,10 @@ let startElmishLoop
   |> Program.run
 
 
-/// Instantiates Application if it is not already running.
-let private instantiateApp () =
-  if isNull Application.Current then Application () |> ignore
-
-
-/// Runs the specified window. This is a blocking function.
+/// Instantiates Application if it is not already running then runs the
+/// specified window. This is a blocking function.
 let private startApp window =
+  if isNull Application.Current then Application () |> ignore
   Application.Current.Run window
 
 
@@ -47,7 +44,6 @@ let private startApp window =
 /// Will instantiate Application if it is not already running, and then run the
 /// specified window. This is a blocking function.
 let runWindowWithConfig config window program =
-  instantiateApp ()
   startElmishLoop config window program
   startApp window
 

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -196,11 +196,11 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
       (onCloseRequested: unit -> unit)
       (preventClose: bool ref)
       initialVisibility =
-    Application.Current.Dispatcher.Invoke(fun () ->
+    let win = getWindow currentModel dispatch
+    winRef.SetTarget win
+    win.Dispatcher.Invoke(fun () ->
       let guiCtx = System.Threading.SynchronizationContext.Current
       async {
-        let win = getWindow currentModel dispatch
-        winRef.SetTarget win
         win.DataContext <- dataContext
         win.Closing.Add(fun ev ->
           ev.Cancel <- !preventClose
@@ -502,7 +502,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
           | true, w ->
               log "[%s] Closing window" winPropChain
               b.WinRef.SetTarget null
-              w.Close ()
+              w.Dispatcher.Invoke(fun () -> w.Close ())
           b.WinRef.SetTarget null
 
         let hide () =
@@ -511,7 +511,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
               log "[%s] Attempted to hide window, but did not find window reference" winPropChain
           | true, w ->
               log "[%s] Hiding window" winPropChain
-              w.Visibility <- Visibility.Hidden
+              w.Dispatcher.Invoke(fun () -> w.Visibility <- Visibility.Hidden)
 
         let showHidden () =
           match b.WinRef.TryGetTarget () with
@@ -519,7 +519,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
               log "[%s] Attempted to show existing hidden window, but did not find window reference" winPropChain
           | true, w ->
               log "[%s] Showing existing hidden window" winPropChain
-              w.Visibility <- Visibility.Visible
+              w.Dispatcher.Invoke(fun () -> w.Visibility <- Visibility.Visible)
 
         let showNew vm initialVisibility =
           b.PreventClose := true


### PR DESCRIPTION
This is a better fix to issue #200, which has already been fixed by PR #201.  This change also allows additional windows to be created in different threads.

Some related discussion is also in issue #202 (but I will include here the parts that I think are most relevant).

In https://github.com/elmish/Elmish.WPF/issues/202#issuecomment-613543070, I said
> ...the thought about which `Dispatcher` instance to use crossed my mind, but I don't know the difference between using one vs another.

I read up on this, and I think I understand this now.  The short answer is that each WPF object instance can only be modified by the thread that created it.  Don't know what thread created a certain WPF object instance?  No worries; just mutate that instance using its `Dispatcher` instance.

This is what @JDiLenarda said in https://github.com/elmish/Elmish.WPF/issues/202#issuecomment-613527232:
> ...the use of FrameworkElement instead of just Window, and replaced every instance of Application.Current.Dispatcher with Dispatcher from the current FrameworkElement in ViewModel module.
> 
> Currently, I cannot use windows submodel in such a plugin. Since it has not been big deal for now, I didn’t investigate the reason or opened issues, but I strongly suspect it’s because of Application.Current.Dispatcher calls. To my mind, such uses should be replaced by the Dispatcher of the main FrameworkElement.

Yes, @JDiLenarda.  That is exactly what the first commit in this PR does.  The `Window` returned by `getWindow` in
https://github.com/elmish/Elmish.WPF/blob/b62f4ed28f806847d6d8521216886e82fb64f6fd/src/Elmish.WPF/ViewModel.fs#L191-L199
is now mutated using its `Dispatcher` instead of the one returned from `Application.Current.Dispatcher`.

As such, this change avoids the `NullReferenceException` bug from issue #200.  To see that, on top of this branch, cherry pick the only commit on [this branch](https://github.com/mbenoni7/Elmish.WPF/tree/initial-cmd-bug) and run the `NewWindow` sample (because the second commit in the branch for this PR essentially reverts the fix from PR #201).

Furthermore, to see that this change also allows windows to be created in different threads,
- first checkout `master`, cherry pick the only commit on [this brach](https://github.com/bender2k14/Elmish.WPF/tree/testing/create_window_in_different_thread), run the `NewWindow` sample, click `Hide`, and observe an `InvalidOperationException`,
- then repeat all that but with the branch for this PR checked out instead of `master`.