### PR TITLE
Replace uses of array type in tests with list type

### DIFF
--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -492,11 +492,11 @@ module OneWaySeqLazy =
   let ``when retrieved initially, should return an ObservableCollection with the values returned by map`` () =
     Property.check <| property {
       let! name = GenX.auto<string>
-      let! m = GenX.auto<int * Guid array>
+      let! m = GenX.auto<int * Guid list>
 
       let get = snd
       let equals = (=)
-      let map = Array.toList
+      let map = id
       let itemEquals = (=)
       let getId = id
 
@@ -513,12 +513,12 @@ module OneWaySeqLazy =
   let ``when retrieved after update and equals returns false, should return an ObservableCollection with the new values returned by map`` () =
       Property.check <| property {
         let! name = GenX.auto<string>
-        let! m1 = GenX.auto<int * Guid array>
-        let! m2 = GenX.auto<int * Guid array>
+        let! m1 = GenX.auto<int * Guid list>
+        let! m2 = GenX.auto<int * Guid list>
 
         let get = snd
         let equals _ _ = false
-        let map = Array.toList
+        let map = id
         let itemEquals = (=)
         let getId = id
 
@@ -537,12 +537,12 @@ module OneWaySeqLazy =
   let ``when retrieved after update and equals returns true, should return an ObservableCollection with the previous values returned by map`` () =
     Property.check <| property {
       let! name = GenX.auto<string>
-      let! m1 = GenX.auto<int * Guid array>
-      let! m2 = GenX.auto<int * Guid array>
+      let! m1 = GenX.auto<int * Guid list>
+      let! m2 = GenX.auto<int * Guid list>
 
       let get = snd
       let equals _ _ = true
-      let map = Array.toList
+      let map = id
       let itemEquals = (=)
       let getId = id
 
@@ -561,12 +561,12 @@ module OneWaySeqLazy =
   let ``map should be called at most once during VM instantiation`` () =
     Property.check <| property {
       let! name = GenX.auto<string>
-      let! m1 = GenX.auto<int * Guid array>
+      let! m1 = GenX.auto<int * Guid list>
       let! eq = Gen.bool
 
       let get = snd
       let equals _ _ = eq
-      let map = InvokeTester Array.toList
+      let map = InvokeTester id
       let itemEquals = (=)
       let getId = id
 
@@ -581,13 +581,13 @@ module OneWaySeqLazy =
   let ``map should be called at most once during model update iff equals returns false`` () =
     Property.check <| property {
       let! name = GenX.auto<string>
-      let! m1 = GenX.auto<int * Guid array>
-      let! m2 = GenX.auto<int * Guid array>
+      let! m1 = GenX.auto<int * Guid list>
+      let! m2 = GenX.auto<int * Guid list>
       let! eq = Gen.bool
 
       let get = snd
       let equals _ _ = eq
-      let map = InvokeTester Array.toList
+      let map = InvokeTester id
       let itemEquals = (=)
       let getId = id
 
@@ -605,12 +605,12 @@ module OneWaySeqLazy =
   let ``when retrieved several times between updates, map is called at most once`` () =
     Property.check <| property {
       let! name = GenX.auto<string>
-      let! m1 = GenX.auto<int * Guid array>
-      let! m2 = GenX.auto<int * Guid array>
+      let! m1 = GenX.auto<int * Guid list>
+      let! m2 = GenX.auto<int * Guid list>
 
       let get = snd
       let equals = (=)
-      let map = InvokeTester Array.toList
+      let map = InvokeTester id
       let itemEquals = (=)
       let getId = id
 
@@ -633,14 +633,14 @@ module OneWaySeqLazy =
   let ``when model is updated, should never trigger PC regardless of equals or itemEquals`` () =  // because this binding should only trigger CC
     Property.check <| property {
       let! name = GenX.auto<string>
-      let! m1 = GenX.auto<int * Guid array>
-      let! m2 = GenX.auto<int * Guid array>
+      let! m1 = GenX.auto<int * Guid list>
+      let! m2 = GenX.auto<int * Guid list>
       let! eq = Gen.bool
       let! itemEq = Gen.bool
 
       let get = snd
       let equals _ _ = eq
-      let map = InvokeTester Array.toList
+      let map = InvokeTester id
       let itemEquals _ _ = itemEq
       let getId = id
 
@@ -657,12 +657,12 @@ module OneWaySeqLazy =
   let ``when model is updated and equals returns true, should never trigger CC`` () =
     Property.check <| property {
       let! name = GenX.auto<string>
-      let! m1 = GenX.auto<int * Guid array>
-      let! m2 = GenX.auto<int * Guid array>
+      let! m1 = GenX.auto<int * Guid list>
+      let! m2 = GenX.auto<int * Guid list>
 
       let get = snd
       let equals _ _ = true
-      let map = Array.toList
+      let map = id
       let itemEquals = (=)
       let getId = id
 
@@ -680,14 +680,14 @@ module OneWaySeqLazy =
   let ``when model is updated and equals returns false, should not trigger CC if elements are identical`` () =
     Property.check <| property {
       let! name = GenX.auto<string>
-      let! m1 = GenX.auto<int * Guid array>
+      let! m1 = GenX.auto<int * Guid list>
       let! i2 = GenX.auto<int>
 
       let m2 = (i2, snd m1)
 
       let get = snd
       let equals _ _ = false
-      let map = Array.toList
+      let map = id
       let itemEquals = (=)
       let getId = id
 
@@ -705,15 +705,15 @@ module OneWaySeqLazy =
   let ``when model is updated and equals returns false, should trigger CC if elements are added`` () =
     Property.check <| property {
       let! name = GenX.auto<string>
-      let! m1 = GenX.auto<int * Guid array>
+      let! m1 = GenX.auto<int * Guid list>
       let! newItem = Gen.guid
       let! i2 = GenX.auto<int>
 
-      let m2 = (i2, Array.concat [snd m1; [|newItem|]])
+      let m2 = (i2, snd m1 @ [newItem])
 
       let get = snd
       let equals _ _ = false
-      let map = Array.toList
+      let map = id
       let itemEquals = (=)
       let getId = id
 
@@ -731,16 +731,16 @@ module OneWaySeqLazy =
   let ``when model is updated and equals returns false, should trigger CC if elements are removed`` () =
     Property.check <| property {
       let! name = GenX.auto<string>
-      let! arr1 = Gen.guid |> Gen.array (Range.exponential 1 50)
+      let! list1 = Gen.guid |> Gen.list (Range.exponential 1 50)
       let! i1 = GenX.auto<int>
       let! i2 = GenX.auto<int>
 
-      let m1 = (i1, arr1)
-      let m2 = (i2, Array.tail arr1)
+      let m1 = (i1, list1)
+      let m2 = (i2, List.tail list1)
 
       let get = snd
       let equals _ _ = false
-      let map = Array.toList
+      let map = id
       let itemEquals = (=)
       let getId = id
 
@@ -758,16 +758,16 @@ module OneWaySeqLazy =
   let ``when model is updated and equals returns false, should trigger CC if elements are re-ordered`` () =
     Property.check <| property {
       let! name = GenX.auto<string>
-      let! arr1 = Gen.guid |> Gen.array (Range.exponential 2 50)
+      let! list1 = Gen.guid |> Gen.list (Range.exponential 2 50)
       let! i1 = GenX.auto<int>
       let! i2 = GenX.auto<int>
 
-      let m1 = (i1, arr1)
-      let m2 = (i2, Array.rev arr1)
+      let m1 = (i1, list1)
+      let m2 = (i2, List.rev list1)
 
       let get = snd
       let equals _ _ = false
-      let map = Array.toList
+      let map = id
       let itemEquals = (=)
       let getId = id
 
@@ -785,17 +785,17 @@ module OneWaySeqLazy =
   let ``when model is updated and equals returns false, should trigger CC if itemEquals returns false`` () =
     Property.check <| property {
       let! name = GenX.auto<string>
-      let! arr1 = Gen.guid |> Gen.array (Range.exponential 1 50)
-      let! arr2 = Gen.guid |> Gen.array (Range.exponential 1 50)
+      let! list1 = Gen.guid |> Gen.list (Range.exponential 1 50)
+      let! list2 = Gen.guid |> Gen.list (Range.exponential 1 50)
       let! i1 = GenX.auto<int>
       let! i2 = GenX.auto<int>
 
-      let m1 = (i1, arr1)
-      let m2 = (i2, arr2)
+      let m1 = (i1, list1)
+      let m2 = (i2, list2)
 
       let get = snd
       let equals _ _ = false
-      let map = Array.toList
+      let map = id
       let itemEquals _ _ = false
       let getId = id
 

--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -502,8 +502,10 @@ module OneWaySeqLazy =
 
       let binding = oneWaySeqLazy name get equals map itemEquals getId
       let vm = TestVm(m, binding)
+      let actual = (vm.Get name : ObservableCollection<obj>) |> Seq.toList |> List.map unbox
 
-      test <@ (vm.Get name : ObservableCollection<obj>) |> Seq.toList |> List.map unbox = (m |> get |> map) @>
+      let expected = m |> get |> map
+      test <@ expected = actual @>
     }
 
 
@@ -524,8 +526,10 @@ module OneWaySeqLazy =
         let vm = TestVm(m1, binding)
 
         vm.UpdateModel m2
+        let actual = (vm.Get name : ObservableCollection<obj>) |> Seq.toList |> List.map unbox
 
-        test <@ (vm.Get name : ObservableCollection<obj>) |> Seq.toList |> List.map unbox = (m2 |> get |> map) @>
+        let expected = m2 |> get |> map
+        test <@ expected = actual @>
     }
 
 
@@ -546,8 +550,10 @@ module OneWaySeqLazy =
       let vm = TestVm(m1, binding)
 
       vm.UpdateModel m2
+      let actual = (vm.Get name : ObservableCollection<obj>) |> Seq.toList |> List.map unbox
 
-      test <@ (vm.Get name : ObservableCollection<obj>) |> Seq.toList |> List.map unbox = (m1 |> get |> map) @>
+      let expected = m1 |> get |> map
+      test <@ expected = actual @>
     }
 
 

--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -494,9 +494,9 @@ module OneWaySeqLazy =
       let! name = GenX.auto<string>
       let! m = GenX.auto<int * Guid array>
 
-      let get : int * Guid array -> Guid array = snd
+      let get = snd
       let equals = (=)
-      let map : Guid array -> Guid list = Array.toList
+      let map = Array.toList
       let itemEquals = (=)
       let getId = id
 
@@ -516,9 +516,9 @@ module OneWaySeqLazy =
         let! m1 = GenX.auto<int * Guid array>
         let! m2 = GenX.auto<int * Guid array>
 
-        let get : int * Guid array -> Guid array = snd
+        let get = snd
         let equals _ _ = false
-        let map : Guid array -> Guid list = Array.toList
+        let map = Array.toList
         let itemEquals = (=)
         let getId = id
 
@@ -540,9 +540,9 @@ module OneWaySeqLazy =
       let! m1 = GenX.auto<int * Guid array>
       let! m2 = GenX.auto<int * Guid array>
 
-      let get : int * Guid array -> Guid array = snd
+      let get = snd
       let equals _ _ = true
-      let map : Guid array -> Guid list = Array.toList
+      let map = Array.toList
       let itemEquals = (=)
       let getId = id
 


### PR DESCRIPTION
As I work on draft PR #214, I want to split off self-contained changes into separate PRs.  Here is one such change.

I think the use of the `list` type is simpler than using the `array` type in these tests.  Specifically, several definitions of `map` have changed from `Array.toList` to `id` and some type annotations are now gone.

I think `array` was originally chosen over `list` in some of these cases because there was some limitation with F#'s type inference with some of the code in quoted expressions.  That limitation was overcome by adding type annotations.

Instead, this PR
1. moves functions with types to be inferred out of quoted expressions,
2. removes the unneeded type annotations, and then
3. replaces uses of the `array` type with the `list` type.