### PR TITLE
Count calls to create and update

### DIFF
--- a/src/Elmish.WPF.Tests/BindingTests.fs
+++ b/src/Elmish.WPF.Tests/BindingTests.fs
@@ -1,4 +1,4 @@
-﻿namespace Elmish.WPF.Tests.BindingTests
+﻿module Elmish.WPF.Tests.BindingTests
 
 open Xunit
 open Hedgehog

--- a/src/Elmish.WPF.Tests/Elmish.WPF.Tests.fsproj
+++ b/src/Elmish.WPF.Tests/Elmish.WPF.Tests.fsproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <Compile Include="InternalUtils.fs" />
     <Compile Include="MergeTests.fs" />
     <Compile Include="ViewModelTests.fs" />
     <Compile Include="BindingTests.fs" />

--- a/src/Elmish.WPF.Tests/InternalUtils.fs
+++ b/src/Elmish.WPF.Tests/InternalUtils.fs
@@ -23,7 +23,7 @@ type InvokeTester2<'a, 'b, 'c>(f: 'a -> 'b -> 'c) =
   let wrapped x y =
     count <- count + 1
     values <- values @ [x, y]
-    f x
+    f x y
   member __.Fn = wrapped
   member __.Count = count
   member __.Values = values

--- a/src/Elmish.WPF.Tests/InternalUtils.fs
+++ b/src/Elmish.WPF.Tests/InternalUtils.fs
@@ -1,0 +1,59 @@
+﻿[<AutoOpen>]
+module internal Elmish.WPF.Tests.InternalUtils
+
+
+type InvokeTester<'a, 'b>(f: 'a -> 'b) =
+  let mutable count = 0
+  let mutable values = []
+  let wrapped x =
+    count <- count + 1
+    values <- values @ [x]
+    f x
+  member __.Fn = wrapped
+  member __.Count = count
+  member __.Values = values
+  member __.Reset () =
+    count <- 0
+    values <- []
+
+
+type InvokeTester2<'a, 'b, 'c>(f: 'a -> 'b -> 'c) =
+  let mutable count = 0
+  let mutable values = []
+  let wrapped x y =
+    count <- count + 1
+    values <- values @ [x, y]
+    f x
+  member __.Fn = wrapped
+  member __.Count = count
+  member __.Values = values
+  member __.Reset () =
+    count <- 0
+    values <- []
+
+
+[<RequireQualifiedAccess>]
+module String =
+
+  let length (s: string) = s.Length
+
+
+[<RequireQualifiedAccess>]
+module List =
+
+  let swap i j =
+    List.permute
+      (function
+        | a when a = i -> j
+        | a when a = j -> i
+        | a -> a)
+
+  let insert i a ma =
+    (ma |> List.take i)
+    @ [ a ]
+    @ (ma |> List.skip i)
+
+  let replace i a ma =
+    (ma |> List.take i)
+    @ [ a ]
+    @ (ma |> List.skip (i + 1))

--- a/src/Elmish.WPF.Tests/InternalUtils.fs
+++ b/src/Elmish.WPF.Tests/InternalUtils.fs
@@ -5,10 +5,10 @@ module internal Elmish.WPF.Tests.InternalUtils
 type InvokeTester<'a, 'b>(f: 'a -> 'b) =
   let mutable count = 0
   let mutable values = []
-  let wrapped x =
+  let wrapped a =
     count <- count + 1
-    values <- values @ [x]
-    f x
+    values <- values @ [a]
+    f a
   member __.Fn = wrapped
   member __.Count = count
   member __.Values = values
@@ -20,10 +20,10 @@ type InvokeTester<'a, 'b>(f: 'a -> 'b) =
 type InvokeTester2<'a, 'b, 'c>(f: 'a -> 'b -> 'c) =
   let mutable count = 0
   let mutable values = []
-  let wrapped x y =
+  let wrapped a b =
     count <- count + 1
-    values <- values @ [x, y]
-    f x y
+    values <- values @ [a, b]
+    f a b
   member __.Fn = wrapped
   member __.Count = count
   member __.Values = values

--- a/src/Elmish.WPF.Tests/InternalUtils.fs
+++ b/src/Elmish.WPF.Tests/InternalUtils.fs
@@ -32,6 +32,21 @@ type InvokeTester2<'a, 'b, 'c>(f: 'a -> 'b -> 'c) =
     values <- []
 
 
+type InvokeTester3<'a, 'b, 'c, 'd>(f: 'a -> 'b -> 'c -> 'd) =
+  let mutable count = 0
+  let mutable values = []
+  let wrapped a b c =
+    count <- count + 1
+    values <- values @ [a, b, c]
+    f a b c
+  member __.Fn = wrapped
+  member __.Count = count
+  member __.Values = values
+  member __.Reset () =
+    count <- 0
+    values <- []
+
+
 [<RequireQualifiedAccess>]
 module String =
 

--- a/src/Elmish.WPF.Tests/MergeTests.fs
+++ b/src/Elmish.WPF.Tests/MergeTests.fs
@@ -1,4 +1,4 @@
-module Elmish.WPF.Tests.MergeTests
+﻿module Elmish.WPF.Tests.MergeTests
 
 open System
 open System.Collections.ObjectModel
@@ -14,7 +14,6 @@ let getIdAsId = id
 let createAsId a _ = a
 let updateNoOp _ _ _ = ()
 let merge x = x |> historicalMerge logNoOp logNoOp
-let simpleMerge x = x |> merge getIdAsId getIdAsId createAsId updateNoOp
 
 
 let private trackCC (observableCollection: ObservableCollection<_>) =
@@ -67,7 +66,7 @@ let ``starting with random items, when merging random items, should contain the 
 
     let observableCollection = ObservableCollection<_> array1
 
-    simpleMerge observableCollection array2
+    merge getIdAsId getIdAsId createAsId updateNoOp observableCollection array2
 
     testObservableCollectionContainsDataInArray observableCollection array2
   }

--- a/src/Elmish.WPF.Tests/MergeTests.fs
+++ b/src/Elmish.WPF.Tests/MergeTests.fs
@@ -1,4 +1,4 @@
-﻿module Elmish.WPF.Tests.MergeTests
+module Elmish.WPF.Tests.MergeTests
 
 open System
 open System.Collections.ObjectModel
@@ -28,32 +28,36 @@ let private testObservableCollectionContainsDataInArray observableCollection arr
 
 
 [<Fact>]
-let ``starting from empty, when items merged, should contain those items and call create exactly once for each one`` () =
+let ``starting from empty, when items merged, should contain those items and call create exactly once for each item and never call update`` () =
   Property.check <| property {
     let! array = GenX.auto<Guid array>
 
     let observableCollection = ObservableCollection<_> ()
     let createTracker = InvokeTester2 createAsId
+    let updateTracker = InvokeTester3 updateNoOp
 
-    merge getIdAsId getIdAsId createTracker.Fn updateNoOp observableCollection array
+    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn observableCollection array
 
     testObservableCollectionContainsDataInArray observableCollection array
     test <@ createTracker.Count = array.Length @>
+    test <@ updateTracker.Count = 0 @>
   }
 
 [<Fact>]
-let ``starting with random items, when merging the same items, should still contain those items and never call create and trigger no CC event`` () =
+let ``starting with random items, when merging the same items, should still contain those items and never call create and call update exactly once for each item and trigger no CC event`` () =
   Property.check <| property {
     let! array = GenX.auto<Guid array>
     
     let observableCollection = ObservableCollection<_> array
     let createTracker = InvokeTester2 createAsId
+    let updateTracker = InvokeTester3 updateNoOp
     let ccEvents = trackCC observableCollection
     
-    merge getIdAsId getIdAsId createTracker.Fn updateNoOp observableCollection array
+    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn observableCollection array
 
     testObservableCollectionContainsDataInArray observableCollection array
     test <@ createTracker.Count = 0 @>
+    test <@ updateTracker.Count = array.Length @>
     test <@ ccEvents.Count = 0 @>
   }
 
@@ -72,7 +76,7 @@ let ``starting with random items, when merging random items, should contain the 
   }
 
 [<Fact>]
-let ``starting with random items, when merging after an addition, should contain the merged items and call create exactly once`` () =
+let ``starting with random items, when merging after an addition, should contain the merged items and call create exactly once and call update exactly once for each original item`` () =
   Property.check <| property {
     let! list1 = GenX.auto<Guid list>
     let! addedItem = Gen.guid
@@ -81,15 +85,17 @@ let ``starting with random items, when merging after an addition, should contain
     let observableCollection = ObservableCollection<_> list1
     let array2 = list2 |> List.toArray
     let createTracker = InvokeTester2 createAsId
+    let updateTracker = InvokeTester3 updateNoOp
     
-    merge getIdAsId getIdAsId createTracker.Fn updateNoOp observableCollection array2
+    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn observableCollection array2
 
     testObservableCollectionContainsDataInArray observableCollection array2
     test <@ createTracker.Count = 1 @>
+    test <@ updateTracker.Count = array2.Length - 1 @>
   }
   
 [<Fact>]
-let ``starting with random items, when merging after a removal, should contain the merged items and never call create`` () =
+let ``starting with random items, when merging after a removal, should contain the merged items and never call create and call update exactly once for each remaining item`` () =
   Property.check <| property {
     let! list2 = GenX.auto<Guid list>
     let! removedItem = Gen.guid
@@ -98,15 +104,17 @@ let ``starting with random items, when merging after a removal, should contain t
     let observableCollection = ObservableCollection<_> list1
     let array2 = list2 |> List.toArray
     let createTracker = InvokeTester2 createAsId
+    let updateTracker = InvokeTester3 updateNoOp
     
-    merge getIdAsId getIdAsId createTracker.Fn updateNoOp observableCollection array2
+    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn observableCollection array2
 
     testObservableCollectionContainsDataInArray observableCollection array2
     test <@ createTracker.Count = 0 @>
+    test <@ updateTracker.Count = array2.Length @>
   }
   
 [<Fact>]
-let ``starting with random items, when merging after a move, should contain the merged items and never call create`` () =
+let ``starting with random items, when merging after a move, should contain the merged items and never call create and call update exactly once for each item`` () =
   Property.check <| property {
     let! list = GenX.auto<Guid list>
     let! movedItem = Gen.guid
@@ -119,15 +127,17 @@ let ``starting with random items, when merging after a move, should contain the 
     let array2 = list |> List.insert i2 movedItem |> List.toArray
     let observableCollection = ObservableCollection<_> list1
     let createTracker = InvokeTester2 createAsId
+    let updateTracker = InvokeTester3 updateNoOp
     
-    merge getIdAsId getIdAsId createTracker.Fn updateNoOp observableCollection array2
+    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn observableCollection array2
 
     testObservableCollectionContainsDataInArray observableCollection array2
     test <@ createTracker.Count = 0 @>
+    test <@ updateTracker.Count = array2.Length @>
   }
   
 [<Fact>]
-let ``starting with random items, when merging after a replacement, should contain the merged items and call create exactly once`` () =
+let ``starting with random items, when merging after a replacement, should contain the merged items and call create exactly once and call update exactly once for each original item that remains`` () =
   Property.check <| property {
     let! list1Head = Gen.guid
     let! list1Tail = GenX.auto<Guid list>
@@ -141,15 +151,17 @@ let ``starting with random items, when merging after a replacement, should conta
       |> List.replace replcementIndex list2Replacement
       |> List.toArray
     let createTracker = InvokeTester2 createAsId
+    let updateTracker = InvokeTester3 updateNoOp
     
-    merge getIdAsId getIdAsId createTracker.Fn updateNoOp observableCollection array2
+    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn observableCollection array2
 
     testObservableCollectionContainsDataInArray observableCollection array2
     test <@ createTracker.Count = 1 @>
+    test <@ updateTracker.Count = array2.Length - 1 @>
   }
   
 [<Fact>]
-let ``starting with random items, when merging after swapping two adjacent items, should contain the merged items and never call create`` () =
+let ``starting with random items, when merging after swapping two adjacent items, should contain the merged items and never call create and call update exactly once for each item`` () =
   Property.check <| property {
     let! list1 = Gen.guid |> Gen.list (Range.exponential 2 50)
     let! firstSwapIndex = (0, list1.Length - 2) ||> Range.constant |> Gen.int
@@ -160,15 +172,17 @@ let ``starting with random items, when merging after swapping two adjacent items
       |> List.swap firstSwapIndex (firstSwapIndex + 1)
       |> List.toArray
     let createTracker = InvokeTester2 createAsId
+    let updateTracker = InvokeTester3 updateNoOp
     
-    merge getIdAsId getIdAsId createTracker.Fn updateNoOp observableCollection array2
+    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn observableCollection array2
 
     testObservableCollectionContainsDataInArray observableCollection array2
     test <@ createTracker.Count = 0 @>
+    test <@ updateTracker.Count = array2.Length @>
   }
   
 [<Fact>]
-let ``starting with random items, when merging after shuffling, should contain the merged items and never call create`` () =
+let ``starting with random items, when merging after shuffling, should contain the merged items and never call create and call update eactly once for each item`` () =
   Property.check <| property {
     let! list1 = Gen.guid |> Gen.list (Range.exponential 2 50)
     let! list2 = list1 |> GenX.shuffle |> GenX.notEqualTo list1
@@ -176,11 +190,13 @@ let ``starting with random items, when merging after shuffling, should contain t
     let observableCollection = ObservableCollection<_> list1
     let array2 = list2 |> List.toArray
     let createTracker = InvokeTester2 createAsId
+    let updateTracker = InvokeTester3 updateNoOp
     
-    merge getIdAsId getIdAsId createTracker.Fn updateNoOp observableCollection array2
+    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn observableCollection array2
 
     testObservableCollectionContainsDataInArray observableCollection array2
     test <@ createTracker.Count = 0 @>
+    test <@ updateTracker.Count = array2.Length @>
   }
   
 type TestClass (id: int, data: string) =

--- a/src/Elmish.WPF.Tests/MergeTests.fs
+++ b/src/Elmish.WPF.Tests/MergeTests.fs
@@ -27,26 +27,6 @@ let private testObservableCollectionContainsDataInArray observableCollection arr
   let expected = array |> Array.toList
   test <@ expected = actual @>
 
-  
-module private List =
-
-  let swap i j =
-    List.permute
-      (function
-        | a when a = i -> j
-        | a when a = j -> i
-        | a -> a)
-
-  let insert i a ma =
-    (ma |> List.take i)
-    @ [ a ]
-    @ (ma |> List.skip i)
-
-  let replace i a ma =
-    (ma |> List.take i)
-    @ [ a ]
-    @ (ma |> List.skip (i + 1))
-
 
 [<Fact>]
 let ``starting from empty, when items merged, should contain those items`` () =

--- a/src/Elmish.WPF.Tests/UtilsTests.fs
+++ b/src/Elmish.WPF.Tests/UtilsTests.fs
@@ -1,4 +1,4 @@
-﻿namespace Elmish.WPF.Tests.UtilsTests
+﻿module Elmish.WPF.Tests.UtilsTests
 
 open Xunit
 open Hedgehog

--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -93,44 +93,9 @@ type internal TestVm<'model, 'msg>(model, bindings) as this =
     )
 
 
-type InvokeTester<'a, 'b>(f: 'a -> 'b) =
-  let mutable count = 0
-  let mutable values = []
-  let wrapped x =
-    count <- count + 1
-    values <- values @ [x]
-    f x
-  member __.Fn = wrapped
-  member __.Count = count
-  member __.Values = values
-  member __.Reset () =
-    count <- 0
-    values <- []
-
-
-type InvokeTester2<'a, 'b, 'c>(f: 'a -> 'b -> 'c) =
-  let mutable count = 0
-  let mutable values = []
-  let wrapped x y =
-    count <- count + 1
-    values <- values @ [x, y]
-    f x
-  member __.Fn = wrapped
-  member __.Count = count
-  member __.Values = values
-  member __.Reset () =
-    count <- 0
-    values <- []
-
-
 
 [<AutoOpen>]
 module Helpers =
-
-
-  module String =
-
-    let length (s: string) = s.Length
 
 
   let internal oneWay

--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -93,42 +93,6 @@ type internal TestVm<'model, 'msg>(model, bindings) as this =
     )
 
 
-type InvokeTesterVal<'a, 'b>(initialRet: 'b) =
-  let mutable count = 0
-  let mutable values = []
-  let mutable retVal = initialRet
-  let wrapped x =
-    count <- count + 1
-    values <- values @ [x]
-    retVal
-  member __.Fn = wrapped
-  member __.Count = count
-  member __.Values = values
-  member __.SetRetVal ret = retVal <- ret
-  member __.Reset () =
-    count <- 0
-    values <- []
-    retVal <- initialRet
-
-
-type InvokeTesterVal2<'a, 'b, 'c>(initialRet: 'c) =
-  let mutable count = 0
-  let mutable values = []
-  let mutable retVal = initialRet
-  let wrapped x y =
-    count <- count + 1
-    values <- values @ [(x, y)]
-    retVal
-  member __.Fn : 'a -> 'b -> 'c = wrapped
-  member __.Count = count
-  member __.Values = values
-  member __.SetRetVal ret = retVal <- ret
-  member __.Reset () =
-    count <- 0
-    values <- []
-    retVal <- initialRet
-
-
 type InvokeTester<'a, 'b>(f: 'a -> 'b) =
   let mutable count = 0
   let mutable values = []

--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -1,4 +1,4 @@
-namespace Elmish.WPF.Tests.ViewModelTests
+module Elmish.WPF.Tests.ViewModelTests
 
 open System
 open System.Collections.Concurrent


### PR DESCRIPTION
More changes split off of draft PR #214.

I couldn't help myself.  This will be the last such split.  I will complete PR #214 after this one completes.

This PR mostly adds assertions to existing merge tests to ensure that `create` and `update` are called the correct number of times.  When we improved the optimization of `emlStyleMerge` from https://github.com/elmish/Elmish.WPF/pull/214#issuecomment-630435425 to https://github.com/elmish/Elmish.WPF/pull/214#issuecomment-631087578, it was by only calling `create` if necessary.  With the assertions added in this PR, the original (less optimized) version of `elmStyleMerge` would now cause some tests to fail.

This PR also adds a test for a swap of two elements that are not necessarily adjacent and improves the organization of the test utility code.

I will merge this after the build completes successfully.