### PR TITLE
Remove one call to `get`

### DIFF
--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -1,4 +1,4 @@
-namespace Elmish.WPF.Tests.ViewModelTests
+﻿namespace Elmish.WPF.Tests.ViewModelTests
 
 open System
 open System.Collections.Concurrent
@@ -598,15 +598,14 @@ module OneWaySeqLazy =
 
 
   [<Fact>]
-  let ``map should be called at most once during model update iff equals returns false`` () =
+  let ``when equals returns true, map should be called at most once during model update`` () =
     Property.check <| property {
       let! name = GenX.auto<string>
       let! m1 = GenX.auto<int * Guid list>
       let! m2 = GenX.auto<int * Guid list>
-      let! eq = Gen.bool
 
       let get = snd
-      let equals _ _ = eq
+      let equals _ _ = true
       let map = InvokeTester id
       let itemEquals = (=)
       let getId = id
@@ -617,7 +616,30 @@ module OneWaySeqLazy =
       map.Reset ()
       vm.UpdateModel m2
 
-      test <@ if eq then map.Count = 0 else map.Count <= 1 @>
+      test <@ map.Count = 0 @>
+    }
+
+
+  [<Fact>]
+  let ``when equals returns false, map should be called at most once during model update`` () =
+    Property.check <| property {
+      let! name = GenX.auto<string>
+      let! m1 = GenX.auto<int * Guid list>
+      let! m2 = GenX.auto<int * Guid list>
+
+      let get = snd
+      let equals _ _ = false
+      let map = InvokeTester id
+      let itemEquals = (=)
+      let getId = id
+
+      let binding = oneWaySeqLazy name get equals map.Fn itemEquals getId
+      let vm = TestVm(m1, binding)
+
+      map.Reset ()
+      vm.UpdateModel m2
+
+      test <@ map.Count <= 1 @>
     }
 
 

--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -1,4 +1,4 @@
-﻿namespace Elmish.WPF.Tests.ViewModelTests
+namespace Elmish.WPF.Tests.ViewModelTests
 
 open System
 open System.Collections.Concurrent
@@ -554,6 +554,26 @@ module OneWaySeqLazy =
 
       let expected = m1 |> get |> map
       test <@ expected = actual @>
+    }
+
+
+  [<Fact>]
+  let ``get should be called at most once during VM instantiation`` () =
+    Property.check <| property {
+      let! name = GenX.auto<string>
+      let! m1 = GenX.auto<int * Guid list>
+      let! eq = Gen.bool
+
+      let get = InvokeTester snd
+      let equals _ _ = eq
+      let map = id
+      let itemEquals = (=)
+      let getId = id
+
+      let binding = oneWaySeqLazy name get.Fn equals map itemEquals getId
+      TestVm(m1, binding) |> ignore
+
+      test <@ get.Count <= 1 @>
     }
 
 

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -422,8 +422,9 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
     | OneWayLazy b ->
         not <| b.Equals (b.Get newModel) (b.Get currentModel)
     | OneWaySeq b ->
-        if not <| b.Equals (b.Get newModel) (b.Get currentModel) then
-          let newVals = newModel |> b.Get |> b.Map |> Seq.toArray
+        let intermediate = b.Get newModel
+        if not <| b.Equals intermediate (b.Get currentModel) then
+          let newVals = intermediate |> b.Map |> Seq.toArray
 
           let newIdxValPairsById = Dictionary<_,_>(newVals.Length)
           for (newIdx, newVal) in newVals |> Seq.indexed do


### PR DESCRIPTION
More changes split off of draft PR #214.

I think this code should only call `get` twice, once for the current model and once for the new model.

The previous code called `get` three times, once for the current model and _twice_ for the new model.

This PR saves the return value from the first time the new model is passed into `get` and uses that in place of another call to `get`.