### PR TITLE
DRAFT: Replace ElmConfig with ProgramWpf

### DIFF
--- a/src/Elmish.WPF/Config.fs
+++ b/src/Elmish.WPF/Config.fs
@@ -1,6 +1,6 @@
 ﻿namespace Elmish.WPF
 
-type ElmConfig =
+type internal ElmConfig =
   { // Whether to log to console. Default false.
     LogConsole: bool
     // Whether to log to trace (VS debug output). Default false.

--- a/src/Elmish.WPF/Program.fs
+++ b/src/Elmish.WPF/Program.fs
@@ -4,8 +4,8 @@ open System.Windows
 open Elmish
 
 
-type ProgramWpf<'arg, 'model, 'msg> = private {
-  ElmishProgram: Program<'arg, 'model, 'msg, Binding<'model, 'msg> list>
+type ProgramWpf<'model, 'msg> = private {
+  ElmishProgram: Program<Unit, 'model, 'msg, Binding<'model, 'msg> list>
   ElmConfig: ElmConfig
 }
 
@@ -18,7 +18,7 @@ module Program =
   /// for normal usage, see runWindow and runWindowWithConfig.
   let startElmishLoop
       (element: FrameworkElement)
-      (program: ProgramWpf<unit, 'model, 'msg>) =
+      (program: ProgramWpf<'model, 'msg>) =
     let mutable lastModel = None
   
     let setState model dispatch =

--- a/src/Elmish.WPF/Program.fs
+++ b/src/Elmish.WPF/Program.fs
@@ -1,101 +1,103 @@
-﻿[<RequireQualifiedAccess>]
-module Elmish.WPF.Program
+﻿namespace Elmish.WPF
 
 open System.Windows
 open Elmish
 
 
-/// Starts the Elmish dispatch loop, setting the bindings as the DataContext
-/// for the specified FrameworkElement. Non-blocking. This is a low-level function;
-/// for normal usage, see runWindow and runWindowWithConfig.
-let startElmishLoop
-    (config: ElmConfig)
-    (element: FrameworkElement)
-    (program: Program<unit, 'model, 'msg, Binding<'model, 'msg> list>) =
-  let mutable lastModel = None
+[<RequireQualifiedAccess>]
+module Program =
 
-  let setState model dispatch =
-    match lastModel with
-    | None ->
-        let bindings = Program.view program model dispatch
-        let vm = ViewModel<'model,'msg>(model, dispatch, bindings, config, "main")
-        element.DataContext <- vm
-        lastModel <- Some vm
-    | Some vm ->
-        vm.UpdateModel model
-
-  let uiDispatch (innerDispatch: Dispatch<'msg>) : Dispatch<'msg> =
-    fun msg -> element.Dispatcher.Invoke(fun () -> innerDispatch msg)
-
-  program
-  |> Program.withSetState setState
-  |> Program.withSyncDispatch uiDispatch
-  |> Program.run
-
-
-/// Instantiates Application and sets its MainWindow if it is not already
-/// running.
-let private initializeApplication window =
-  if isNull Application.Current then
-    Application () |> ignore
-    Application.Current.MainWindow <- window
-
-
-/// Starts the Elmish and WPF dispatch loops with the specified configuration.
-/// Will instantiate Application and set its MainWindow if it is not already
-/// running, and then run the specified window. This is a blocking function.
-let runWindowWithConfig config (window: Window) program =
-  initializeApplication window
-  window.Show ()
-  startElmishLoop config window program
-  Application.Current.Run window
-
-
-/// Starts the Elmish and WPF dispatch loops. Will instantiate Application and
-/// set its MainWindow if it is not already running, and then run the specified
-/// window. This is a blocking function.
-let runWindow window program =
-  runWindowWithConfig ElmConfig.Default window program
-
-
-/// Same as mkSimple, but with a signature adapted for Elmish.WPF.
-let mkSimpleWpf
-    (init: unit -> 'model)
-    (update: 'msg  -> 'model -> 'model)
-    (bindings: unit -> Binding<'model, 'msg> list) =
-  Program.mkSimple init update (fun _ _ -> bindings ())
-
-
-/// Same as mkProgram, but with a signature adapted for Elmish.WPF.
-let mkProgramWpf
-    (init: unit -> 'model * Cmd<'msg>)
-    (update: 'msg  -> 'model -> 'model * Cmd<'msg>)
-    (bindings: unit -> Binding<'model, 'msg> list) =
-  Program.mkProgram init update (fun _ _ -> bindings ())
-
-
-/// Same as mkProgramWpf, except that init and update doesn't return Cmd<'msg>
-/// directly, but instead return a CmdMsg discriminated union that is converted
-/// to Cmd<'msg> using toCmd. This means that the init and update functions
-/// return only data, and thus are easier to unit test. The CmdMsg pattern is
-/// general; this is just a trivial convenience function that automatically
-/// converts CmdMsg to Cmd<'msg> for you in inint and update
-let mkProgramWpfWithCmdMsg
-    (init: unit -> 'model * 'cmdMsg list)
-    (update: 'msg -> 'model -> 'model * 'cmdMsg list)
-    (bindings: unit -> Binding<'model, 'msg> list)
-    (toCmd: 'cmdMsg -> Cmd<'msg>) =
-  let convert (model, cmdMsgs) =
-    model, (cmdMsgs |> List.map toCmd |> Cmd.batch)
-  mkProgramWpf
-    (init >> convert)
-    (fun msg model -> update msg model |> convert)
-    bindings
-
-
-/// Traces all updates using System.Diagnostics.Debug.WriteLine.
-let withDebugTrace program =
-  program |> Program.withTrace (fun msg model ->
-    System.Diagnostics.Debug.WriteLine(sprintf "New message: %A" msg)
-    System.Diagnostics.Debug.WriteLine(sprintf "Updated state: %A" model)
-  )
+  /// Starts the Elmish dispatch loop, setting the bindings as the DataContext
+  /// for the specified FrameworkElement. Non-blocking. This is a low-level function;
+  /// for normal usage, see runWindow and runWindowWithConfig.
+  let startElmishLoop
+      (config: ElmConfig)
+      (element: FrameworkElement)
+      (program: Program<unit, 'model, 'msg, Binding<'model, 'msg> list>) =
+    let mutable lastModel = None
+  
+    let setState model dispatch =
+      match lastModel with
+      | None ->
+          let bindings = Program.view program model dispatch
+          let vm = ViewModel<'model,'msg>(model, dispatch, bindings, config, "main")
+          element.DataContext <- vm
+          lastModel <- Some vm
+      | Some vm ->
+          vm.UpdateModel model
+  
+    let uiDispatch (innerDispatch: Dispatch<'msg>) : Dispatch<'msg> =
+      fun msg -> element.Dispatcher.Invoke(fun () -> innerDispatch msg)
+  
+    program
+    |> Program.withSetState setState
+    |> Program.withSyncDispatch uiDispatch
+    |> Program.run
+  
+  
+  /// Instantiates Application and sets its MainWindow if it is not already
+  /// running.
+  let private initializeApplication window =
+    if isNull Application.Current then
+      Application () |> ignore
+      Application.Current.MainWindow <- window
+  
+  
+  /// Starts the Elmish and WPF dispatch loops with the specified configuration.
+  /// Will instantiate Application and set its MainWindow if it is not already
+  /// running, and then run the specified window. This is a blocking function.
+  let runWindowWithConfig config (window: Window) program =
+    initializeApplication window
+    window.Show ()
+    startElmishLoop config window program
+    Application.Current.Run window
+  
+  
+  /// Starts the Elmish and WPF dispatch loops. Will instantiate Application and
+  /// set its MainWindow if it is not already running, and then run the specified
+  /// window. This is a blocking function.
+  let runWindow window program =
+    runWindowWithConfig ElmConfig.Default window program
+  
+  
+  /// Same as mkSimple, but with a signature adapted for Elmish.WPF.
+  let mkSimpleWpf
+      (init: unit -> 'model)
+      (update: 'msg  -> 'model -> 'model)
+      (bindings: unit -> Binding<'model, 'msg> list) =
+    Program.mkSimple init update (fun _ _ -> bindings ())
+  
+  
+  /// Same as mkProgram, but with a signature adapted for Elmish.WPF.
+  let mkProgramWpf
+      (init: unit -> 'model * Cmd<'msg>)
+      (update: 'msg  -> 'model -> 'model * Cmd<'msg>)
+      (bindings: unit -> Binding<'model, 'msg> list) =
+    Program.mkProgram init update (fun _ _ -> bindings ())
+  
+  
+  /// Same as mkProgramWpf, except that init and update doesn't return Cmd<'msg>
+  /// directly, but instead return a CmdMsg discriminated union that is converted
+  /// to Cmd<'msg> using toCmd. This means that the init and update functions
+  /// return only data, and thus are easier to unit test. The CmdMsg pattern is
+  /// general; this is just a trivial convenience function that automatically
+  /// converts CmdMsg to Cmd<'msg> for you in inint and update
+  let mkProgramWpfWithCmdMsg
+      (init: unit -> 'model * 'cmdMsg list)
+      (update: 'msg -> 'model -> 'model * 'cmdMsg list)
+      (bindings: unit -> Binding<'model, 'msg> list)
+      (toCmd: 'cmdMsg -> Cmd<'msg>) =
+    let convert (model, cmdMsgs) =
+      model, (cmdMsgs |> List.map toCmd |> Cmd.batch)
+    mkProgramWpf
+      (init >> convert)
+      (fun msg model -> update msg model |> convert)
+      bindings
+  
+  
+  /// Traces all updates using System.Diagnostics.Debug.WriteLine.
+  let withDebugTrace program =
+    program |> Program.withTrace (fun msg model ->
+      System.Diagnostics.Debug.WriteLine(sprintf "New message: %A" msg)
+      System.Diagnostics.Debug.WriteLine(sprintf "Updated state: %A" model)
+    )

--- a/src/Elmish.WPF/Program.fs
+++ b/src/Elmish.WPF/Program.fs
@@ -116,3 +116,14 @@ module Program =
 
   let withMeasureLimitMs i program =
     { program with ElmConfig = { program.ElmConfig with MeasureLimitMs = i } }
+    
+
+
+[<RequireQualifiedAccess>]
+module ElmishProgram =
+
+  let withConsoleTrace program =
+    program |> Program.mapElmishProgram Program.withConsoleTrace
+
+  let withSubscription subscribe program =
+    program |> Program.mapElmishProgram (Program.withSubscription subscribe)

--- a/src/Samples/EventBindingsAndBehaviors/Program.fs
+++ b/src/Samples/EventBindingsAndBehaviors/Program.fs
@@ -71,7 +71,7 @@ let bindings () : Binding<Model, Msg> list = [
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf init update bindings
-  |> Program.mapElmishProgram Program.withConsoleTrace
+  |> ElmishProgram.withConsoleTrace
   |> Program.logConsole
   |> Program.measure
   |> Program.runWindow

--- a/src/Samples/EventBindingsAndBehaviors/Program.fs
+++ b/src/Samples/EventBindingsAndBehaviors/Program.fs
@@ -71,7 +71,8 @@ let bindings () : Binding<Model, Msg> list = [
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf init update bindings
-  |> Program.withConsoleTrace
-  |> Program.runWindowWithConfig
-     { ElmConfig.Default with LogConsole = true; Measure = true }
+  |> Program.mapElmishProgram Program.withConsoleTrace
+  |> Program.logConsole
+  |> Program.measure
+  |> Program.runWindow
      (MainWindow())

--- a/src/Samples/FileDialogs.CmdMsg/Program.fs
+++ b/src/Samples/FileDialogs.CmdMsg/Program.fs
@@ -122,8 +122,10 @@ let timerTick dispatch =
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkProgramWpfWithCmdMsg init update bindings toCmd
-  |> Program.withSubscription (fun _ -> Cmd.ofSub timerTick)
-  |> Program.withConsoleTrace
-  |> Program.runWindowWithConfig
-    { ElmConfig.Default with LogConsole = true; Measure = true }
+  |> Program.mapElmishProgram (
+       Program.withSubscription (fun _ -> Cmd.ofSub timerTick)
+       >> Program.withConsoleTrace)
+  |> Program.logConsole
+  |> Program.measure
+  |> Program.runWindow
     (MainWindow())

--- a/src/Samples/FileDialogs.CmdMsg/Program.fs
+++ b/src/Samples/FileDialogs.CmdMsg/Program.fs
@@ -122,9 +122,8 @@ let timerTick dispatch =
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkProgramWpfWithCmdMsg init update bindings toCmd
-  |> Program.mapElmishProgram (
-       Program.withSubscription (fun _ -> Cmd.ofSub timerTick)
-       >> Program.withConsoleTrace)
+  |> ElmishProgram.withSubscription (fun _ -> Cmd.ofSub timerTick)
+  |> ElmishProgram.withConsoleTrace
   |> Program.logConsole
   |> Program.measure
   |> Program.runWindow

--- a/src/Samples/FileDialogs/Program.fs
+++ b/src/Samples/FileDialogs/Program.fs
@@ -100,8 +100,10 @@ let timerTick dispatch =
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkProgramWpf init update bindings
-  |> Program.withSubscription (fun _ -> Cmd.ofSub timerTick)
-  |> Program.withConsoleTrace
-  |> Program.runWindowWithConfig
-    { ElmConfig.Default with LogConsole = true; Measure = true }
+  |> Program.mapElmishProgram (
+       Program.withSubscription (fun _ -> Cmd.ofSub timerTick)
+       >> Program.withConsoleTrace)
+  |> Program.logConsole
+  |> Program.measure
+  |> Program.runWindow
     (MainWindow())

--- a/src/Samples/FileDialogs/Program.fs
+++ b/src/Samples/FileDialogs/Program.fs
@@ -100,9 +100,8 @@ let timerTick dispatch =
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkProgramWpf init update bindings
-  |> Program.mapElmishProgram (
-       Program.withSubscription (fun _ -> Cmd.ofSub timerTick)
-       >> Program.withConsoleTrace)
+  |> Elmish.WPF.ElmishProgram.withSubscription (fun _ -> Cmd.ofSub timerTick)
+  |> ElmishProgram.withConsoleTrace
   |> Program.logConsole
   |> Program.measure
   |> Program.runWindow

--- a/src/Samples/NewWindow/Program.fs
+++ b/src/Samples/NewWindow/Program.fs
@@ -111,7 +111,7 @@ module App =
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf App.init App.update App.bindings
-  |> Program.mapElmishProgram Program.withConsoleTrace
+  |> ElmishProgram.withConsoleTrace
   |> Program.logConsole
   |> Program.measure
   |> Program.runWindow

--- a/src/Samples/NewWindow/Program.fs
+++ b/src/Samples/NewWindow/Program.fs
@@ -111,7 +111,8 @@ module App =
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf App.init App.update App.bindings
-  |> Program.withConsoleTrace
-  |> Program.runWindowWithConfig
-    { ElmConfig.Default with LogConsole = true; Measure = true }
+  |> Program.mapElmishProgram Program.withConsoleTrace
+  |> Program.logConsole
+  |> Program.measure
+  |> Program.runWindow
     (MainWindow())

--- a/src/Samples/OneWaySeq/Program.fs
+++ b/src/Samples/OneWaySeq/Program.fs
@@ -33,7 +33,7 @@ let bindings () : Binding<Model, Msg> list = [
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf init update bindings
-  |> Program.mapElmishProgram Program.withConsoleTrace
+  |> ElmishProgram.withConsoleTrace
   |> Program.logConsole
   |> Program.measure
   |> Program.runWindow

--- a/src/Samples/OneWaySeq/Program.fs
+++ b/src/Samples/OneWaySeq/Program.fs
@@ -33,7 +33,8 @@ let bindings () : Binding<Model, Msg> list = [
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf init update bindings
-  |> Program.withConsoleTrace
-  |> Program.runWindowWithConfig
-    { ElmConfig.Default with LogConsole = true }
+  |> Program.mapElmishProgram Program.withConsoleTrace
+  |> Program.logConsole
+  |> Program.measure
+  |> Program.runWindow
     (MainWindow())

--- a/src/Samples/SingleCounter/Program.fs
+++ b/src/Samples/SingleCounter/Program.fs
@@ -39,7 +39,7 @@ let bindings () : Binding<Model, Msg> list = [
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf (fun () -> init) update bindings
-  |> Program.mapElmishProgram Program.withConsoleTrace
+  |> ElmishProgram.withConsoleTrace
   |> Program.logConsole
   |> Program.measure
   |> Program.runWindow

--- a/src/Samples/SingleCounter/Program.fs
+++ b/src/Samples/SingleCounter/Program.fs
@@ -39,7 +39,8 @@ let bindings () : Binding<Model, Msg> list = [
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf (fun () -> init) update bindings
-  |> Program.withConsoleTrace
-  |> Program.runWindowWithConfig
-    { ElmConfig.Default with LogConsole = true; Measure = true }
+  |> Program.mapElmishProgram Program.withConsoleTrace
+  |> Program.logConsole
+  |> Program.measure
+  |> Program.runWindow
     (MainWindow())

--- a/src/Samples/SubModel/Program.fs
+++ b/src/Samples/SubModel/Program.fs
@@ -143,9 +143,8 @@ let timerTick dispatch =
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf App.init App.update App.bindings
-  |> Program.mapElmishProgram (
-       Program.withSubscription (fun _ -> Cmd.ofSub timerTick)
-       >> Program.withConsoleTrace)
+  |> ElmishProgram.withSubscription (fun _ -> Cmd.ofSub timerTick)
+  |> ElmishProgram.withConsoleTrace
   |> Program.logConsole
   |> Program.measure
   |> Program.runWindow

--- a/src/Samples/SubModel/Program.fs
+++ b/src/Samples/SubModel/Program.fs
@@ -143,8 +143,10 @@ let timerTick dispatch =
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf App.init App.update App.bindings
-  |> Program.withSubscription (fun _ -> Cmd.ofSub timerTick)
-  |> Program.withConsoleTrace
-  |> Program.runWindowWithConfig
-    { ElmConfig.Default with LogConsole = true; Measure = true }
+  |> Program.mapElmishProgram (
+       Program.withSubscription (fun _ -> Cmd.ofSub timerTick)
+       >> Program.withConsoleTrace)
+  |> Program.logConsole
+  |> Program.measure
+  |> Program.runWindow
     (MainWindow())

--- a/src/Samples/SubModelOpt/Program.fs
+++ b/src/Samples/SubModelOpt/Program.fs
@@ -119,7 +119,8 @@ module App =
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf App.init App.update App.bindings
-  |> Program.withConsoleTrace
-  |> Program.runWindowWithConfig
-    { ElmConfig.Default with LogConsole = true; Measure = true }
+  |> Program.mapElmishProgram Program.withConsoleTrace
+  |> Program.logConsole
+  |> Program.measure
+  |> Program.runWindow
     (MainWindow())

--- a/src/Samples/SubModelOpt/Program.fs
+++ b/src/Samples/SubModelOpt/Program.fs
@@ -119,7 +119,7 @@ module App =
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf App.init App.update App.bindings
-  |> Program.mapElmishProgram Program.withConsoleTrace
+  |> ElmishProgram.withConsoleTrace
   |> Program.logConsole
   |> Program.measure
   |> Program.runWindow

--- a/src/Samples/SubModelSelectedItem/Program.fs
+++ b/src/Samples/SubModelSelectedItem/Program.fs
@@ -44,7 +44,8 @@ let bindings () : Binding<Model, Msg> list = [
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf init update bindings
-  |> Program.withConsoleTrace
-  |> Program.runWindowWithConfig
-    { ElmConfig.Default with LogConsole = true; Measure = true }
+  |> Program.mapElmishProgram Program.withConsoleTrace
+  |> Program.logConsole
+  |> Program.measure
+  |> Program.runWindow
     (MainWindow())

--- a/src/Samples/SubModelSelectedItem/Program.fs
+++ b/src/Samples/SubModelSelectedItem/Program.fs
@@ -44,7 +44,7 @@ let bindings () : Binding<Model, Msg> list = [
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf init update bindings
-  |> Program.mapElmishProgram Program.withConsoleTrace
+  |> ElmishProgram.withConsoleTrace
   |> Program.logConsole
   |> Program.measure
   |> Program.runWindow

--- a/src/Samples/SubModelSeq/Program.fs
+++ b/src/Samples/SubModelSeq/Program.fs
@@ -223,7 +223,8 @@ module Bindings =
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf App.init App.update Bindings.rootBindings
-  |> Program.withConsoleTrace
-  |> Program.runWindowWithConfig
-    { ElmConfig.Default with LogConsole = true; Measure = true }
+  |> Program.mapElmishProgram Program.withConsoleTrace
+  |> Program.logConsole
+  |> Program.measure
+  |> Program.runWindow
     (MainWindow())

--- a/src/Samples/SubModelSeq/Program.fs
+++ b/src/Samples/SubModelSeq/Program.fs
@@ -223,7 +223,7 @@ module Bindings =
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf App.init App.update Bindings.rootBindings
-  |> Program.mapElmishProgram Program.withConsoleTrace
+  |> ElmishProgram.withConsoleTrace
   |> Program.logConsole
   |> Program.measure
   |> Program.runWindow

--- a/src/Samples/UiBoundCmdParam/Program.fs
+++ b/src/Samples/UiBoundCmdParam/Program.fs
@@ -35,7 +35,7 @@ let bindings () : Binding<Model, Msg> list = [
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf init update bindings
-  |> Program.mapElmishProgram Program.withConsoleTrace
+  |> ElmishProgram.withConsoleTrace
   |> Program.logConsole
   |> Program.measure
   |> Program.runWindow

--- a/src/Samples/UiBoundCmdParam/Program.fs
+++ b/src/Samples/UiBoundCmdParam/Program.fs
@@ -35,7 +35,8 @@ let bindings () : Binding<Model, Msg> list = [
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf init update bindings
-  |> Program.withConsoleTrace
-  |> Program.runWindowWithConfig
-    { ElmConfig.Default with LogConsole = true; Measure = true }
+  |> Program.mapElmishProgram Program.withConsoleTrace
+  |> Program.logConsole
+  |> Program.measure
+  |> Program.runWindow
     (MainWindow())

--- a/src/Samples/Validation/Program.fs
+++ b/src/Samples/Validation/Program.fs
@@ -50,7 +50,7 @@ let bindings () : Binding<Model, Msg> list = [
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf init update bindings
-  |> Program.mapElmishProgram Program.withConsoleTrace
+  |> ElmishProgram.withConsoleTrace
   |> Program.logConsole
   |> Program.measure
   |> Program.runWindow

--- a/src/Samples/Validation/Program.fs
+++ b/src/Samples/Validation/Program.fs
@@ -50,7 +50,8 @@ let bindings () : Binding<Model, Msg> list = [
 [<EntryPoint; STAThread>]
 let main _ =
   Program.mkSimpleWpf init update bindings
-  |> Program.withConsoleTrace
-  |> Program.runWindowWithConfig
-    { ElmConfig.Default with LogConsole = true; Measure = true }
+  |> Program.mapElmishProgram Program.withConsoleTrace
+  |> Program.logConsole
+  |> Program.measure
+  |> Program.runWindow
     (MainWindow())


### PR DESCRIPTION
This _draft_ PR is initial work towards resolving #105.  See especially https://github.com/elmish/Elmish.WPF/issues/105#issuecomment-635701641.

This PR contains two commits.  The first commit changes the indentation in most of Program.fs, so it is helpful to review each commit separately while ignoring whitespace changes.

The first commit makes the `Program` module into a module within the namespace `Elmish.WPF`.

The second commit replaces `ElmConfig` with `ProgramWpf`.  The constructor of `ProgramWpf` is private and public setters/mapers are provided, just like Elmish does with its `Program` record.  The `ProgramWpf` record contains the `Elmish.Program` record.  Modifications to this underlying `Elmish.Prgoram` record are allowed via `Program.mapElmishProgram`.

I tried to make the second commit as small as possible to help emphasize the change to the API.  There are many other internal changes that would naturally follow that I have excluded for now.

What are you thoughts on this approach where the `ProgramWpf` record contains the `Elmish.Program` record?

As for naming and the public API, one change that I think would be nice is to rename
- the module `Program` module to `WpfProgram`,
- the record `ProgramWpf` to `WpfProgram`,
- the function `mkProgramWpf` to `mkWpfProgram`, and
- the function `mkProgramWpfWithCmdMsg` to `mkWpfProgramWithCmdMsg`.

This would help distinguish which functions take `Elmish.Program` as input and which ones take `Elmish.WPF.WpfProgram` as input...while also putting `Wpf` before `Program`, which is the natural placement of the adjective `Wpf` of the noun `Program`.  Of course we would deprecate instead of remove the existing functions and module to facilitate migration.