### PR TITLE
Test merge with one item moved

### DIFF
--- a/src/Elmish.WPF.Tests/MergeTests.fs
+++ b/src/Elmish.WPF.Tests/MergeTests.fs
@@ -1,12 +1,8 @@
-﻿module Elmish.WPF.Tests.MergeTests
+module Elmish.WPF.Tests.MergeTests
 
 open System
-open System.Collections.Concurrent
 open System.Collections.ObjectModel
 open System.Collections.Specialized
-open System.ComponentModel
-open System.Windows.Input
-open FSharp.Interop.Dynamic
 open Xunit
 open Hedgehog
 open Swensen.Unquote

--- a/src/Elmish.WPF.Tests/MergeTests.fs
+++ b/src/Elmish.WPF.Tests/MergeTests.fs
@@ -29,12 +29,18 @@ let private testObservableCollectionContainsDataInArray observableCollection arr
 
   
 module private List =
+
   let swap i j =
     List.permute
       (function
         | a when a = i -> j
         | a when a = j -> i
         | a -> a)
+
+  let replace i a ma =
+    (ma |> List.take i)
+    @ [ a ]
+    @ (ma |> List.skip (i + 1))
 
 
 [<Fact>]
@@ -118,9 +124,8 @@ let ``starting with random items, when merging after a replacement, should conta
     let list1 = list1Head :: list1Tail
     let observableCollection = ObservableCollection<_> list1
     let array2 =
-      (list1 |> List.take replcementIndex)
-      @ [list2Replacement]
-      @ (list1 |> List.skip (replcementIndex + 1))
+      list1
+      |> List.replace replcementIndex list2Replacement
       |> List.toArray
     
     simpleMerge observableCollection array2

--- a/src/Elmish.WPF.Tests/MergeTests.fs
+++ b/src/Elmish.WPF.Tests/MergeTests.fs
@@ -1,4 +1,4 @@
-module Elmish.WPF.Tests.MergeTests
+﻿module Elmish.WPF.Tests.MergeTests
 
 open System
 open System.Collections.ObjectModel
@@ -36,6 +36,11 @@ module private List =
         | a when a = i -> j
         | a when a = j -> i
         | a -> a)
+
+  let insert i a ma =
+    (ma |> List.take i)
+    @ [ a ]
+    @ (ma |> List.skip i)
 
   let replace i a ma =
     (ma |> List.take i)
@@ -107,6 +112,25 @@ let ``starting with random items, when merging after a removal, should contain t
     
     let observableCollection = ObservableCollection<_> list1
     let array2 = list2 |> List.toArray
+    
+    simpleMerge observableCollection array2
+
+    testObservableCollectionContainsDataInArray observableCollection array2
+  }
+  
+[<Fact>]
+let ``starting with random items, when merging after a move, should contain the merged items`` () =
+  Property.check <| property {
+    let! list = GenX.auto<Guid list>
+    let! movedItem = Gen.guid
+    let! additionalItem = Gen.guid
+    let! i1 = (0, list.Length + 1) ||> Range.constant |> Gen.int
+    let! i2 = (0, list.Length + 1) ||> Range.constant |> Gen.int |> GenX.notEqualTo i1
+
+    let list = additionalItem :: list
+    let list1 = list |> List.insert i1 movedItem
+    let array2 = list |> List.insert i2 movedItem |> List.toArray
+    let observableCollection = ObservableCollection<_> list1
     
     simpleMerge observableCollection array2
 


### PR DESCRIPTION
More changes split off of draft PR #214.

This PR adds a merge test for when a single item is moved (and some other minor improvement I found in the process).

I will merge this after the build completes successfully.