### PR TITLE
Unify OneWaySeq and SubModel merges

### DIFF
--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -469,6 +469,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
       getSourceId
       getTargetId
       create
+      update
       (b: SubModelSeqBinding<_, _, _, _, _>)
       (newSubModels: _ array) =
     let newIdxSubModelPairsById = Dictionary<_,_>(newSubModels.Length)
@@ -489,7 +490,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
       // Update existing models
       for Kvp (oldId, (_, vm)) in oldIdxSubViewModelPairsById do
         match newIdxSubModelPairsById.TryGetValue oldId with
-        | true, (_, m) -> vm.UpdateModel m
+        | true, (_, m) -> update m vm
         | _ -> ()
       
       // Remove old view models that no longer exist
@@ -630,8 +631,9 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
         let create m id = 
           let chain = getPropChainForItem bindingName (id |> string)
           ViewModel(m, (fun msg -> b.ToMsg (id, msg) |> dispatch), b.GetBindings (), config, chain)
+        let update m (vm: ViewModel<_, _>) = vm.UpdateModel m
         let newSubModels = newModel |> b.GetModels |> Seq.toArray
-        subModelSeqMerge logInvalidGetId logInvalidGetTargetId b.GetId getTargetId create b newSubModels
+        subModelSeqMerge logInvalidGetId logInvalidGetTargetId b.GetId getTargetId create update b newSubModels
         false
     | SubModelSelectedItem b ->
         b.Get newModel <> b.Get currentModel

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -464,7 +464,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
         if oldIdx <> newIdx then b.Values.Move(oldIdx, newIdx)
 
   let subModelSeqMerge
-      bindingName
+      create
       (b: SubModelSeqBinding<_, _, _, _, _>)
       newModel =
     let newSubModels = newModel |> b.GetModels |> Seq.toArray
@@ -501,9 +501,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
             b.Vms.RemoveAt oldIdx
       
       // Add new models that don't currently exist
-      let create (Kvp (id, (_, m))) =
-        let chain = getPropChainForItem bindingName (id |> string)
-        ViewModel(m, (fun msg -> b.ToMsg (id, msg) |> dispatch), b.GetBindings (), config, chain)
+      let create (Kvp (id, (_, m))) = create m id
       newIdxSubModelPairsById
       |> Seq.filter (Kvp.key >> oldIdxSubViewModelPairsById.ContainsKey >> not)
       |> Seq.map create
@@ -625,7 +623,10 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
             vm.UpdateModel m
             false
     | SubModelSeq b ->
-        subModelSeqMerge bindingName b newModel
+        let create m id = 
+          let chain = getPropChainForItem bindingName (id |> string)
+          ViewModel(m, (fun msg -> b.ToMsg (id, msg) |> dispatch), b.GetBindings (), config, chain)
+        subModelSeqMerge create b newModel
         false
     | SubModelSelectedItem b ->
         b.Get newModel <> b.Get currentModel

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -464,12 +464,13 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
         if oldIdx <> newIdx then b.Values.Move(oldIdx, newIdx)
 
   let subModelSeqMerge
+      getSourceId
       create
       (b: SubModelSeqBinding<_, _, _, _, _>)
       (newSubModels: _ array) =
     let newIdxSubModelPairsById = Dictionary<_,_>(newSubModels.Length)
     for (newIdx, m) in newSubModels |> Seq.indexed do
-      let id = b.GetId m
+      let id = getSourceId m
       if newIdxSubModelPairsById.ContainsKey id
       then logInvalidGetId id (newIdxSubModelPairsById.[id]) m
       else newIdxSubModelPairsById.Add(id, (newIdx, m))
@@ -625,7 +626,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
           let chain = getPropChainForItem bindingName (id |> string)
           ViewModel(m, (fun msg -> b.ToMsg (id, msg) |> dispatch), b.GetBindings (), config, chain)
         let newSubModels = newModel |> b.GetModels |> Seq.toArray
-        subModelSeqMerge create b newSubModels
+        subModelSeqMerge b.GetId create b newSubModels
         false
     | SubModelSelectedItem b ->
         b.Get newModel <> b.Get currentModel

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -464,6 +464,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
         if oldIdx <> newIdx then b.Values.Move(oldIdx, newIdx)
 
   let subModelSeqMerge
+      logInvalidGetSourceId
       getSourceId
       getTargetId
       create
@@ -473,7 +474,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
     for (newIdx, m) in newSubModels |> Seq.indexed do
       let id = getSourceId m
       if newIdxSubModelPairsById.ContainsKey id
-      then logInvalidGetId id (newIdxSubModelPairsById.[id]) m
+      then logInvalidGetSourceId id (newIdxSubModelPairsById.[id]) m
       else newIdxSubModelPairsById.Add(id, (newIdx, m))
 
     let oldIdxSubViewModelPairsById = Dictionary<_,_>(b.Vms.Count)
@@ -628,7 +629,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
           let chain = getPropChainForItem bindingName (id |> string)
           ViewModel(m, (fun msg -> b.ToMsg (id, msg) |> dispatch), b.GetBindings (), config, chain)
         let newSubModels = newModel |> b.GetModels |> Seq.toArray
-        subModelSeqMerge b.GetId getTargetId create b newSubModels
+        subModelSeqMerge logInvalidGetId b.GetId getTargetId create b newSubModels
         false
     | SubModelSelectedItem b ->
         b.Get newModel <> b.Get currentModel

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -463,7 +463,10 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
           |> fst
         if oldIdx <> newIdx then b.Values.Move(oldIdx, newIdx)
 
-  let subModelSeqMerge bindingName (b: SubModelSeqBinding<_, _, _, _, _>) newModel =
+  let subModelSeqMerge
+      bindingName
+      (b: SubModelSeqBinding<_, _, _, _, _>)
+      newModel =
     let newSubModels = newModel |> b.GetModels |> Seq.toArray
 
     let newIdxSubModelPairsById = Dictionary<_,_>(newSubModels.Length)

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -413,6 +413,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
     dict :> IReadOnlyDictionary<string, VmBinding<'model, 'msg>>
 
   let oneWaySeqMerge
+      logInvalidGetSourceId
       getId
       update
       (observableCollection: ObservableCollection<_>)
@@ -421,7 +422,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
     for (newIdx, newVal) in newVals |> Seq.indexed do
       let id = getId newVal
       if newIdxValPairsById.ContainsKey id
-      then logInvalidGetId id (newIdxValPairsById.[id]) newVal
+      then logInvalidGetSourceId id (newIdxValPairsById.[id]) newVal
       else newIdxValPairsById.Add(id, (newIdx, newVal))
 
     let oldIdxValPairsById = Dictionary<_,_>(observableCollection.Count)
@@ -537,7 +538,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
             if not (b.ItemEquals newVal oldVal) then
               b.Values.[oldIdx] <- newVal
           let newVals = intermediate |> b.Map |> Seq.toArray
-          oneWaySeqMerge b.GetId update b.Values newVals
+          oneWaySeqMerge logInvalidGetId b.GetId update b.Values newVals
         false
     | Cmd _
     | CmdParam _ ->

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -465,6 +465,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
 
   let subModelSeqMerge
       logInvalidGetSourceId
+      logInvalidGetTargetId
       getSourceId
       getTargetId
       create
@@ -481,7 +482,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
     for (oldIdx, vm) in b.Vms |> Seq.indexed do
       let id = getTargetId vm
       if oldIdxSubViewModelPairsById.ContainsKey id
-      then logInvalidGetId id (oldIdxSubViewModelPairsById.[id]) vm.CurrentModel
+      then logInvalidGetTargetId id (oldIdxSubViewModelPairsById.[id]) vm
       else oldIdxSubViewModelPairsById.Add(id, (oldIdx, vm))
 
     if newIdxSubModelPairsById.Count = newSubModels.Length && oldIdxSubViewModelPairsById.Count = b.Vms.Count then
@@ -624,12 +625,13 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
             vm.UpdateModel m
             false
     | SubModelSeq b ->
+        let logInvalidGetTargetId a b (vm: ViewModel<_, _>) = logInvalidGetId a b vm.CurrentModel
         let getTargetId (vm: ViewModel<_, _>) = b.GetId vm.CurrentModel
         let create m id = 
           let chain = getPropChainForItem bindingName (id |> string)
           ViewModel(m, (fun msg -> b.ToMsg (id, msg) |> dispatch), b.GetBindings (), config, chain)
         let newSubModels = newModel |> b.GetModels |> Seq.toArray
-        subModelSeqMerge logInvalidGetId b.GetId getTargetId create b newSubModels
+        subModelSeqMerge logInvalidGetId logInvalidGetTargetId b.GetId getTargetId create b newSubModels
         false
     | SubModelSelectedItem b ->
         b.Get newModel <> b.Get currentModel

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -416,6 +416,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
       logInvalidGetSourceId
       logInvalidGetTargetId
       getId
+      create
       update
       (observableCollection: ObservableCollection<_>)
       (newVals: _ array) =
@@ -452,10 +453,10 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
             observableCollection.RemoveAt oldIdx
       
       // Add new values that don't currently exist
+      let create (Kvp (id, (_, m))) = create m id
       newIdxValPairsById
       |> Seq.filter (Kvp.key >> oldIdxValPairsById.ContainsKey >> not)
-      |> Seq.map Kvp.value
-      |> Seq.map snd
+      |> Seq.map create
       |> Seq.iter observableCollection.Add
       
       // Reorder according to new model list
@@ -535,11 +536,12 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
     | OneWaySeq b ->
         let intermediate = b.Get newModel
         if not <| b.Equals intermediate (b.Get currentModel) then
+          let create v _ = v
           let update oldVal newVal oldIdx =
             if not (b.ItemEquals newVal oldVal) then
               b.Values.[oldIdx] <- newVal
           let newVals = intermediate |> b.Map |> Seq.toArray
-          oneWaySeqMerge logInvalidGetId logInvalidGetId b.GetId update b.Values newVals
+          oneWaySeqMerge logInvalidGetId logInvalidGetId b.GetId create update b.Values newVals
         false
     | Cmd _
     | CmdParam _ ->

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -415,21 +415,22 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
   let oneWaySeqMerge
       logInvalidGetSourceId
       logInvalidGetTargetId
-      getId
+      getSourceId
+      getTargetId
       create
       update
       (observableCollection: ObservableCollection<_>)
       (newVals: _ array) =
     let newIdxValPairsById = Dictionary<_,_>(newVals.Length)
     for (newIdx, newVal) in newVals |> Seq.indexed do
-      let id = getId newVal
+      let id = getSourceId newVal
       if newIdxValPairsById.ContainsKey id
       then logInvalidGetSourceId id (newIdxValPairsById.[id]) newVal
       else newIdxValPairsById.Add(id, (newIdx, newVal))
 
     let oldIdxValPairsById = Dictionary<_,_>(observableCollection.Count)
     for (oldIdx, oldVal) in observableCollection |> Seq.indexed do
-      let id = getId oldVal
+      let id = getTargetId oldVal
       if oldIdxValPairsById.ContainsKey id
       then logInvalidGetTargetId id (oldIdxValPairsById.[id]) oldVal
       else oldIdxValPairsById.Add(id, (oldIdx, oldVal))
@@ -447,7 +448,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
       then observableCollection.Clear ()
       else
         for i in observableCollection.Count - 1..-1..0 do
-          let oldId = getId observableCollection.[i]
+          let oldId = getTargetId observableCollection.[i]
           if oldId |> newIdxValPairsById.ContainsKey |> not then
             let (oldIdx, _) = oldIdxValPairsById.[oldId]
             observableCollection.RemoveAt oldIdx
@@ -464,7 +465,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
         let oldIdx =
           observableCollection
           |> Seq.indexed
-          |> Seq.find (fun (_, oldVal) -> getId oldVal = newId)
+          |> Seq.find (fun (_, oldVal) -> getTargetId oldVal = newId)
           |> fst
         if oldIdx <> newIdx then observableCollection.Move(oldIdx, newIdx)
 
@@ -541,7 +542,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
             if not (b.ItemEquals newVal oldVal) then
               b.Values.[oldIdx] <- newVal
           let newVals = intermediate |> b.Map |> Seq.toArray
-          oneWaySeqMerge logInvalidGetId logInvalidGetId b.GetId create update b.Values newVals
+          oneWaySeqMerge logInvalidGetId logInvalidGetId b.GetId b.GetId create update b.Values newVals
         false
     | Cmd _
     | CmdParam _ ->

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -490,9 +490,9 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
 
     if newIdxSubModelPairsById.Count = newSubModels.Length && oldIdxSubViewModelPairsById.Count = observableCollection.Count then
       // Update existing models
-      for Kvp (oldId, (_, vm)) in oldIdxSubViewModelPairsById do
+      for Kvp (oldId, (oldIdx, vm)) in oldIdxSubViewModelPairsById do
         match newIdxSubModelPairsById.TryGetValue oldId with
-        | true, (_, m) -> update vm m
+        | true, (_, m) -> update vm m oldIdx
         | _ -> ()
       
       // Remove old view models that no longer exist
@@ -637,7 +637,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
         let create m id = 
           let chain = getPropChainForItem bindingName (id |> string)
           ViewModel(m, (fun msg -> b.ToMsg (id, msg) |> dispatch), b.GetBindings (), config, chain)
-        let update (vm: ViewModel<_, _>) m = vm.UpdateModel m
+        let update (vm: ViewModel<_, _>) m _ = vm.UpdateModel m
         let newSubModels = newModel |> b.GetModels |> Seq.toArray
         subModelSeqMerge logInvalidGetId logInvalidGetTargetId b.GetId getTargetId create update b.Vms newSubModels
         false

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -414,6 +414,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
 
   let oneWaySeqMerge
       logInvalidGetSourceId
+      logInvalidGetTargetId
       getId
       update
       (observableCollection: ObservableCollection<_>)
@@ -429,7 +430,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
     for (oldIdx, oldVal) in observableCollection |> Seq.indexed do
       let id = getId oldVal
       if oldIdxValPairsById.ContainsKey id
-      then logInvalidGetId id (oldIdxValPairsById.[id]) oldVal
+      then logInvalidGetTargetId id (oldIdxValPairsById.[id]) oldVal
       else oldIdxValPairsById.Add(id, (oldIdx, oldVal))
 
     if newIdxValPairsById.Count = newVals.Length && oldIdxValPairsById.Count = observableCollection.Count then
@@ -538,7 +539,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
             if not (b.ItemEquals newVal oldVal) then
               b.Values.[oldIdx] <- newVal
           let newVals = intermediate |> b.Map |> Seq.toArray
-          oneWaySeqMerge logInvalidGetId b.GetId update b.Values newVals
+          oneWaySeqMerge logInvalidGetId logInvalidGetId b.GetId update b.Values newVals
         false
     | Cmd _
     | CmdParam _ ->

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -466,9 +466,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
   let subModelSeqMerge
       create
       (b: SubModelSeqBinding<_, _, _, _, _>)
-      newModel =
-    let newSubModels = newModel |> b.GetModels |> Seq.toArray
-
+      (newSubModels: _ array) =
     let newIdxSubModelPairsById = Dictionary<_,_>(newSubModels.Length)
     for (newIdx, m) in newSubModels |> Seq.indexed do
       let id = b.GetId m
@@ -626,7 +624,8 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
         let create m id = 
           let chain = getPropChainForItem bindingName (id |> string)
           ViewModel(m, (fun msg -> b.ToMsg (id, msg) |> dispatch), b.GetBindings (), config, chain)
-        subModelSeqMerge create b newModel
+        let newSubModels = newModel |> b.GetModels |> Seq.toArray
+        subModelSeqMerge create b newSubModels
         false
     | SubModelSelectedItem b ->
         b.Get newModel <> b.Get currentModel

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -492,7 +492,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
       // Update existing models
       for Kvp (oldId, (_, vm)) in oldIdxSubViewModelPairsById do
         match newIdxSubModelPairsById.TryGetValue oldId with
-        | true, (_, m) -> update m vm
+        | true, (_, m) -> update vm m
         | _ -> ()
       
       // Remove old view models that no longer exist
@@ -637,7 +637,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
         let create m id = 
           let chain = getPropChainForItem bindingName (id |> string)
           ViewModel(m, (fun msg -> b.ToMsg (id, msg) |> dispatch), b.GetBindings (), config, chain)
-        let update m (vm: ViewModel<_, _>) = vm.UpdateModel m
+        let update (vm: ViewModel<_, _>) m = vm.UpdateModel m
         let newSubModels = newModel |> b.GetModels |> Seq.toArray
         subModelSeqMerge logInvalidGetId logInvalidGetTargetId b.GetId getTargetId create update b.Vms newSubModels
         false

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -412,7 +412,9 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
           updateValidationError initialModel b.Name binding)
     dict :> IReadOnlyDictionary<string, VmBinding<'model, 'msg>>
 
-  let oneWaySeqMerge (b: OneWaySeqBinding<_, _, _, _>) intermediate =
+  let oneWaySeqMerge
+      (b: OneWaySeqBinding<_, _, _, _>)
+      intermediate =
     let newVals = intermediate |> b.Map |> Seq.toArray
     let newIdxValPairsById = Dictionary<_,_>(newVals.Length)
     for (newIdx, newVal) in newVals |> Seq.indexed do

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -414,8 +414,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
 
   let oneWaySeqMerge
       (b: OneWaySeqBinding<_, _, _, _>)
-      intermediate =
-    let newVals = intermediate |> b.Map |> Seq.toArray
+      (newVals: _ array) =
     let newIdxValPairsById = Dictionary<_,_>(newVals.Length)
     for (newIdx, newVal) in newVals |> Seq.indexed do
       let id = b.GetId newVal
@@ -533,7 +532,8 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
     | OneWaySeq b ->
         let intermediate = b.Get newModel
         if not <| b.Equals intermediate (b.Get currentModel) then
-          oneWaySeqMerge b intermediate
+          let newVals = intermediate |> b.Map |> Seq.toArray
+          oneWaySeqMerge b newVals
         false
     | Cmd _
     | CmdParam _ ->


### PR DESCRIPTION
More changes split off of draft PR #214.

This PR extracts the aspects of `oneWaySeqMerge` and `SubModelSeqMerge` that differ.

The next PR in this sequence will rename identifiers in these methods to confirm they are really the same function by observing they have exactly the same source code.  Then the PR after that will delete one of these functions and keep the other.