### PR TITLE
DRAFT: Improve sub model seq composability

### DIFF
--- a/src/Elmish.WPF.Tests/BindingTests.fs
+++ b/src/Elmish.WPF.Tests/BindingTests.fs
@@ -2119,7 +2119,7 @@ module cmdIf =
     let ``sets the correct binding name`` () =
       Property.check <| property {
         let! bindingName = GenX.auto<string>
-        let binding = bindingName |> Binding.cmdIf(fail, fail, id)
+        let binding = bindingName |> Binding.cmdIf(fail, fail)
         test <@ binding.Name = bindingName @>
       }
 
@@ -2476,7 +2476,7 @@ module cmdParamIf =
     let ``final autoRequery equals original uiBoundCmdParam`` () =
       Property.check <| property {
         let! uiBoundCmdParam = GenX.auto<bool>
-        let d = Binding.cmdParamIf(fail, fail, uiBoundCmdParam = uiBoundCmdParam, wrapDispatch = id) |> getCmdParamData
+        let d = Binding.cmdParamIf(fail, fail, uiBoundCmdParam = uiBoundCmdParam) |> getCmdParamData
         test <@ d.AutoRequery = uiBoundCmdParam @>
       }
 
@@ -3775,18 +3775,18 @@ module sorting =
         let! b = GenX.auto<bool>
         let! vo = GenX.auto<obj voption>
         let data =
-          [ SubModelSelectedItemData { Get = fail; Set = fail2; SubModelSeqBindingName = s; WrapDispatch = fail }
+          [ SubModelSelectedItemData { Get = fail; Set = fail2; SubModelSeqBindingName = s }
             OneWayData { Get = fail }
             OneWayLazyData { Get = fail; Map = fail; Equals = fail2 }
             OneWaySeqLazyData { Get = fail; Map = fail; Equals = fail2; GetId = fail; ItemEquals = fail2 }
-            TwoWayData { Get = fail; Set = fail2; WrapDispatch = fail }
-            TwoWayValidateData { Get = fail; Set = fail2; Validate = fail; WrapDispatch = fail }
-            CmdData { Exec = fail; CanExec = fail; WrapDispatch = fail }
-            CmdParamData { Exec = fail2; CanExec = fail2; AutoRequery = b; WrapDispatch = fail }
+            TwoWayData { Get = fail; Set = fail2 }
+            TwoWayValidateData { Get = fail; Set = fail2; Validate = fail }
+            CmdData { Exec = fail; CanExec = fail }
+            CmdParamData { Exec = fail2; CanExec = fail2; AutoRequery = b }
             SubModelData { GetModel = fail; GetBindings = fail; ToMsg = fail; Sticky = b }
             SubModelWinData { GetState = fail; GetBindings = fail; ToMsg = fail; GetWindow = fail2; IsModal = b; OnCloseRequested = vo }
             SubModelSeqData { GetModels = fail; GetId = fail; GetBindings = fail; ToMsg = fail }
-            SubModelSelectedItemData { Get = fail; Set = fail2; SubModelSeqBindingName = s; WrapDispatch = fail }
+            SubModelSelectedItemData { Get = fail; Set = fail2; SubModelSeqBindingName = s }
           ]
         let sorted = data |> List.sortWith BindingData.subModelSelectedItemLast
         match sorted with

--- a/src/Elmish.WPF.Tests/BindingTests.fs
+++ b/src/Elmish.WPF.Tests/BindingTests.fs
@@ -2984,9 +2984,10 @@ module subModel =
     [<Fact>]
     let ``final toMsg simply unboxes`` () =
       Property.check <| property {
+        let! m = GenX.auto<int>
         let! x = GenX.auto<int>
         let d = Binding.subModel(fail, fail) |> getSubModelData
-        test <@ d.ToMsg (box x) = x @>
+        test <@ d.ToMsg m (box x) = x @>
       }
 
 
@@ -3024,12 +3025,13 @@ module subModel =
     [<Fact>]
     let ``final toMsg returns value from original toMsg`` () =
       Property.check <| property {
+        let! m = GenX.auto<int>
         let! x = GenX.auto<int>
 
         let toMsg = string
         let d = Binding.subModel(fail, toMsg, fail) |> getSubModelData
 
-        test <@ d.ToMsg (box x) = toMsg x @>
+        test <@ d.ToMsg m (box x) = toMsg x @>
       }
 
 
@@ -3067,12 +3069,13 @@ module subModel =
     [<Fact>]
     let ``final toMsg returns value from original toMsg`` () =
       Property.check <| property {
+        let! m = GenX.auto<int>
         let! x = GenX.auto<int>
 
         let toMsg = string
         let d = Binding.subModel(fail, fail, toMsg, fail) |> getSubModelData
 
-        test <@ d.ToMsg (box x) = toMsg x @>
+        test <@ d.ToMsg m (box x) = toMsg x @>
       }
 
 
@@ -3123,9 +3126,10 @@ module subModelOpt =
     [<Fact>]
     let ``final toMsg simply unboxes`` () =
       Property.check <| property {
+        let! m = GenX.auto<int>
         let! x = GenX.auto<int>
         let d = Binding.subModelOpt((fail: _ -> _ voption), fail) |> getSubModelData
-        test <@ d.ToMsg (box x) = x @>
+        test <@ d.ToMsg m (box x) = x @>
       }
 
 
@@ -3182,9 +3186,10 @@ module subModelOpt =
     [<Fact>]
     let ``final toMsg simply unboxes`` () =
       Property.check <| property {
+        let! m = GenX.auto<int>
         let! x = GenX.auto<int>
         let d = Binding.subModelOpt((fail: _ -> _ option), fail) |> getSubModelData
-        test <@ d.ToMsg (box x) = x @>
+        test <@ d.ToMsg m (box x) = x @>
       }
 
 
@@ -3240,12 +3245,13 @@ module subModelOpt =
     [<Fact>]
     let ``final toMsg returns value from original toMsg`` () =
       Property.check <| property {
+        let! m = GenX.auto<int>
         let! x = GenX.auto<int>
 
         let toMsg = string
         let d = Binding.subModelOpt((fail: _ -> _ voption), toMsg, fail) |> getSubModelData
 
-        test <@ d.ToMsg (box x) = toMsg x @>
+        test <@ d.ToMsg m (box x) = toMsg x @>
       }
 
 
@@ -3302,12 +3308,13 @@ module subModelOpt =
     [<Fact>]
     let ``final toMsg returns value from original toMsg`` () =
       Property.check <| property {
+        let! m = GenX.auto<int>
         let! x = GenX.auto<int>
 
         let toMsg = string
         let d = Binding.subModelOpt((fail: _ -> _ option), toMsg, fail) |> getSubModelData
 
-        test <@ d.ToMsg (box x) = toMsg x @>
+        test <@ d.ToMsg m (box x) = toMsg x @>
       }
 
 
@@ -3364,12 +3371,13 @@ module subModelOpt =
     [<Fact>]
     let ``final toMsg returns value from original toMsg`` () =
       Property.check <| property {
+        let! m = GenX.auto<int>
         let! x = GenX.auto<int>
 
         let toMsg = string
         let d = Binding.subModelOpt((fail: _ -> _ voption), fail, toMsg, fail) |> getSubModelData
 
-        test <@ d.ToMsg (box x) = toMsg x @>
+        test <@ d.ToMsg m (box x) = toMsg x @>
       }
 
 
@@ -3427,12 +3435,13 @@ module subModelOpt =
     [<Fact>]
     let ``final toMsg returns value from original toMsg`` () =
       Property.check <| property {
+        let! m = GenX.auto<int>
         let! x = GenX.auto<int>
 
         let toMsg = string
         let d = Binding.subModelOpt((fail: _ -> _ option), fail, toMsg, fail) |> getSubModelData
 
-        test <@ d.ToMsg (box x) = toMsg x @>
+        test <@ d.ToMsg m (box x) = toMsg x @>
       }
 
 
@@ -3492,10 +3501,11 @@ module subModelSeq =
     [<Fact>]
     let ``final toMsg extracts and unboxes the second tuple element`` () =
       Property.check <| property {
+        let! m = GenX.auto<int>
         let! x = GenX.auto<int>
         let! y = GenX.auto<string>
         let d = Binding.subModelSeq(fail, fail, fail) |> getSubModelSeqData
-        test <@ d.ToMsg (box x, box y) |> unbox = y @>
+        test <@ d.ToMsg m (box x, box y) |> unbox = y @>
       }
 
 
@@ -3535,11 +3545,12 @@ module subModelSeq =
     [<Fact>]
     let ``final toMsg returns the value of original toMsg`` () =
       Property.check <| property {
+        let! m = GenX.auto<int>
         let! id = GenX.auto<int>
         let! msg = GenX.auto<string>
         let toMsg (id: int, msg: string) = msg.Length + id
         let d = Binding.subModelSeq(fail, fail, toMsg, fail) |> getSubModelSeqData
-        test <@ d.ToMsg (box id, box msg) |> unbox = toMsg (id, msg) @>
+        test <@ d.ToMsg m (box id, box msg) |> unbox = toMsg (id, msg) @>
       }
 
 
@@ -3581,11 +3592,12 @@ module subModelSeq =
       [<Fact>]
       let ``final toMsg returns the value of original toMsg`` () =
         Property.check <| property {
+          let! m = GenX.auto<int>
           let! id = GenX.auto<int>
           let! msg = GenX.auto<string>
           let toMsg (id: int, msg: string) = msg.Length + id
           let d = Binding.subModelSeq(fail, fail, fail, toMsg, fail) |> getSubModelSeqData
-          test <@ d.ToMsg (box id, box msg) |> unbox = toMsg (id, msg) @>
+          test <@ d.ToMsg m (box id, box msg) |> unbox = toMsg (id, msg) @>
         }
 
 

--- a/src/Elmish.WPF.Tests/BindingTests.fs
+++ b/src/Elmish.WPF.Tests/BindingTests.fs
@@ -3773,7 +3773,6 @@ module sorting =
       Property.check <| property {
         let! s = GenX.auto<string>
         let! b = GenX.auto<bool>
-        let! vo = GenX.auto<obj voption>
         let data =
           [ SubModelSelectedItemData { Get = fail; Set = fail2; SubModelSeqBindingName = s }
             OneWayData { Get = fail }
@@ -3784,7 +3783,7 @@ module sorting =
             CmdData { Exec = fail; CanExec = fail }
             CmdParamData { Exec = fail2; CanExec = fail2; AutoRequery = b }
             SubModelData { GetModel = fail; GetBindings = fail; ToMsg = fail; Sticky = b }
-            SubModelWinData { GetState = fail; GetBindings = fail; ToMsg = fail; GetWindow = fail2; IsModal = b; OnCloseRequested = vo }
+            SubModelWinData { GetState = fail; GetBindings = fail; ToMsg = fail; GetWindow = fail2; IsModal = b; OnCloseRequested = fail }
             SubModelSeqData { GetModels = fail; GetId = fail; GetBindings = fail; ToMsg = fail }
             SubModelSelectedItemData { Get = fail; Set = fail2; SubModelSeqBindingName = s }
           ]

--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -187,7 +187,7 @@ module Helpers =
     name |> createBinding (SubModelData {
       GetModel = getModel >> ValueOption.map box
       GetBindings = fun () -> bindings |> List.map boxBinding
-      ToMsg = unbox<'subMsg> >> toMsg
+      ToMsg = fun _ -> unbox<'subMsg> >> toMsg
       Sticky = sticky
     })
 
@@ -202,7 +202,7 @@ module Helpers =
       GetModels = getModels >> Seq.map box
       GetId = unbox<'subModel> >> getId >> box
       GetBindings = fun () -> bindings |> List.map boxBinding
-      ToMsg = fun (id, msg) -> toMsg (unbox<'id> id, unbox<'subMsg> msg)
+      ToMsg = fun _ (id, msg) -> toMsg (unbox<'id> id, unbox<'subMsg> msg)
     })
 
 

--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -141,7 +141,6 @@ module Helpers =
     name |> createBinding (TwoWayData {
       Get = get >> box
       Set = unbox<'a> >> set
-      WrapDispatch = id
     })
 
 
@@ -154,7 +153,6 @@ module Helpers =
       Get = get >> box
       Set = unbox<'a> >> set
       Validate = validate
-      WrapDispatch = id
     })
 
 
@@ -165,7 +163,6 @@ module Helpers =
     name |> createBinding (CmdData {
       Exec = exec
       CanExec = canExec
-      WrapDispatch = id
     })
 
 
@@ -178,7 +175,6 @@ module Helpers =
       Exec = unbox >> exec
       CanExec = unbox >> canExec
       AutoRequery = autoRequery
-      WrapDispatch = id
     })
 
 
@@ -219,7 +215,6 @@ module Helpers =
       Get = get >> ValueOption.map box
       Set = ValueOption.map unbox<'id> >> set
       SubModelSeqBindingName = subModelSeqBindingName
-      WrapDispatch = id
     })
 
 

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -33,17 +33,17 @@ module WindowState =
     | ValueNone -> WindowState.Closed
 
 
-type internal OneWayData<'model, 'a> = {
+type OneWayData<'model, 'a> = {
   Get: 'model -> 'a
 }
 
-type internal OneWayLazyData<'model, 'a, 'b> = {
+type OneWayLazyData<'model, 'a, 'b> = {
   Get: 'model -> 'a
   Map: 'a -> 'b
   Equals: 'a -> 'a -> bool
 }
 
-type internal OneWaySeqLazyData<'model, 'a, 'b, 'id> = {
+type OneWaySeqLazyData<'model, 'a, 'b, 'id> = {
   Get: 'model -> 'a
   Map: 'a -> 'b seq
   Equals: 'a -> 'a -> bool
@@ -51,42 +51,42 @@ type internal OneWaySeqLazyData<'model, 'a, 'b, 'id> = {
   ItemEquals: 'b -> 'b -> bool
 }
 
-type internal TwoWayData<'model, 'msg, 'a> = {
+type TwoWayData<'model, 'msg, 'a> = {
   Get: 'model -> 'a
   Set: 'a -> 'model -> 'msg
 }
 
-type internal TwoWayValidateData<'model, 'msg, 'a> = {
+type TwoWayValidateData<'model, 'msg, 'a> = {
   Get: 'model -> 'a
   Set: 'a -> 'model -> 'msg
   Validate: 'model -> string voption
 }
 
-type internal CmdData<'model, 'msg> = {
+type CmdData<'model, 'msg> = {
   Exec: 'model -> 'msg voption
   CanExec: 'model -> bool
 }
 
-type internal CmdParamData<'model, 'msg> = {
+type CmdParamData<'model, 'msg> = {
   Exec: obj -> 'model -> 'msg voption
   CanExec: obj -> 'model -> bool
   AutoRequery: bool
 }
 
-type internal SubModelSelectedItemData<'model, 'msg, 'id> = {
+type SubModelSelectedItemData<'model, 'msg, 'id> = {
   Get: 'model -> 'id voption
   Set: 'id voption -> 'model -> 'msg
   SubModelSeqBindingName: string
 }
 
-type internal SubModelData<'model, 'msg, 'bindingModel, 'bindingMsg> = {
+type SubModelData<'model, 'msg, 'bindingModel, 'bindingMsg> = {
   GetModel: 'model -> 'bindingModel voption
   GetBindings: unit -> Binding<'bindingModel, 'bindingMsg> list
   ToMsg: 'model -> 'bindingMsg -> 'msg
   Sticky: bool
 }
 
-and internal SubModelWinData<'model, 'msg, 'bindingModel, 'bindingMsg> = {
+and SubModelWinData<'model, 'msg, 'bindingModel, 'bindingMsg> = {
   GetState: 'model -> WindowState<'bindingModel>
   GetBindings: unit -> Binding<'bindingModel, 'bindingMsg> list
   ToMsg: 'model -> 'bindingMsg -> 'msg
@@ -95,7 +95,7 @@ and internal SubModelWinData<'model, 'msg, 'bindingModel, 'bindingMsg> = {
   OnCloseRequested: 'model -> 'msg voption
 }
 
-and internal SubModelSeqData<'model, 'msg, 'bindingModel, 'bindingMsg, 'id> = {
+and SubModelSeqData<'model, 'msg, 'bindingModel, 'bindingMsg, 'id> = {
   GetModels: 'model -> 'bindingModel seq
   GetId: 'bindingModel -> 'id
   GetBindings: unit -> Binding<'bindingModel, 'bindingMsg> list
@@ -104,7 +104,7 @@ and internal SubModelSeqData<'model, 'msg, 'bindingModel, 'bindingMsg, 'id> = {
 
 
 /// Represents all necessary data used to create the different binding types.
-and internal BindingData<'model, 'msg> =
+and BindingData<'model, 'msg> =
   | OneWayData of OneWayData<'model, obj>
   | OneWayLazyData of OneWayLazyData<'model, obj, obj>
   | OneWaySeqLazyData of OneWaySeqLazyData<'model, obj, obj, obj>
@@ -120,12 +120,11 @@ and internal BindingData<'model, 'msg> =
 
 /// Represents all necessary data used to create a binding.
 and Binding<'model, 'msg> =
-  internal
     { Name: string
       Data: BindingData<'model, 'msg> }
 
 
-module internal BindingData =
+module BindingData =
 
   let subModelSelectedItemLast a b =
     match a, b with
@@ -247,7 +246,7 @@ module internal BindingData =
   let mapMsg f = mapMsgWithModel (fun _ -> f)
 
 
-module internal Binding =
+module Binding =
 
   let mapData f binding =
     { Name = binding.Name
@@ -261,7 +260,7 @@ module internal Binding =
     BindingData.subModelSelectedItemLast a.Data b.Data
 
 
-module internal Bindings =
+module Bindings =
 
   let mapModel        f bindings = bindings |> List.map (Binding.mapModel        f)
   let mapMsgWithModel f bindings = bindings |> List.map (Binding.mapMsgWithModel f)

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -92,7 +92,7 @@ and internal SubModelWinData<'model, 'msg, 'bindingModel, 'bindingMsg> = {
   ToMsg: 'bindingMsg -> 'msg
   GetWindow: 'model -> Dispatch<'msg> -> Window
   IsModal: bool
-  OnCloseRequested: 'msg voption
+  OnCloseRequested: 'model -> 'msg voption
 }
 
 and internal SubModelSeqData<'model, 'msg, 'bindingModel, 'bindingMsg, 'id> = {
@@ -182,7 +182,7 @@ module internal BindingData =
           ToMsg = d.ToMsg
           GetWindow = f >> d.GetWindow
           IsModal = d.IsModal
-          OnCloseRequested = d.OnCloseRequested
+          OnCloseRequested = f >> d.OnCloseRequested
         } |> SubModelWinData
     | SubModelSeqData d ->
         { GetModels = f >> d.GetModels
@@ -230,7 +230,7 @@ module internal BindingData =
         ToMsg = d.ToMsg >> f
         GetWindow = fun m dispatch -> d.GetWindow m (f >> dispatch)
         IsModal = d.IsModal
-        OnCloseRequested = d.OnCloseRequested |> ValueOption.map f
+        OnCloseRequested = d.OnCloseRequested >> ValueOption.map f
       }
     | SubModelSeqData d -> SubModelSeqData {
         GetModels = d.GetModels
@@ -1295,7 +1295,7 @@ type Binding private () =
       ToMsg = unbox<'bindingMsg> >> toMsg
       GetWindow = fun m d -> upcast getWindow m d
       IsModal = defaultArg isModal false
-      OnCloseRequested = defaultArg (onCloseRequested |> Option.map ValueSome) ValueNone
+      OnCloseRequested = fun _ -> defaultArg (onCloseRequested |> Option.map ValueSome) ValueNone
     } |> createBinding
 
 
@@ -1411,7 +1411,7 @@ type Binding private () =
       ToMsg = unbox<'subMsg> >> toMsg
       GetWindow = fun m d -> upcast getWindow m d
       IsModal = defaultArg isModal false
-      OnCloseRequested = defaultArg (onCloseRequested |> Option.map ValueSome) ValueNone
+      OnCloseRequested = fun _ -> defaultArg (onCloseRequested |> Option.map ValueSome) ValueNone
     } |> createBinding
 
 
@@ -1513,7 +1513,7 @@ type Binding private () =
       ToMsg = unbox<'msg>
       GetWindow = fun m d -> upcast getWindow m d
       IsModal = defaultArg isModal false
-      OnCloseRequested = defaultArg (onCloseRequested |> Option.map ValueSome) ValueNone
+      OnCloseRequested = fun _ -> defaultArg (onCloseRequested |> Option.map ValueSome) ValueNone
     } |> createBinding
 
 

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -54,34 +54,29 @@ type internal OneWaySeqLazyData<'model, 'a, 'b, 'id> = {
 type internal TwoWayData<'model, 'msg, 'a> = {
   Get: 'model -> 'a
   Set: 'a -> 'model -> 'msg
-  WrapDispatch: Dispatch<'msg> -> Dispatch<'msg>
 }
 
 type internal TwoWayValidateData<'model, 'msg, 'a> = {
   Get: 'model -> 'a
   Set: 'a -> 'model -> 'msg
   Validate: 'model -> string voption
-  WrapDispatch: Dispatch<'msg> -> Dispatch<'msg>
 }
 
 type internal CmdData<'model, 'msg> = {
   Exec: 'model -> 'msg voption
   CanExec: 'model -> bool
-  WrapDispatch: Dispatch<'msg> -> Dispatch<'msg>
 }
 
 type internal CmdParamData<'model, 'msg> = {
   Exec: obj -> 'model -> 'msg voption
   CanExec: obj -> 'model -> bool
   AutoRequery: bool
-  WrapDispatch: Dispatch<'msg> -> Dispatch<'msg>
 }
 
 type internal SubModelSelectedItemData<'model, 'msg, 'id> = {
   Get: 'model -> 'id voption
   Set: 'id voption -> 'model -> 'msg
   SubModelSeqBindingName: string
-  WrapDispatch: Dispatch<'msg> -> Dispatch<'msg>
 }
 
 type internal SubModelData<'model, 'msg, 'bindingModel, 'bindingMsg> = {
@@ -139,15 +134,7 @@ module internal BindingData =
     | _, SubModelSelectedItemData _ -> -1
     | _, _ -> 0
 
-  let boxWrapDispatch
-      (unboxMsg: 'boxedMsg -> 'msg)
-      (boxMsg: 'msg -> 'boxedMsg)
-      (strongWrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
-      : Dispatch<'boxedMsg> -> Dispatch<'boxedMsg> =
-    ((>>) boxMsg) >> strongWrapDispatch >> ((>>) unboxMsg)
-
   let boxMsg
-      (unboxMsg: 'boxedMsg -> 'msg)
       (boxMsg: 'msg -> 'boxedMsg)
       : BindingData<'model, 'msg> -> BindingData<'model, 'boxedMsg> = function
     | OneWayData d -> d |> OneWayData
@@ -156,24 +143,20 @@ module internal BindingData =
     | TwoWayData d -> TwoWayData {
         Get = d.Get
         Set = fun v m -> d.Set v m |> boxMsg
-        WrapDispatch = boxWrapDispatch unboxMsg boxMsg d.WrapDispatch
       }
     | TwoWayValidateData d -> TwoWayValidateData {
         Get = d.Get
         Set = fun v m -> d.Set v m |> boxMsg
         Validate = unbox >> d.Validate
-        WrapDispatch = boxWrapDispatch unboxMsg boxMsg d.WrapDispatch
       }
     | CmdData d -> CmdData {
         Exec = d.Exec >> ValueOption.map boxMsg
         CanExec = d.CanExec
-        WrapDispatch = boxWrapDispatch unboxMsg boxMsg d.WrapDispatch
       }
     | CmdParamData d -> CmdParamData {
         Exec = fun p m -> d.Exec p m |> ValueOption.map boxMsg
         CanExec = fun p m -> d.CanExec p m
         AutoRequery = d.AutoRequery
-        WrapDispatch = boxWrapDispatch unboxMsg boxMsg d.WrapDispatch
       }
     | SubModelData d -> SubModelData {
         GetModel = d.GetModel
@@ -199,7 +182,6 @@ module internal BindingData =
         Get = d.Get
         Set = fun v m -> d.Set v m |> boxMsg
         SubModelSeqBindingName = d.SubModelSeqBindingName
-        WrapDispatch = boxWrapDispatch unboxMsg boxMsg d.WrapDispatch
       }
 
   let mapModel f data =
@@ -223,24 +205,20 @@ module internal BindingData =
     | TwoWayData d ->
         { Get = f >> d.Get
           Set = binaryHelper d.Set
-          WrapDispatch = d.WrapDispatch
         } |> TwoWayData
     | TwoWayValidateData d ->
         { Get = f >> d.Get
           Set = binaryHelper d.Set
           Validate = f >> d.Validate
-          WrapDispatch = d.WrapDispatch
         } |> TwoWayValidateData
     | CmdData d ->
         { Exec = f >> d.Exec
           CanExec = f >> d.CanExec
-          WrapDispatch = d.WrapDispatch
         } |> CmdData
     | CmdParamData d ->
         { Exec = binaryHelper d.Exec
           CanExec = binaryHelper d.CanExec
           AutoRequery = d.AutoRequery
-          WrapDispatch = d.WrapDispatch
         } |> CmdParamData
     | SubModelData d ->
         { GetModel = f >> d.GetModel
@@ -266,7 +244,6 @@ module internal BindingData =
         { Get = f >> d.Get
           Set = binaryHelper d.Set
           SubModelSeqBindingName = d.SubModelSeqBindingName
-          WrapDispatch = d.WrapDispatch
         } |> SubModelSelectedItemData
 
 
@@ -297,7 +274,7 @@ module internal Helpers =
 
   let boxBinding (binding: Binding<'a, 'b>) : Binding<obj, obj> =
     { Name = binding.Name
-      Data = BindingData.boxMsg unbox box binding.Data }
+      Data = BindingData.boxMsg box binding.Data }
     |> Binding.mapModel unbox
 
 
@@ -503,19 +480,13 @@ type Binding private () =
   /// <summary>Creates a two-way binding.</summary>
   /// <param name="get">Gets the value from the model.</param>
   /// <param name="set">Returns the message to dispatch.</param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member twoWay
       (get: 'model -> 'a,
-       set: 'a -> 'model -> 'msg,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       set: 'a -> 'model -> 'msg)
       : string -> Binding<'model, 'msg> =
     TwoWayData {
       Get = get >> box
       Set = unbox<'a> >> set
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -526,19 +497,13 @@ type Binding private () =
   /// </summary>
   /// <param name="get">Gets the value from the model.</param>
   /// <param name="set">Returns the message to dispatch.</param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member twoWayOpt
       (get: 'model -> 'a option,
-       set: 'a option -> 'model -> 'msg,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       set: 'a option -> 'model -> 'msg)
       : string -> Binding<'model, 'msg> =
     TwoWayData {
       Get = get >> Option.map box >> Option.toObj
       Set = Option.ofObj >> Option.map unbox<'a> >> set
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -549,19 +514,13 @@ type Binding private () =
   /// </summary>
   /// <param name="get">Gets the value from the model.</param>
   /// <param name="set">Returns the message to dispatch.</param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member twoWayOpt
       (get: 'model -> 'a voption,
-       set: 'a voption -> 'model -> 'msg,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       set: 'a voption -> 'model -> 'msg)
       : string -> Binding<'model, 'msg> =
     TwoWayData {
       Get = get >> ValueOption.map box >> ValueOption.toObj
       Set = ValueOption.ofObj >> ValueOption.map unbox<'a> >> set
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -574,21 +533,15 @@ type Binding private () =
   /// <param name="validate">
   ///   Returns the validation message from the updated model.
   /// </param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member twoWayValidate
       (get: 'model -> 'a,
        set: 'a -> 'model -> 'msg,
-       validate: 'model -> string voption,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       validate: 'model -> string voption)
       : string -> Binding<'model, 'msg> =
     TwoWayValidateData {
       Get = get >> box
       Set = unbox<'a> >> set
       Validate = validate
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -601,21 +554,15 @@ type Binding private () =
   /// <param name="validate">
   ///   Returns the validation message from the updated model.
   /// </param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member twoWayValidate
       (get: 'model -> 'a,
        set: 'a -> 'model -> 'msg,
-       validate: 'model -> string option,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       validate: 'model -> string option)
       : string -> Binding<'model, 'msg> =
     TwoWayValidateData {
       Get = get >> box
       Set = unbox<'a> >> set
       Validate = validate >> ValueOption.ofOption
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -628,21 +575,15 @@ type Binding private () =
   /// <param name="validate">
   ///   Returns the validation message from the updated model.
   /// </param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member twoWayValidate
       (get: 'model -> 'a,
        set: 'a -> 'model -> 'msg,
-       validate: 'model -> Result<'ignored, string>,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       validate: 'model -> Result<'ignored, string>)
       : string -> Binding<'model, 'msg> =
     TwoWayValidateData {
       Get = get >> box
       Set = unbox<'a> >> set
       Validate = validate >> ValueOption.ofError
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -657,21 +598,15 @@ type Binding private () =
   /// <param name="validate">
   ///   Returns the validation message from the updated model.
   /// </param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member twoWayOptValidate
       (get: 'model -> 'a voption,
        set: 'a voption -> 'model -> 'msg,
-       validate: 'model -> string voption,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       validate: 'model -> string voption)
       : string -> Binding<'model, 'msg> =
     TwoWayValidateData {
       Get = get >> ValueOption.map box >> ValueOption.toObj
       Set = ValueOption.ofObj >> ValueOption.map unbox<'a> >> set
       Validate = validate
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -686,21 +621,15 @@ type Binding private () =
   /// <param name="validate">
   ///   Returns the validation message from the updated model.
   /// </param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member twoWayOptValidate
       (get: 'model -> 'a voption,
        set: 'a voption -> 'model -> 'msg,
-       validate: 'model -> string option,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       validate: 'model -> string option)
       : string -> Binding<'model, 'msg> =
     TwoWayValidateData {
       Get = get >> ValueOption.map box >> ValueOption.toObj
       Set = ValueOption.ofObj >> ValueOption.map unbox<'a> >> set
       Validate = validate >> ValueOption.ofOption
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -715,21 +644,15 @@ type Binding private () =
   /// <param name="validate">
   ///   Returns the validation message from the updated model.
   /// </param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member twoWayOptValidate
       (get: 'model -> 'a voption,
        set: 'a voption -> 'model -> 'msg,
-       validate: 'model -> Result<'ignored, string>,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       validate: 'model -> Result<'ignored, string>)
       : string -> Binding<'model, 'msg> =
     TwoWayValidateData {
       Get = get >> ValueOption.map box >> ValueOption.toObj
       Set = ValueOption.ofObj >> ValueOption.map unbox<'a> >> set
       Validate = validate >> ValueOption.ofError
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -744,21 +667,15 @@ type Binding private () =
   /// <param name="validate">
   ///   Returns the validation message from the updated model.
   /// </param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member twoWayOptValidate
       (get: 'model -> 'a option,
        set: 'a option -> 'model -> 'msg,
-       validate: 'model -> string voption,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       validate: 'model -> string voption)
       : string -> Binding<'model, 'msg> =
     TwoWayValidateData {
       Get = get >> Option.map box >> Option.toObj
       Set = Option.ofObj >> Option.map unbox<'a> >> set
       Validate = validate
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -773,21 +690,15 @@ type Binding private () =
   /// <param name="validate">
   ///   Returns the validation message from the updated model.
   /// </param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member twoWayOptValidate
       (get: 'model -> 'a option,
        set: 'a option -> 'model -> 'msg,
-       validate: 'model -> string option,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       validate: 'model -> string option)
       : string -> Binding<'model, 'msg> =
     TwoWayValidateData {
       Get = get >> Option.map box >> Option.toObj
       Set = Option.ofObj >> Option.map unbox<'a> >> set
       Validate = validate >> ValueOption.ofOption
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -802,21 +713,15 @@ type Binding private () =
   /// <param name="validate">
   ///   Returns the validation message from the updated model.
   /// </param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member twoWayOptValidate
       (get: 'model -> 'a option,
        set: 'a option -> 'model -> 'msg,
-       validate: 'model -> Result<'ignored, string>,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       validate: 'model -> Result<'ignored, string>)
       : string -> Binding<'model, 'msg> =
     TwoWayValidateData {
       Get = get >> Option.map box >> Option.toObj
       Set = Option.ofObj >> Option.map unbox<'a> >> set
       Validate = validate >> ValueOption.ofError
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -825,18 +730,12 @@ type Binding private () =
   ///   <c>CommandParameter</c>) and can always execute.
   /// </summary>
   /// <param name="exec">Returns the message to dispatch.</param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member cmd
-      (exec: 'model -> 'msg,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      (exec: 'model -> 'msg)
       : string -> Binding<'model, 'msg> =
     CmdData {
       Exec = exec >> ValueSome
       CanExec = fun _ -> true
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -848,19 +747,13 @@ type Binding private () =
   /// </summary>
   /// <param name="exec">Returns the message to dispatch.</param>
   /// <param name="canExec">Indicates whether the command can execute.</param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member cmdIf
       (exec: 'model -> 'msg,
-       canExec: 'model -> bool,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       canExec: 'model -> bool)
       : string -> Binding<'model, 'msg> =
     CmdData {
       Exec = exec >> ValueSome
       CanExec = canExec
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -871,18 +764,12 @@ type Binding private () =
   ///   returns <c>ValueSome</c>.
   /// </summary>
   /// <param name="exec">Returns the message to dispatch.</param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member cmdIf
-      (exec: 'model -> 'msg voption,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      (exec: 'model -> 'msg voption)
       : string -> Binding<'model, 'msg> =
     CmdData {
       Exec = exec
       CanExec = exec >> ValueOption.isSome
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -893,18 +780,12 @@ type Binding private () =
   ///   returns <c>Some</c>.
   /// </summary>
   /// <param name="exec">Returns the message to dispatch.</param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member cmdIf
-      (exec: 'model -> 'msg option,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      (exec: 'model -> 'msg option)
       : string -> Binding<'model, 'msg> =
     CmdData {
       Exec = exec >> ValueOption.ofOption
       CanExec = exec >> Option.isSome
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -918,18 +799,12 @@ type Binding private () =
   ///   for inputs and commands.
   /// </summary>
   /// <param name="exec">Returns the message to dispatch.</param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member cmdIf
-      (exec: 'model -> Result<'msg, 'ignored>,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      (exec: 'model -> Result<'msg, 'ignored>)
       : string -> Binding<'model, 'msg> =
     CmdData {
       Exec = exec >> ValueOption.ofOk
       CanExec = exec >> Result.isOk
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -939,19 +814,13 @@ type Binding private () =
   ///   and can always execute.
   /// </summary>
   /// <param name="exec">Returns the message to dispatch.</param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member cmdParam
-      (exec: obj -> 'model -> 'msg,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      (exec: obj -> 'model -> 'msg)
       : string -> Binding<'model, 'msg> =
     CmdParamData {
       Exec = fun p model -> exec p model |> ValueSome
       CanExec = fun _ _ -> true
       AutoRequery = false
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -970,21 +839,15 @@ type Binding private () =
   ///   necessary, but is needed if you have bound the <c>CommandParameter</c>
   ///   to another UI property.
   /// </param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member cmdParamIf
       (exec: obj -> 'model -> 'msg,
        canExec: obj -> 'model -> bool,
-       ?uiBoundCmdParam: bool,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       ?uiBoundCmdParam: bool)
       : string -> Binding<'model, 'msg> =
     CmdParamData {
       Exec = fun p m -> exec p m |> ValueSome
       CanExec = canExec
       AutoRequery = defaultArg uiBoundCmdParam false
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -1002,20 +865,14 @@ type Binding private () =
   ///   necessary, but is needed if you have bound the <c>CommandParameter</c>
   ///   to another UI property.
   /// </param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member cmdParamIf
       (exec: obj -> 'model -> 'msg voption,
-       ?uiBoundCmdParam: bool,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       ?uiBoundCmdParam: bool)
       : string -> Binding<'model, 'msg> =
     CmdParamData {
       Exec = exec
       CanExec = fun p m -> exec p m |> ValueOption.isSome
       AutoRequery = defaultArg uiBoundCmdParam false
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -1033,20 +890,14 @@ type Binding private () =
   ///   necessary, but is needed if you have bound the <c>CommandParameter</c>
   ///   to another UI property.
   /// </param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member cmdParamIf
       (exec: obj -> 'model -> 'msg option,
-       ?uiBoundCmdParam: bool,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       ?uiBoundCmdParam: bool)
       : string -> Binding<'model, 'msg> =
     CmdParamData {
       Exec = fun p m -> exec p m |> ValueOption.ofOption
       CanExec = fun p m -> exec p m |> Option.isSome
       AutoRequery = defaultArg uiBoundCmdParam false
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -1067,20 +918,14 @@ type Binding private () =
   ///   necessary, but is needed if you have bound the <c>CommandParameter</c>
   ///   to another UI property.
   /// </param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member cmdParamIf
       (exec: obj -> 'model -> Result<'msg, 'ignored>,
-       ?uiBoundCmdParam: bool,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       ?uiBoundCmdParam: bool)
       : string -> Binding<'model, 'msg> =
     CmdParamData {
       Exec = fun p m -> exec p m |> ValueOption.ofOk
       CanExec = fun p m -> exec p m |> Result.isOk
       AutoRequery = defaultArg uiBoundCmdParam false
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -1831,21 +1676,15 @@ type Binding private () =
   /// <param name="set">
   ///   Returns the message to dispatch on selections/de-selections.
   /// </param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member subModelSelectedItem
       (subModelSeqBindingName: string,
        get: 'model -> 'id voption,
-       set: 'id voption -> 'model -> 'msg,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       set: 'id voption -> 'model -> 'msg)
       : string -> Binding<'model, 'msg> =
     SubModelSelectedItemData {
       Get = get >> ValueOption.map box
       Set = ValueOption.map unbox<'id> >> set
       SubModelSeqBindingName = subModelSeqBindingName
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -1875,21 +1714,15 @@ type Binding private () =
   /// <param name="set">
   ///   Returns the message to dispatch on selections/de-selections.
   /// </param>
-  /// <param name="wrapDispatch">
-  ///   Wraps the dispatch function with additional behavior, such as
-  ///   throttling, debouncing, or limiting.
-  /// </param>
   static member subModelSelectedItem
       (subModelSeqBindingName: string,
        get: 'model -> 'id option,
-       set: 'id option -> 'model -> 'msg,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       set: 'id option -> 'model -> 'msg)
       : string -> Binding<'model, 'msg> =
     SubModelSelectedItemData {
       Get = get >> ValueOption.ofOption >> ValueOption.map box
       Set = ValueOption.map unbox<'id> >> ValueOption.toOption >> set
       SubModelSeqBindingName = subModelSeqBindingName
-      WrapDispatch = defaultArg wrapDispatch id
     } |> createBinding
 
 
@@ -1903,19 +1736,13 @@ module Extensions =
     /// <summary>Creates a two-way binding.</summary>
     /// <param name="get">Gets the value from the model.</param>
     /// <param name="set">Returns the message to dispatch.</param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member twoWay
         (get: 'model -> 'a,
-         set: 'a -> 'msg,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+         set: 'a -> 'msg)
         : string -> Binding<'model, 'msg> =
       TwoWayData {
         Get = get >> box
         Set = fun p _ -> p |> unbox<'a> |> set
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -1926,19 +1753,13 @@ module Extensions =
     /// </summary>
     /// <param name="get">Gets the value from the model.</param>
     /// <param name="set">Returns the message to dispatch.</param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member twoWayOpt
         (get: 'model -> 'a option,
-         set: 'a option -> 'msg,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+         set: 'a option -> 'msg)
         : string -> Binding<'model, 'msg> =
       TwoWayData {
         Get = get >> Option.map box >> Option.toObj
         Set = fun p _ -> p |> Option.ofObj |> Option.map unbox<'a> |> set
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -1949,19 +1770,13 @@ module Extensions =
     /// </summary>
     /// <param name="get">Gets the value from the model.</param>
     /// <param name="set">Returns the message to dispatch.</param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member twoWayOpt
         (get: 'model -> 'a voption,
-         set: 'a voption -> 'msg,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+         set: 'a voption -> 'msg)
         : string -> Binding<'model, 'msg> =
       TwoWayData {
         Get = get >> ValueOption.map box >> ValueOption.toObj
         Set = fun p _ -> p |> ValueOption.ofObj |> ValueOption.map unbox<'a> |> set
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -1974,21 +1789,15 @@ module Extensions =
     /// <param name="validate">
     ///   Returns the validation message from the updated model.
     /// </param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member twoWayValidate
         (get: 'model -> 'a,
          set: 'a -> 'msg,
-         validate: 'model -> string voption,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+         validate: 'model -> string voption)
         : string -> Binding<'model, 'msg> =
       TwoWayValidateData {
         Get = get >> box
         Set = fun p _ -> p |> unbox<'a> |> set
         Validate = validate
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -2001,21 +1810,15 @@ module Extensions =
     /// <param name="validate">
     ///   Returns the validation message from the updated model.
     /// </param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member twoWayValidate
         (get: 'model -> 'a,
          set: 'a -> 'msg,
-         validate: 'model -> string option,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+         validate: 'model -> string option)
         : string -> Binding<'model, 'msg> =
       TwoWayValidateData {
         Get = get >> box
         Set = fun p  _ -> p |> unbox<'a> |> set
         Validate = validate >> ValueOption.ofOption
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -2028,21 +1831,15 @@ module Extensions =
     /// <param name="validate">
     ///   Returns the validation message from the updated model.
     /// </param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member twoWayValidate
         (get: 'model -> 'a,
          set: 'a -> 'msg,
-         validate: 'model -> Result<'ignored, string>,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+         validate: 'model -> Result<'ignored, string>)
         : string -> Binding<'model, 'msg> =
       TwoWayValidateData {
         Get = get >> box
         Set = fun p _ -> p |> unbox<'a> |> set
         Validate = validate >> ValueOption.ofError
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -2057,21 +1854,15 @@ module Extensions =
     /// <param name="validate">
     ///   Returns the validation message from the updated model.
     /// </param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member twoWayOptValidate
         (get: 'model -> 'a voption,
          set: 'a voption -> 'msg,
-         validate: 'model -> string voption,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+         validate: 'model -> string voption)
         : string -> Binding<'model, 'msg> =
       TwoWayValidateData {
         Get = get >> ValueOption.map box >> ValueOption.toObj
         Set = fun p _ -> p |> ValueOption.ofObj |> ValueOption.map unbox<'a> |> set
         Validate = validate
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -2086,21 +1877,15 @@ module Extensions =
     /// <param name="validate">
     ///   Returns the validation message from the updated model.
     /// </param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member twoWayOptValidate
         (get: 'model -> 'a voption,
          set: 'a voption -> 'msg,
-         validate: 'model -> string option,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+         validate: 'model -> string option)
         : string -> Binding<'model, 'msg> =
       TwoWayValidateData {
         Get = get >> ValueOption.map box >> ValueOption.toObj
         Set = fun p _ -> p |> ValueOption.ofObj |> ValueOption.map unbox<'a> |> set
         Validate = validate >> ValueOption.ofOption
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -2115,21 +1900,15 @@ module Extensions =
     /// <param name="validate">
     ///   Returns the validation message from the updated model.
     /// </param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member twoWayOptValidate
         (get: 'model -> 'a voption,
          set: 'a voption -> 'msg,
-         validate: 'model -> Result<'ignored, string>,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+         validate: 'model -> Result<'ignored, string>)
         : string -> Binding<'model, 'msg> =
       TwoWayValidateData {
         Get = get >> ValueOption.map box >> ValueOption.toObj
         Set = fun p _ -> p |> ValueOption.ofObj |> ValueOption.map unbox<'a> |> set
         Validate = validate >> ValueOption.ofError
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -2144,21 +1923,15 @@ module Extensions =
     /// <param name="validate">
     ///   Returns the validation message from the updated model.
     /// </param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member twoWayOptValidate
         (get: 'model -> 'a option,
          set: 'a option -> 'msg,
-         validate: 'model -> string voption,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+         validate: 'model -> string voption)
         : string -> Binding<'model, 'msg> =
       TwoWayValidateData {
         Get = get >> Option.map box >> Option.toObj
         Set = fun p _ -> p |> Option.ofObj |> Option.map unbox<'a> |> set
         Validate = validate
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -2173,21 +1946,15 @@ module Extensions =
     /// <param name="validate">
     ///   Returns the validation message from the updated model.
     /// </param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member twoWayOptValidate
         (get: 'model -> 'a option,
          set: 'a option -> 'msg,
-         validate: 'model -> string option,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+         validate: 'model -> string option)
         : string -> Binding<'model, 'msg> =
       TwoWayValidateData {
         Get = get >> Option.map box >> Option.toObj
         Set = fun p _ -> p |> Option.ofObj |> Option.map unbox<'a> |> set
         Validate = validate >> ValueOption.ofOption
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -2202,21 +1969,15 @@ module Extensions =
     /// <param name="validate">
     ///   Returns the validation message from the updated model.
     /// </param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member twoWayOptValidate
         (get: 'model -> 'a option,
          set: 'a option -> 'msg,
-         validate: 'model -> Result<'ignored, string>,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+         validate: 'model -> Result<'ignored, string>)
         : string -> Binding<'model, 'msg> =
       TwoWayValidateData {
         Get = get >> Option.map box >> Option.toObj
         Set = fun p _ -> p |> Option.ofObj |> Option.map unbox<'a> |> set
         Validate = validate >> ValueOption.ofError
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -2225,18 +1986,12 @@ module Extensions =
     ///   and can always execute.
     /// </summary>
     /// <param name="exec">Returns the message to dispatch.</param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member cmd
-        (exec: 'msg,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        (exec: 'msg)
         : string -> Binding<'model, 'msg> =
       CmdData {
         Exec = fun _ -> exec |> ValueSome
         CanExec = fun _ -> true
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -2246,19 +2001,13 @@ module Extensions =
     /// </summary>
     /// <param name="exec">Returns the message to dispatch.</param>
     /// <param name="canExec">Indicates whether the command can execute.</param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member cmdIf
         (exec: 'msg,
-         canExec: 'model -> bool,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+         canExec: 'model -> bool)
         : string -> Binding<'model, 'msg> =
       CmdData {
         Exec = fun _ -> exec |> ValueSome
         CanExec = canExec
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -2268,19 +2017,13 @@ module Extensions =
     ///   and can always execute.
     /// </summary>
     /// <param name="exec">Returns the message to dispatch.</param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member cmdParam
-        (exec: obj -> 'msg,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        (exec: obj -> 'msg)
         : string -> Binding<'model, 'msg> =
       CmdParamData {
         Exec = fun p _ -> exec p |> ValueSome
         CanExec = fun _ _ -> true
         AutoRequery = false
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -2298,20 +2041,14 @@ module Extensions =
     ///   necessary, but is needed if you have bound the <c>CommandParameter</c>
     ///   to another UI property.
     /// </param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member cmdParamIf
         (exec: obj -> 'msg voption,
-         ?uiBoundCmdParam: bool,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+         ?uiBoundCmdParam: bool)
         : string -> Binding<'model, 'msg> =
       CmdParamData {
         Exec = fun p _ -> exec p
         CanExec = fun p _ -> exec p |> ValueOption.isSome
         AutoRequery = defaultArg uiBoundCmdParam false
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -2329,20 +2066,14 @@ module Extensions =
     ///   necessary, but is needed if you have bound the <c>CommandParameter</c>
     ///   to another UI property.
     /// </param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member cmdParamIf
         (exec: obj -> 'msg option,
-         ?uiBoundCmdParam: bool,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+         ?uiBoundCmdParam: bool)
         : string -> Binding<'model, 'msg> =
       CmdParamData {
         Exec = fun p _ -> exec p |> ValueOption.ofOption
         CanExec = fun p _ -> exec p |> Option.isSome
         AutoRequery = defaultArg uiBoundCmdParam false
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -2363,20 +2094,14 @@ module Extensions =
     ///   necessary, but is needed if you have bound the <c>CommandParameter</c>
     ///   to another UI property.
     /// </param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member cmdParamIf
         (exec: obj -> Result<'msg, 'ignored>,
-         ?uiBoundCmdParam: bool,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+         ?uiBoundCmdParam: bool)
         : string -> Binding<'model, 'msg> =
       CmdParamData {
         Exec = fun p _ -> exec p |> ValueOption.ofOk
         CanExec = fun p _ -> exec p |> Result.isOk
         AutoRequery = defaultArg uiBoundCmdParam false
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -2395,21 +2120,15 @@ module Extensions =
     ///   necessary, but is needed if you have bound the <c>CommandParameter</c>
     ///   to another UI property.
     /// </param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member cmdParamIf
         (exec: obj -> 'msg,
          canExec: obj -> bool,
-         ?uiBoundCmdParam: bool,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+         ?uiBoundCmdParam: bool)
         : string -> Binding<'model, 'msg> =
       CmdParamData {
         Exec = fun p _ -> exec p |> ValueSome
         CanExec = fun p _ -> canExec p
         AutoRequery = defaultArg uiBoundCmdParam false
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -2440,21 +2159,15 @@ module Extensions =
     /// <param name="set">
     ///   Returns the message to dispatch on selections/de-selections.
     /// </param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member subModelSelectedItem
         (subModelSeqBindingName: string,
          get: 'model -> 'id voption,
-         set: 'id voption -> 'msg,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+         set: 'id voption -> 'msg)
         : string -> Binding<'model, 'msg> =
       SubModelSelectedItemData {
         Get = get >> ValueOption.map box
         Set = fun id _ -> id |> ValueOption.map unbox<'id> |> set
         SubModelSeqBindingName = subModelSeqBindingName
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 
@@ -2485,21 +2198,15 @@ module Extensions =
     /// <param name="set">
     ///   Returns the message to dispatch on selections/de-selections.
     /// </param>
-    /// <param name="wrapDispatch">
-    ///   Wraps the dispatch function with additional behavior, such as
-    ///   throttling, debouncing, or limiting.
-    /// </param>
     static member subModelSelectedItem
         (subModelSeqBindingName: string,
          get: 'model -> 'id option,
-         set: 'id option -> 'msg,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+         set: 'id option -> 'msg)
         : string -> Binding<'model, 'msg> =
       SubModelSelectedItemData {
         Get = get >> ValueOption.ofOption >> ValueOption.map box
         Set = fun id _ -> id |> ValueOption.map unbox<'id> |> ValueOption.toOption |> set
         SubModelSeqBindingName = subModelSeqBindingName
-        WrapDispatch = defaultArg wrapDispatch id
       } |> createBinding
 
 

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -465,22 +465,19 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
           Values = values }
     | TwoWayData d ->
         let set = measure2 name "set" d.Set
-        let dispatch' = d.WrapDispatch dispatch
         Some <| TwoWay {
           Get = measure name "get" d.Get
-          Set = fun obj m -> set obj m |> dispatch' }
+          Set = fun obj m -> set obj m |> dispatch }
     | TwoWayValidateData d ->
         let set = measure2 name "set" d.Set
-        let dispatch' = d.WrapDispatch dispatch
         Some <| TwoWayValidate {
           Get = measure name "get" d.Get
-          Set = fun obj m -> set obj m |> dispatch'
+          Set = fun obj m -> set obj m |> dispatch
           Validate = measure name "validate" d.Validate }
     | CmdData d ->
         let exec = measure name "exec" d.Exec
         let canExec = measure name "canExec" d.CanExec
-        let dispatch' = d.WrapDispatch dispatch
-        let execute _ = exec currentModel |> ValueOption.iter dispatch'
+        let execute _ = exec currentModel |> ValueOption.iter dispatch
         let canExecute _ = canExec currentModel
         Some <| Cmd {
           Cmd = Command(execute, canExecute, false)
@@ -488,8 +485,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
     | CmdParamData d ->
         let exec = measure2 name "exec" d.Exec
         let canExec = measure2 name "canExec" d.CanExec
-        let dispatch' = d.WrapDispatch dispatch
-        let execute param = exec param currentModel |> ValueOption.iter dispatch'
+        let execute param = exec param currentModel |> ValueOption.iter dispatch
         let canExecute param = canExec param currentModel
         Some <| CmdParam (Command(execute, canExecute, d.AutoRequery))
     | SubModelData d ->
@@ -594,10 +590,9 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
         | Some (SubModelSeq b) ->
           let get = measure name "get" d.Get
           let set = measure2 name "set" d.Set
-          let dispatch' = d.WrapDispatch dispatch
           SubModelSelectedItem {
             Get = get
-            Set = fun obj m -> set obj m |> dispatch'
+            Set = fun obj m -> set obj m |> dispatch
             SubModelSeqBinding = b
           } |> withCaching |> Some
         | _ ->

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -283,7 +283,7 @@ and internal SubModelWinBinding<'model, 'msg, 'bindingModel, 'bindingMsg> = {
   ToMsg: 'bindingMsg -> 'msg
   GetWindow: 'model -> Dispatch<'msg> -> Window
   IsModal: bool
-  OnCloseRequested: unit -> unit
+  OnCloseRequested: 'model -> unit
   WinRef: WeakReference<Window>
   PreventClose: bool ref
   VmWinState: WindowState<ViewModel<'bindingModel, 'bindingMsg>> ref
@@ -415,7 +415,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
       (getWindow: 'model -> Dispatch<'msg> -> Window)
       dataContext
       isDialog
-      (onCloseRequested: unit -> unit)
+      (onCloseRequested: 'model -> unit)
       (preventClose: bool ref)
       initialVisibility =
     let win = getWindow currentModel dispatch
@@ -428,7 +428,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
           ev.Cancel <- !preventClose
           async {
             do! Async.SwitchToThreadPool()
-            onCloseRequested ()
+            onCloseRequested currentModel
           } |> Async.StartImmediate
         )
         do! Async.SwitchToContext guiCtx
@@ -513,7 +513,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
         let getState = measure name "getState" d.GetState
         let getBindings = measure name "bindings" d.GetBindings
         let toMsg = measure name "toMsg" d.ToMsg
-        let onCloseRequested = fun () -> d.OnCloseRequested |> ValueOption.iter dispatch
+        let onCloseRequested = fun m -> m |> d.OnCloseRequested |> ValueOption.iter dispatch
         match getState initialModel with
         | WindowState.Closed ->
             Some <| SubModelWin {

--- a/src/Samples/SubModelSeq.Views/Counter.xaml
+++ b/src/Samples/SubModelSeq.Views/Counter.xaml
@@ -1,6 +1,11 @@
 ﻿<UserControl x:Class="Elmish.WPF.Samples.SubModelSeq.Counter"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelSeq;assembly=SubModelSeq"
+             mc:Ignorable="d"
+             d:DataContext="{x:Static vm:Program.counterDesignVm}">
   <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top">
     <TextBlock Text="{Binding CounterValue, StringFormat='Counter value: {0}'}" Width="110" Margin="0,5,10,5" />
     <Button Command="{Binding Decrement}" Content="-" Margin="0,5,10,5" Width="30" />

--- a/src/Samples/SubModelSeq/Program.fs
+++ b/src/Samples/SubModelSeq/Program.fs
@@ -261,6 +261,7 @@ module Bindings =
     "AddCounter" |> Binding.cmd(fun m -> AddChild m.DummyRoot.Data.Id)
   ]
 
+let counterDesignVm = ViewModel.designInstance Counter.init (Counter.bindings ())
 let mainDesignVm = ViewModel.designInstance (App.init ()) (Bindings.rootBindings ())
 
 let main window =


### PR DESCRIPTION
This is a repost as a draft PR of issue #242 since the ability to include specific comments in the corresponding branch is likely useful.  The original comment from that issue now follows in full.  The branch linked at the start of the second paragraph is now the branch in this PR.

---

I want the `SubModelSeq` sample to have more composable code.  In particular, I want the counter bindings to be defined with the rest of the counter code and then for those bindings to be "mapped" to higher-level bindings at the `App` level.

I am trying to achieve this in [this branch](https://github.com/bender2k14/Elmish.WPF/tree/improve_SubModelSeq_Composability).  Although I am trying to write really good code, I am not suggesting that necessarily merge in any of those commits as is.  The primary purpose of this branch is as a proof of concept.  I first want to get it working and then consider how to internally structure the code and what the external API should be.

Below, the function `Bindings.mapMsgWithModel` doesn't exist, but I have almost created it.  To get this far, ~the two important changes are~ one important change is removing the `wrapDispatch` feature (which I originally [requested](https://github.com/elmish/Elmish.WPF/issues/114), [contributed](https://github.com/elmish/Elmish.WPF/pull/118), and later [regretted](https://github.com/elmish/Elmish.WPF/pull/212)) ~and changed the type of the binding argument `OnCloseRequested` from (essentially) `'msg` to `'model -> 'msg`.  I am going to (independently) suggest this second change in a separate issue.~  (Edited: I did add issue #243 about changing the type of `OnCloseRequested`, but I realized that it is not important because it doesn't require a change to the public API.)

Tomorrow, I plan to continue trying to create `Bindings.mapMsgWithModel`.  A remaining difficulty is the `toMsg` binding arguments.  I currently don't expect to encounter any other difficulties.

Now to be more specific, I will compare what we have now to what I want.  For what we have now, I use the code in PR #241.

# Current Code

The counter code is...
```F#
type Counter =
  { Count: int
    StepSize: int }

type CounterMsg =
  | Increment
  | Decrement
  | SetStepSize of int
  | Reset

module Counter =

  let init =
    { Count = 0
      StepSize = 1 }
  
  let canReset = (<>) init
  
  let update msg m =
    match msg with
    | Increment -> { m with Count = m.Count + m.StepSize }
    | Decrement -> { m with Count = m.Count - m.StepSize }
    | SetStepSize x -> { m with StepSize = x }
    | Reset -> init
```

...which lacks bindings while the recursive bindings are

```F#
let rec counterBindings () : Binding<Model * Identifiable<Counter>, Msg> list = [
  "CounterIdText" |> Binding.oneWay(fun (_, c) -> c.Id)

  "CounterValue" |> Binding.oneWay(fun (_, c) -> c.Value.Count)
  "Increment" |> Binding.cmd(fun (_, c) -> CounterMsg (c.Id, Increment))
  "Decrement" |> Binding.cmd(fun (_, c) -> CounterMsg (c.Id, Decrement))
  "StepSize" |> Binding.twoWay(
    (fun (_, c) -> float c.Value.StepSize),
    (fun v (_, c) -> CounterMsg (c.Id, SetStepSize (int v))))
  "Reset" |> Binding.cmdIf(
    (fun (_, c) -> CounterMsg (c.Id, Reset)),
    (fun (_, c) -> Counter.canReset c.Value))

  "Remove" |> Binding.cmd(fun (_, c) -> Remove c.Id)

  "AddChild" |> Binding.cmd(fun (_, c) -> AddCounter c.Id)

  "MoveUp" |> Binding.cmdIf(
    (fun (_, c) -> MoveUp c.Id),
    (fun (m, c) -> m |> childrenCountersOfParentOf c.Id |> List.tryHead <> Some c))

  "MoveDown" |> Binding.cmdIf(
    (fun (_, c) -> MoveDown c.Id),
    (fun (m, c) -> m |> childrenCountersOfParentOf c.Id |> List.tryLast <> Some c))

  "GlobalState" |> Binding.oneWay(fun (m, _) -> m.SomeGlobalState)

  "ChildCounters" |> Binding.subModelSeq(
    (fun (m, c) -> m |> childrenCountersOf c.Id),
    (fun ((m, _), childCounter) -> (m, childCounter)),
    (fun (_, c) -> c.Id),
    snd,
    counterBindings)
]
```

# Desired Code

Instead, I want the counter bindings to be defined with the rest of the Counter code like they are in the `SingleCounter` sample, which would look like...

```F#
type Counter =
  { Count: int
    StepSize: int }

type CounterMsg =
  | Increment
  | Decrement
  | SetStepSize of int
  | Reset

module Counter =

  let init =
    { Count = 0
      StepSize = 1 }
  
  let canReset = (<>) init
  
  let update msg m =
    match msg with
    | Increment -> { m with Count = m.Count + m.StepSize }
    | Decrement -> { m with Count = m.Count - m.StepSize }
    | SetStepSize x -> { m with StepSize = x }
    | Reset -> init

  let bindings () : Binding<Counter, CounterMsg> list = [
    "CounterValue" |> Binding.oneWay (fun m -> m.Count)
    "Increment" |> Binding.cmd Increment
    "Decrement" |> Binding.cmd Decrement
    "StepSize" |> Binding.twoWay(
      (fun m -> float m.StepSize),
      int >> SetStepSize)
    "Reset" |> Binding.cmdIf(Reset, canReset)
]
```

...and then the recursive bindings would be defined something like this
```F#
let rec counterBindings () : Binding<Model * Identifiable<Counter>, Msg> list =
  Counter.bindings
  |> Bindings.mapModel (fun (_, c) -> c.Value)
  |> Bindings.mapMsgWithModel (fun (_, c) msg -> CounterMsg (c.Id, msg))
  |> List.append
    [
      "CounterIdText" |> Binding.oneWay(fun (_, c) -> c.Id)
    
      "Remove" |> Binding.cmd(fun (_, c) -> Remove c.Id)
    
      "AddChild" |> Binding.cmd(fun (_, c) -> AddCounter c.Id)
    
      "MoveUp" |> Binding.cmdIf(
        (fun (_, c) -> MoveUp c.Id),
        (fun (m, c) -> m |> childrenCountersOfParentOf c.Id |> List.tryHead <> Some c))
    
      "MoveDown" |> Binding.cmdIf(
        (fun (_, c) -> MoveDown c.Id),
        (fun (m, c) -> m |> childrenCountersOfParentOf c.Id |> List.tryLast <> Some c))
    
      "GlobalState" |> Binding.oneWay(fun (m, _) -> m.SomeGlobalState)
    
      "ChildCounters" |> Binding.subModelSeq(
        (fun (m, c) -> m |> childrenCountersOf c.Id),
        (fun ((m, _), childCounter) -> (m, childCounter)),
        (fun (_, c) -> c.Id),
        snd,
        counterBindings)
    ]
```