### PR TITLE
initialize main Window before starting Elmish dispatch loop #206

### DIFF
--- a/src/Elmish.WPF/Program.fs
+++ b/src/Elmish.WPF/Program.fs
@@ -33,24 +33,28 @@ let startElmishLoop
   |> Program.run
 
 
-/// Instantiates Application if it is not already running then runs the
-/// specified window. This is a blocking function.
-let private startApp window =
-  if isNull Application.Current then Application () |> ignore
-  Application.Current.Run window
+/// Instantiates Application and sets its MainWindow if it is not already
+/// running.
+let private initializeApplication window =
+  if isNull Application.Current
+  then
+    Application () |> ignore
+    Application.Current.MainWindow <- window
 
 
 /// Starts the Elmish and WPF dispatch loops with the specified configuration.
-/// Will instantiate Application if it is not already running, and then run the
-/// specified window. This is a blocking function.
-let runWindowWithConfig config window program =
+/// Will instantiate Application and set its MainWindow if it is not already
+/// running, and then run the specified window. This is a blocking function.
+let runWindowWithConfig config (window: Window) program =
+  initializeApplication window
+  window.Show ()
   startElmishLoop config window program
-  startApp window
+  Application.Current.Run window
 
 
-/// Starts the Elmish and WPF dispatch loops. Will instantiate Application
-/// if it is not already running, and then run the specified window. This is
-/// a blocking function.
+/// Starts the Elmish and WPF dispatch loops. Will instantiate Application and
+/// set its MainWindow if it is not already running, and then run the specified
+/// window. This is a blocking function.
 let runWindow window program =
   runWindowWithConfig ElmConfig.Default window program
 

--- a/src/Elmish.WPF/Program.fs
+++ b/src/Elmish.WPF/Program.fs
@@ -36,8 +36,7 @@ let startElmishLoop
 /// Instantiates Application and sets its MainWindow if it is not already
 /// running.
 let private initializeApplication window =
-  if isNull Application.Current
-  then
+  if isNull Application.Current then
     Application () |> ignore
     Application.Current.MainWindow <- window
 


### PR DESCRIPTION
Fixes #206

As @cmeeren suggested in https://github.com/elmish/Elmish.WPF/issues/206#issuecomment-618504164, this PR initializes `Application` and shows the provided `Window` before starting the Elmish dispatch loop.

One additional change is also needed though, which is to set the provided window to `Applicaiton.Current.MainWindow`.  The [documentation](https://docs.microsoft.com/en-us/dotnet/framework/wpf/app-development/how-to-get-and-set-the-main-application-window) says that...
> The first Window that is instantiated within a Windows Presentation Foundation (WPF) application is automatically set by `Application` as the main application window.

...but this is only true if `Application` has been instantiated.  Therefore, this PR also assigns the provided `Window` to `Application.Current.MainWindow` if `Application` had not yet been instantiated.