### PR TITLE
Also target .NET Core 3.0 in tests

### DIFF
--- a/src/Elmish.WPF.Tests/Elmish.WPF.Tests.fsproj
+++ b/src/Elmish.WPF.Tests/Elmish.WPF.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!--Turn on warnings for unused values (arguments and let bindings) -->
     <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>


### PR DESCRIPTION
Fixes #238 

Test project now also targets .NET Core 3.0.

I will complete this after I see the automated build succeed.