### PR TITLE
Replaced calls to Range.exponential with Range.constant to avoid issue #237

### DIFF
--- a/src/Elmish.WPF.Tests/MergeTests.fs
+++ b/src/Elmish.WPF.Tests/MergeTests.fs
@@ -162,7 +162,7 @@ let ``starting with random items, when merging after a replacement, should conta
 [<Fact>]
 let ``starting with random items, when merging after swapping two adjacent items, should contain the merged items and never call create and call update exactly once for each item`` () =
   Property.check <| property {
-    let! list1 = Gen.guid |> Gen.list (Range.exponential 2 50)
+    let! list1 = Gen.guid |> Gen.list (Range.constant 2 50)
     let! firstSwapIndex = (0, list1.Length - 2) ||> Range.constant |> Gen.int
 
     let observableCollection = ObservableCollection<_> list1
@@ -183,7 +183,7 @@ let ``starting with random items, when merging after swapping two adjacent items
 [<Fact>]
 let ``starting with random items, when merging after swapping two items, should contain the merged items and never call create and call update exactly once for each item`` () =
   Property.check <| property {
-    let! list1 = Gen.guid |> Gen.list (Range.exponential 2 50)
+    let! list1 = Gen.guid |> Gen.list (Range.constant 2 50)
     let! i = (0, list1.Length - 1) ||> Range.constant |> Gen.int
     let! j = (0, list1.Length - 1) ||> Range.constant |> Gen.int |> GenX.notEqualTo i
 
@@ -205,7 +205,7 @@ let ``starting with random items, when merging after swapping two items, should 
 [<Fact>]
 let ``starting with random items, when merging after shuffling, should contain the merged items and never call create and call update eactly once for each item`` () =
   Property.check <| property {
-    let! list1 = Gen.guid |> Gen.list (Range.exponential 2 50)
+    let! list1 = Gen.guid |> Gen.list (Range.constant 2 50)
     let! list2 = list1 |> GenX.shuffle |> GenX.notEqualTo list1
     
     let observableCollection = ObservableCollection<_> list1

--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -694,8 +694,8 @@ module OneWaySeqLazy =
   let ``given equals returns false and itemEquals returns false, when model is updated, should contain expected items in collection`` () =
     Property.check <| property {
       let! name = GenX.auto<string>
-      let! m1 = Gen.guid |> Gen.list (Range.exponential 1 50)
-      let! m2 = Gen.guid |> Gen.list (Range.exponential 1 50)
+      let! m1 = Gen.guid |> Gen.list (Range.constant 1 50)
+      let! m2 = Gen.guid |> Gen.list (Range.constant 1 50)
 
       let get = id
       let equals _ _ = false


### PR DESCRIPTION
Replacing calls to `Range.exponential` with `Range.constant` seems like an easy way to avoid issue #237.  For this branch, all the tests pass on my machine, which is using MSBuild 16.6.0.  Since AppVeyor is still using version 16.5.0, I expect all tests to pass for both the current state of `master` as well as for this branch.

I am not confident in my understanding of the difference between `Range.exponential` and `Range.constant`.

Does `Range.constant x y` model the ([discrete](https://en.wikipedia.org/wiki/Discrete_uniform_distribution) or [continuous](https://en.wikipedia.org/wiki/Uniform_distribution_(continuous))) uniform distribution  and `Range.exponential` model either the [(discrete) geometric distribution](https://en.wikipedia.org/wiki/Geometric_distribution) or the [(continuous) exponential distribution](https://en.wikipedia.org/wiki/Exponential_distribution)?