### PR TITLE
added design-time view models for all samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Then use the following attributes wherever you need a design-time VM:
 
 When targeting .NET Framework, “Project code” must be enabled in the XAML designer for this to work.
 
-When targeting .NET Core 3, the designer is buggy when it comes to design-time view models as used above. If you don’t get the data you expect, try to remove and re-add (e.g. undo) the `d:DataContext` line. That should make it work. You will have to do this as often as needed.
+When targeting .NET Core 3, a bug in the XAML designer causes design-time data to not be displayed through `DataContext` bindings.  See [this issue](https://developercommunity.visualstudio.com/content/problem/1133390/design-time-data-in-datacontext-binding-not-displa.html) for more details.
 
 #### Can I open new windows/dialogs?
 

--- a/src/Elmish.WPF.sln
+++ b/src/Elmish.WPF.sln
@@ -3,13 +3,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28803.352
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "SingleCounter", "Samples\SingleCounter\SingleCounter.fsproj", "{2DBB8062-2843-43A0-B73C-4777A30BD4FF}"
-EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Elmish.WPF", "Elmish.WPF\Elmish.WPF.fsproj", "{8C6E8D34-7205-4C57-9722-87E30E4FC5CE}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SingleCounter.Views", "Samples\SingleCounter.Views\SingleCounter.Views.csproj", "{55F79BA4-8265-4612-8354-D04F91BF9B03}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "SingleCounter", "Samples\SingleCounter\SingleCounter.fsproj", "{2DBB8062-2843-43A0-B73C-4777A30BD4FF}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Elmish.WPF", "Elmish.WPF\Elmish.WPF.fsproj", "{8C6E8D34-7205-4C57-9722-87E30E4FC5CE}"
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "UiBoundCmdParam", "Samples\UiBoundCmdParam\UiBoundCmdParam.fsproj", "{9581A1DE-70A6-4AC2-AF65-FD6E95F3A983}"
 EndProject

--- a/src/Samples/EventBindingsAndBehaviors.Views/EventBindingsAndBehaviors.Views.csproj
+++ b/src/Samples/EventBindingsAndBehaviors.Views/EventBindingsAndBehaviors.Views.csproj
@@ -2,11 +2,16 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <UseWpf>true</UseWpf>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EventBindingsAndBehaviors\EventBindingsAndBehaviors.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Samples/EventBindingsAndBehaviors.Views/MainWindow.xaml
+++ b/src/Samples/EventBindingsAndBehaviors.Views/MainWindow.xaml
@@ -1,12 +1,17 @@
 ﻿<Window x:Class="Elmish.WPF.Samples.EventBindingsAndBehaviors.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Elmish.WPF.Samples.EventBindingsAndBehaviors"
+        xmlns:vm="clr-namespace:Elmish.WPF.Samples.EventBindingsAndBehaviors;assembly=EventBindingsAndBehaviors"
         Title="EventBindings"
         Height="450"
         Width="400"
-        WindowStartupLocation="CenterScreen">
+        WindowStartupLocation="CenterScreen"
+        mc:Ignorable="d"
+        d:DataContext="{x:Static vm:Program.designVm}">
   <StackPanel Margin="15" HorizontalAlignment="Center">
     <TextBlock Text="Switch focus between these two inputs." Margin="0,0,0,10" TextAlignment="Center" />
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">

--- a/src/Samples/EventBindingsAndBehaviors.Views/Program.cs
+++ b/src/Samples/EventBindingsAndBehaviors.Views/Program.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Elmish.WPF.Samples.EventBindingsAndBehaviors;
+using static Elmish.WPF.Samples.EventBindingsAndBehaviors.Program;
+
+namespace EventBindingsAndBehaviors.Views {
+  public static class Program {
+    [STAThread]
+    public static void Main() =>
+      main(new MainWindow());
+  }
+}

--- a/src/Samples/EventBindingsAndBehaviors/EventBindingsAndBehaviors.fsproj
+++ b/src/Samples/EventBindingsAndBehaviors/EventBindingsAndBehaviors.fsproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -13,7 +12,6 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\Elmish.WPF\Elmish.WPF.fsproj" />
-    <ProjectReference Include="..\EventBindingsAndBehaviors.Views\EventBindingsAndBehaviors.Views.csproj" />
   </ItemGroup>
   
 </Project>

--- a/src/Samples/EventBindingsAndBehaviors/Program.fs
+++ b/src/Samples/EventBindingsAndBehaviors/Program.fs
@@ -1,6 +1,5 @@
 ﻿module Elmish.WPF.Samples.EventBindingsAndBehaviors.Program
 
-open System
 open Elmish
 open Elmish.WPF
 open System.Windows
@@ -67,11 +66,12 @@ let bindings () : Binding<Model, Msg> list = [
   "MousePosition" |> Binding.oneWay (fun m -> sprintf "%dx%d" m.MousePosition.X m.MousePosition.Y)
 ]
 
+let designVm = ViewModel.designInstance (init ()) (bindings ())
 
-[<EntryPoint; STAThread>]
-let main _ =
+
+let main window =
   Program.mkSimpleWpf init update bindings
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
      { ElmConfig.Default with LogConsole = true; Measure = true }
-     (MainWindow())
+     window

--- a/src/Samples/FileDialogs.CmdMsg.Views/FileDialogs.CmdMsg.Views.csproj
+++ b/src/Samples/FileDialogs.CmdMsg.Views/FileDialogs.CmdMsg.Views.csproj
@@ -2,7 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <UseWpf>true</UseWpf>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FileDialogs.CmdMsg\FileDialogs.CmdMsg.fsproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Samples/FileDialogs.CmdMsg.Views/MainWindow.xaml
+++ b/src/Samples/FileDialogs.CmdMsg.Views/MainWindow.xaml
@@ -1,10 +1,15 @@
 ﻿<Window x:Class="Elmish.WPF.Samples.FileDialogs.CmdMsg.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:Elmish.WPF.Samples.FileDialogs.CmdMsg;assembly=FileDialogs.CmdMsg"
         Title="File dialogs"
         Height="400"
         Width="500"
-        WindowStartupLocation="CenterScreen">
+        WindowStartupLocation="CenterScreen"
+        mc:Ignorable="d"
+        d:DataContext="{x:Static vm:Program.designVm}">
   <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,25,0,0">
     <StackPanel>
       <TextBox Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}" Width="200" Height="100" TextWrapping="Wrap" AcceptsReturn="True" Margin="0,5,10,5" />

--- a/src/Samples/FileDialogs.CmdMsg.Views/Program.cs
+++ b/src/Samples/FileDialogs.CmdMsg.Views/Program.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Elmish.WPF.Samples.FileDialogs.CmdMsg;
+using static Elmish.WPF.Samples.FileDialogs.CmdMsg.Program;
+
+namespace FileDialogs.CmdMsg.Views {
+  public static class Program {
+    [STAThread]
+    public static void Main() =>
+      main(new MainWindow());
+  }
+}

--- a/src/Samples/FileDialogs.CmdMsg/FileDialogs.CmdMsg.fsproj
+++ b/src/Samples/FileDialogs.CmdMsg/FileDialogs.CmdMsg.fsproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -13,7 +12,6 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\Elmish.WPF\Elmish.WPF.fsproj" />
-    <ProjectReference Include="..\FileDialogs.CmdMsg.Views\FileDialogs.CmdMsg.Views.csproj" />
   </ItemGroup>
   
 </Project>

--- a/src/Samples/FileDialogs.CmdMsg/Program.fs
+++ b/src/Samples/FileDialogs.CmdMsg/Program.fs
@@ -113,17 +113,19 @@ open Core
 open Platform
 
 
+let designVm = ViewModel.designInstance (init () |> fst) (bindings ())
+
+
 let timerTick dispatch =
   let timer = new Timers.Timer(1000.)
   timer.Elapsed.Add (fun _ -> dispatch (SetTime DateTimeOffset.Now))
   timer.Start()
 
 
-[<EntryPoint; STAThread>]
-let main _ =
+let main window =
   Program.mkProgramWpfWithCmdMsg init update bindings toCmd
   |> Program.withSubscription (fun _ -> Cmd.ofSub timerTick)
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
     { ElmConfig.Default with LogConsole = true; Measure = true }
-    (MainWindow())
+    window

--- a/src/Samples/FileDialogs.Views/FileDialogs.Views.csproj
+++ b/src/Samples/FileDialogs.Views/FileDialogs.Views.csproj
@@ -2,7 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <UseWpf>true</UseWpf>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FileDialogs\FileDialogs.fsproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Samples/FileDialogs.Views/MainWindow.xaml
+++ b/src/Samples/FileDialogs.Views/MainWindow.xaml
@@ -1,10 +1,15 @@
 ﻿<Window x:Class="Elmish.WPF.Samples.FileDialogs.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:Elmish.WPF.Samples.FileDialogs;assembly=FileDialogs"
         Title="File dialogs"
         Height="400"
         Width="500"
-        WindowStartupLocation="CenterScreen">
+        WindowStartupLocation="CenterScreen"
+        mc:Ignorable="d"
+        d:DataContext="{x:Static vm:Program.designVm}">
   <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,25,0,0">
     <StackPanel>
       <TextBox Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}" Width="200" Height="100" TextWrapping="Wrap" AcceptsReturn="True" Margin="0,5,10,5" />

--- a/src/Samples/FileDialogs.Views/Program.cs
+++ b/src/Samples/FileDialogs.Views/Program.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Elmish.WPF.Samples.FileDialogs;
+using static Elmish.WPF.Samples.FileDialogs.Program;
+
+namespace FileDialogs.Views {
+  public static class Program {
+    [STAThread]
+    public static void Main() =>
+      main(new MainWindow());
+  }
+}

--- a/src/Samples/FileDialogs/FileDialogs.fsproj
+++ b/src/Samples/FileDialogs/FileDialogs.fsproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -13,7 +12,6 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\Elmish.WPF\Elmish.WPF.fsproj" />
-    <ProjectReference Include="..\FileDialogs.Views\FileDialogs.Views.csproj" />
   </ItemGroup>
   
 </Project>

--- a/src/Samples/FileDialogs/Program.fs
+++ b/src/Samples/FileDialogs/Program.fs
@@ -1,4 +1,4 @@
-module Elmish.WPF.Samples.FileDialogs.Program
+﻿module Elmish.WPF.Samples.FileDialogs.Program
 
 open System
 open System.IO
@@ -12,12 +12,13 @@ type Model =
   { CurrentTime: DateTimeOffset
     Text: string
     StatusMsg: string }
-
+    
+        
 let init () =
   { CurrentTime = DateTimeOffset.Now
     Text = ""
     StatusMsg = "" },
-  Cmd.none
+  []
 
 type Msg =
   | SetTime of DateTimeOffset
@@ -88,17 +89,19 @@ let bindings () : Binding<Model, Msg> list = [
 ]
 
 
+let designVm = ViewModel.designInstance (init () |> fst) (bindings ())
+
+
 let timerTick dispatch =
   let timer = new Timers.Timer(1000.)
   timer.Elapsed.Add (fun _ -> dispatch (SetTime DateTimeOffset.Now))
   timer.Start()
 
 
-[<EntryPoint; STAThread>]
-let main _ =
+let main window =
   Program.mkProgramWpf init update bindings
   |> Program.withSubscription (fun _ -> Cmd.ofSub timerTick)
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
     { ElmConfig.Default with LogConsole = true; Measure = true }
-    (MainWindow())
+    window

--- a/src/Samples/NewWindow.Views/MainWindow.xaml
+++ b/src/Samples/NewWindow.Views/MainWindow.xaml
@@ -1,10 +1,15 @@
 ﻿<Window x:Class="Elmish.WPF.Samples.NewWindow.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:Elmish.WPF.Samples.NewWindow;assembly=NewWindow"
         Title="Multiple windows"
         Height="250"
         Width="300"
-        WindowStartupLocation="CenterScreen">
+        WindowStartupLocation="CenterScreen"
+        mc:Ignorable="d"
+        d:DataContext="{x:Static vm:Program.mainDesignVm}">
   <Window.Resources>
     <ResourceDictionary>
       <BooleanToVisibilityConverter x:Key="VisibilityConverter" />

--- a/src/Samples/NewWindow.Views/NewWindow.Views.csproj
+++ b/src/Samples/NewWindow.Views/NewWindow.Views.csproj
@@ -2,7 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <UseWpf>true</UseWpf>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NewWindow\NewWindow.fsproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Samples/NewWindow.Views/Program.cs
+++ b/src/Samples/NewWindow.Views/Program.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Elmish.WPF.Samples.NewWindow;
+using static Elmish.WPF.Samples.NewWindow.Program;
+
+namespace NewWindow.Views {
+  public static class Program {
+    [STAThread]
+    public static void Main() =>
+      main(new MainWindow(), () => new Window1(), () => new Window2());
+  }
+}

--- a/src/Samples/NewWindow.Views/Window1.xaml
+++ b/src/Samples/NewWindow.Views/Window1.xaml
@@ -1,9 +1,14 @@
 ﻿<Window x:Class="Elmish.WPF.Samples.NewWindow.Window1"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:Elmish.WPF.Samples.NewWindow;assembly=NewWindow"
         Width="400"
         Height="400"
-        Title="Window 1">
+        Title="Window 1"
+        mc:Ignorable="d"
+        d:DataContext="{x:Static vm:Program.window1DesignVm}">
   <StackPanel VerticalAlignment="Center" Width="300">
     <TextBlock
         TextWrapping="Wrap">

--- a/src/Samples/NewWindow.Views/Window2.xaml
+++ b/src/Samples/NewWindow.Views/Window2.xaml
@@ -1,9 +1,14 @@
 ﻿<Window x:Class="Elmish.WPF.Samples.NewWindow.Window2"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:Elmish.WPF.Samples.NewWindow;assembly=NewWindow"
         Width="500"
         Height="500"
-        Title="Window 2">
+        Title="Window 2"
+        mc:Ignorable="d"
+        d:DataContext="{x:Static vm:Program.window2DesignVm}">
   <Window.Resources>
     <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
   </Window.Resources>

--- a/src/Samples/NewWindow/NewWindow.fsproj
+++ b/src/Samples/NewWindow/NewWindow.fsproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -13,7 +12,6 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\Elmish.WPF\Elmish.WPF.fsproj" />
-    <ProjectReference Include="..\NewWindow.Views\NewWindow.Views.csproj" />
   </ItemGroup>
   
 </Project>

--- a/src/Samples/NewWindow/Program.fs
+++ b/src/Samples/NewWindow/Program.fs
@@ -1,4 +1,4 @@
-module Elmish.WPF.Samples.NewWindow.Program
+﻿module Elmish.WPF.Samples.NewWindow.Program
 
 open System
 open System.Windows
@@ -112,12 +112,21 @@ module App =
   ]
 
 
-[<EntryPoint; STAThread>]
-let main _ =
-  let createWindow2 () = Window2(Owner = Application.Current.MainWindow)
-  let bindings = App.mainBindings Window1 createWindow2
+let fail _ = failwith "never called"
+let mainDesignVm = ViewModel.designInstance (App.init ()) (App.mainBindings fail fail ())
+let window1DesignVm = ViewModel.designInstance (App.init ()) (App.window1Bindings ())
+let window2DesignVm = ViewModel.designInstance App.initWindow2 (App.window2Bindings ())
+
+
+let main mainWindow (createWindow1: Func<#Window>) (createWindow2: Func<#Window>) =
+  let createWindow1 () = createWindow1.Invoke()
+  let createWindow2 () =
+    let window = createWindow2.Invoke()
+    window.Owner <- mainWindow
+    window
+  let bindings = App.mainBindings createWindow1 createWindow2
   Program.mkSimpleWpf App.init App.update bindings
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
     { ElmConfig.Default with LogConsole = true; Measure = true }
-    (MainWindow())
+    mainWindow

--- a/src/Samples/OneWaySeq.Views/MainWindow.xaml
+++ b/src/Samples/OneWaySeq.Views/MainWindow.xaml
@@ -1,10 +1,15 @@
 ﻿<Window x:Class="Elmish.WPF.Samples.OneWaySeq.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:Elmish.WPF.Samples.OneWaySeq;assembly=OneWaySeq"
         Title="OneWaySeq"
         Height="400"
         Width="400"
-        WindowStartupLocation="CenterScreen">
+        WindowStartupLocation="CenterScreen"
+        mc:Ignorable="d"
+        d:DataContext="{x:Static vm:Program.designVm}">
   <StackPanel>
     <TextBlock
         Text="This sample shows the difference between Binding.oneWay and Binding.oneWaySeq. For oneWay, the whole ListView is re-rendered for every change. For oneWaySeq, only the new item is added."

--- a/src/Samples/OneWaySeq.Views/OneWaySeq.Views.csproj
+++ b/src/Samples/OneWaySeq.Views/OneWaySeq.Views.csproj
@@ -2,7 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <UseWpf>true</UseWpf>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OneWaySeq\OneWaySeq.fsproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Samples/OneWaySeq.Views/Program.cs
+++ b/src/Samples/OneWaySeq.Views/Program.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Elmish.WPF.Samples.OneWaySeq;
+using static Elmish.WPF.Samples.OneWaySeq.Program;
+
+namespace OneWaySeq.Views {
+  public static class Program {
+    [STAThread]
+    public static void Main() =>
+      main(new MainWindow());
+  }
+}

--- a/src/Samples/OneWaySeq/OneWaySeq.fsproj
+++ b/src/Samples/OneWaySeq/OneWaySeq.fsproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -13,7 +12,6 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\Elmish.WPF\Elmish.WPF.fsproj" />
-    <ProjectReference Include="..\OneWaySeq.Views\OneWaySeq.Views.csproj" />
   </ItemGroup>
   
 </Project>

--- a/src/Samples/OneWaySeq/Program.fs
+++ b/src/Samples/OneWaySeq/Program.fs
@@ -1,6 +1,5 @@
 ﻿module Elmish.WPF.Samples.OneWaySeq.Program
 
-open System
 open Elmish
 open Elmish.WPF
 
@@ -29,11 +28,11 @@ let bindings () : Binding<Model, Msg> list = [
   "AddOneWayNumber" |> Binding.cmd AddOneWayNumber
 ]
 
+let designVm = ViewModel.designInstance (init ()) (bindings ())
 
-[<EntryPoint; STAThread>]
-let main _ =
+let main window =
   Program.mkSimpleWpf init update bindings
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
     { ElmConfig.Default with LogConsole = true }
-    (MainWindow())
+    window

--- a/src/Samples/SingleCounter.Views/MainWindow.xaml
+++ b/src/Samples/SingleCounter.Views/MainWindow.xaml
@@ -1,10 +1,15 @@
 ﻿<Window x:Class="Elmish.WPF.Samples.SingleCounter.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:Elmish.WPF.Samples.SingleCounter;assembly=SingleCounter"
         Title="Single counter"
         Height="120"
         Width="500"
-        WindowStartupLocation="CenterScreen">
+        WindowStartupLocation="CenterScreen"
+        mc:Ignorable="d"
+        d:DataContext="{x:Static vm:Program.designVm}">
   <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,25,0,0">
     <TextBlock Text="{Binding CounterValue, StringFormat='Counter value: {0}'}" Width="110" Margin="0,5,10,5" />
     <Button Command="{Binding Decrement}" Content="-" Margin="0,5,10,5" Width="30" />

--- a/src/Samples/SingleCounter.Views/Program.cs
+++ b/src/Samples/SingleCounter.Views/Program.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Elmish.WPF.Samples.SingleCounter;
+using static Elmish.WPF.Samples.SingleCounter.Program;
+
+namespace SingleCounter.Views {
+  public static class Program {
+    [STAThread]
+    public static void Main() =>
+      main(new MainWindow());
+  }
+}

--- a/src/Samples/SingleCounter.Views/SingleCounter.Views.csproj
+++ b/src/Samples/SingleCounter.Views/SingleCounter.Views.csproj
@@ -2,7 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <UseWpf>true</UseWpf>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SingleCounter\SingleCounter.fsproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Samples/SingleCounter/Program.fs
+++ b/src/Samples/SingleCounter/Program.fs
@@ -1,6 +1,5 @@
 ﻿module Elmish.WPF.Samples.SingleCounter.Program
 
-open System
 open Elmish
 open Elmish.WPF
 
@@ -37,11 +36,12 @@ let bindings () : Binding<Model, Msg> list = [
   "Reset" |> Binding.cmdIf(Reset, canReset)
 ]
 
+let designVm = ViewModel.designInstance init (bindings ())
 
-[<EntryPoint; STAThread>]
-let main _ =
+
+let main window =
   Program.mkSimpleWpf (fun () -> init) update bindings
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
     { ElmConfig.Default with LogConsole = true; Measure = true }
-    (MainWindow())
+    window

--- a/src/Samples/SingleCounter/SingleCounter.fsproj
+++ b/src/Samples/SingleCounter/SingleCounter.fsproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -13,7 +12,6 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\Elmish.WPF\Elmish.WPF.fsproj" />
-    <ProjectReference Include="..\SingleCounter.Views\SingleCounter.Views.csproj" />
   </ItemGroup>
   
 </Project>

--- a/src/Samples/SubModel.Views/Clock.xaml
+++ b/src/Samples/SubModel.Views/Clock.xaml
@@ -1,6 +1,11 @@
 ﻿<UserControl x:Class="Elmish.WPF.Samples.SubModel.Clock"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModel;assembly=SubModel"
+             mc:Ignorable="d"
+             d:DataContext="{x:Static vm:Program.clockDesignVm}">
   <StackPanel Orientation="Horizontal">
     <TextBlock Text="{Binding Time, StringFormat='Today is {0:MMMM dd, yyyy}. The time is {0:HH:mm:ssK}. It is {0:dddd}.'}" />
     <Button Command="{Binding ToggleUtc}" Content="Toggle UTC" Margin="10,0,0,0" />

--- a/src/Samples/SubModel.Views/Counter.xaml
+++ b/src/Samples/SubModel.Views/Counter.xaml
@@ -1,6 +1,11 @@
 ﻿<UserControl x:Class="Elmish.WPF.Samples.SubModel.Counter"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModel;assembly=SubModel"
+             mc:Ignorable="d"
+             d:DataContext="{x:Static vm:Program.counterDesignVm}">
   <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top">
     <TextBlock Text="{Binding CounterValue, StringFormat='Counter value: {0}'}" Width="110" Margin="0,5,10,5" />
     <Button Command="{Binding Decrement}" Content="-" Margin="0,5,10,5" Width="30" />

--- a/src/Samples/SubModel.Views/CounterWithClock.xaml
+++ b/src/Samples/SubModel.Views/CounterWithClock.xaml
@@ -1,7 +1,12 @@
 ﻿<UserControl x:Class="Elmish.WPF.Samples.SubModel.CounterWithClock"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:Elmish.WPF.Samples.SubModel">
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:local="clr-namespace:Elmish.WPF.Samples.SubModel"
+             xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModel;assembly=SubModel"
+             mc:Ignorable="d"
+             d:DataContext="{x:Static vm:Program.counterWithClockDesignVm}">
   <StackPanel>
     <local:Counter DataContext="{Binding Counter}" HorizontalAlignment="Center" />
     <local:Clock DataContext="{Binding Clock}" HorizontalAlignment="Center" />

--- a/src/Samples/SubModel.Views/MainWindow.xaml
+++ b/src/Samples/SubModel.Views/MainWindow.xaml
@@ -1,11 +1,16 @@
 ﻿<Window x:Class="Elmish.WPF.Samples.SubModel.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Elmish.WPF.Samples.SubModel"
+        xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModel;assembly=SubModel"
         Title="Sub-model"
         Height="270"
         Width="500"
-        WindowStartupLocation="CenterScreen">
+        WindowStartupLocation="CenterScreen"
+        mc:Ignorable="d"
+        d:DataContext="{x:Static vm:Program.mainDesignVm}">
   <StackPanel>
     <TextBlock Text="Counter with clock 1" FontSize="18" FontWeight="Bold" Margin="0,25,0,0" HorizontalAlignment="Center" />
     <local:CounterWithClock DataContext="{Binding ClockCounter1}" />

--- a/src/Samples/SubModel.Views/Program.cs
+++ b/src/Samples/SubModel.Views/Program.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Elmish.WPF.Samples.SubModel;
+using static Elmish.WPF.Samples.SubModel.Program;
+
+namespace SubModel.Views {
+  public static class Program {
+    [STAThread]
+    public static void Main() =>
+      main(new MainWindow());
+  }
+}

--- a/src/Samples/SubModel.Views/SubModel.Views.csproj
+++ b/src/Samples/SubModel.Views/SubModel.Views.csproj
@@ -2,7 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <UseWpf>true</UseWpf>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SubModel\SubModel.fsproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Samples/SubModel/Program.fs
+++ b/src/Samples/SubModel/Program.fs
@@ -129,6 +129,12 @@ module App =
   ]
 
 
+let counterDesignVm = ViewModel.designInstance Counter.init (Counter.bindings ())
+let clockDesignVm = ViewModel.designInstance (Clock.init ()) (Clock.bindings ())
+let counterWithClockDesignVm = ViewModel.designInstance (CounterWithClock.init ()) (CounterWithClock.bindings ())
+let mainDesignVm = ViewModel.designInstance (App.init ()) (App.bindings ())
+
+
 let timerTick dispatch =
   let timer = new System.Timers.Timer(1000.)
   timer.Elapsed.Add (fun _ ->
@@ -142,11 +148,10 @@ let timerTick dispatch =
   timer.Start()
 
 
-[<EntryPoint; STAThread>]
-let main _ =
+let main window =
   Program.mkSimpleWpf App.init App.update App.bindings
   |> Program.withSubscription (fun _ -> Cmd.ofSub timerTick)
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
     { ElmConfig.Default with LogConsole = true; Measure = true }
-    (MainWindow())
+    window

--- a/src/Samples/SubModel/SubModel.fsproj
+++ b/src/Samples/SubModel/SubModel.fsproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -13,7 +12,6 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\Elmish.WPF\Elmish.WPF.fsproj" />
-    <ProjectReference Include="..\SubModel.Views\SubModel.Views.csproj" />
   </ItemGroup>
   
 </Project>

--- a/src/Samples/SubModelOpt.Views/Form1.xaml
+++ b/src/Samples/SubModelOpt.Views/Form1.xaml
@@ -1,7 +1,12 @@
 ﻿<UserControl x:Class="Elmish.WPF.Samples.SubModelOpt.Form1"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             Padding="10">
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelOpt;assembly=SubModelOpt"
+             Padding="10"
+             mc:Ignorable="d"
+             d:DataContext="{x:Static vm:Program.form1DesignVm}">
   <StackPanel Width="300">
     <TextBlock Text="Form 1" FontSize="18" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,5" />
     <TextBox Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}" TextWrapping="Wrap" AcceptsReturn="True" Height="80" Margin="0,5,0,5" />

--- a/src/Samples/SubModelOpt.Views/Form2.xaml
+++ b/src/Samples/SubModelOpt.Views/Form2.xaml
@@ -1,7 +1,12 @@
 ﻿<UserControl x:Class="Elmish.WPF.Samples.SubModelOpt.Form2"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             Padding="10">
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelOpt;assembly=SubModelOpt"
+             Padding="10"
+             mc:Ignorable="d"
+             d:DataContext="{x:Static vm:Program.form2DesignVm}">
   <StackPanel Width="300">
     <TextBlock Text="Form 2" FontSize="18" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,5" />
     <TextBox Text="{Binding Input1, UpdateSourceTrigger=PropertyChanged}" Margin="0,5,0,5" />

--- a/src/Samples/SubModelOpt.Views/MainWindow.xaml
+++ b/src/Samples/SubModelOpt.Views/MainWindow.xaml
@@ -1,11 +1,16 @@
 ﻿<Window x:Class="Elmish.WPF.Samples.SubModelOpt.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelOpt;assembly=SubModelOpt"
         xmlns:local="clr-namespace:Elmish.WPF.Samples.SubModelOpt"
         Title="Sub-model"
         Height="350"
         Width="500"
-        WindowStartupLocation="CenterScreen">
+        WindowStartupLocation="CenterScreen"
+        mc:Ignorable="d"
+        d:DataContext="{x:Static vm:Program.mainDesignVm}">
   <Window.Resources>
     <ResourceDictionary>
       <BooleanToVisibilityConverter x:Key="VisibilityConverter" />

--- a/src/Samples/SubModelOpt.Views/Program.cs
+++ b/src/Samples/SubModelOpt.Views/Program.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Elmish.WPF.Samples.SubModelOpt;
+using static Elmish.WPF.Samples.SubModelOpt.Program;
+
+namespace SubModelOpt.Views {
+  public static class Program {
+    [STAThread]
+    public static void Main() =>
+      main(new MainWindow());
+  }
+}

--- a/src/Samples/SubModelOpt.Views/SubModelOpt.Views.csproj
+++ b/src/Samples/SubModelOpt.Views/SubModelOpt.Views.csproj
@@ -2,7 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <UseWpf>true</UseWpf>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SubModelOpt\SubModelOpt.fsproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Samples/SubModelOpt/Program.fs
+++ b/src/Samples/SubModelOpt/Program.fs
@@ -1,6 +1,5 @@
 ﻿module Elmish.WPF.Samples.SubModelOpt.Program
 
-open System
 open Elmish
 open Elmish.WPF
 
@@ -116,10 +115,14 @@ module App =
   ]
 
 
-[<EntryPoint; STAThread>]
-let main _ =
+let form1DesignVm = ViewModel.designInstance Form1.init (Form1.bindings ())
+let form2DesignVm = ViewModel.designInstance Form2.init (Form2.bindings ())
+let mainDesignVm = ViewModel.designInstance (App.init ()) (App.bindings ())
+
+
+let main window =
   Program.mkSimpleWpf App.init App.update App.bindings
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
     { ElmConfig.Default with LogConsole = true; Measure = true }
-    (MainWindow())
+    window

--- a/src/Samples/SubModelOpt/SubModelOpt.fsproj
+++ b/src/Samples/SubModelOpt/SubModelOpt.fsproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -13,7 +12,6 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\Elmish.WPF\Elmish.WPF.fsproj" />
-    <ProjectReference Include="..\SubModelOpt.Views\SubModelOpt.Views.csproj" />
   </ItemGroup>
   
 </Project>

--- a/src/Samples/SubModelSelectedItem.Views/MainWindow.xaml
+++ b/src/Samples/SubModelSelectedItem.Views/MainWindow.xaml
@@ -1,10 +1,15 @@
 ﻿<Window x:Class="Elmish.WPF.Samples.SubModelSelectedItem.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelSelectedItem;assembly=SubModelSelectedItem"
         WindowStartupLocation="CenterScreen"
         Title="SubModelSelectedItem"
         Height="350"
-        Width="500">
+        Width="500"
+        mc:Ignorable="d"
+        d:DataContext="{x:Static vm:Program.designVm}">
   <StackPanel Margin="0,15,0,0">
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
       <Button Command="{Binding SelectRandom}" Margin="5 5" Width="100">Select random</Button>

--- a/src/Samples/SubModelSelectedItem.Views/Program.cs
+++ b/src/Samples/SubModelSelectedItem.Views/Program.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Elmish.WPF.Samples.SubModelSelectedItem;
+using static Elmish.WPF.Samples.SubModelSelectedItem.Program;
+
+namespace SubModelSelectedItem.Views {
+  public static class Program {
+    [STAThread]
+    public static void Main() =>
+      main(new MainWindow());
+  }
+}

--- a/src/Samples/SubModelSelectedItem.Views/SubModelSelectedItem.Views.csproj
+++ b/src/Samples/SubModelSelectedItem.Views/SubModelSelectedItem.Views.csproj
@@ -2,7 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <UseWpf>true</UseWpf>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SubModelSelectedItem\SubModelSelectedItem.fsproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Samples/SubModelSelectedItem/Program.fs
+++ b/src/Samples/SubModelSelectedItem/Program.fs
@@ -40,11 +40,11 @@ let bindings () : Binding<Model, Msg> list = [
   "SelectedEntity" |> Binding.subModelSelectedItem("Entities", (fun m -> m.Selected), Select)
 ]
 
+let designVm = ViewModel.designInstance (init ()) (bindings ())
 
-[<EntryPoint; STAThread>]
-let main _ =
+let main window =
   Program.mkSimpleWpf init update bindings
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
     { ElmConfig.Default with LogConsole = true; Measure = true }
-    (MainWindow())
+    window

--- a/src/Samples/SubModelSelectedItem/SubModelSelectedItem.fsproj
+++ b/src/Samples/SubModelSelectedItem/SubModelSelectedItem.fsproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -13,7 +12,6 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\Elmish.WPF\Elmish.WPF.fsproj" />
-    <ProjectReference Include="..\SubModelSelectedItem.Views\SubModelSelectedItem.Views.csproj" />
   </ItemGroup>
   
 </Project>

--- a/src/Samples/SubModelSeq.Views/MainWindow.xaml
+++ b/src/Samples/SubModelSeq.Views/MainWindow.xaml
@@ -1,11 +1,16 @@
 ﻿<Window x:Class="Elmish.WPF.Samples.SubModelSeq.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelSeq;assembly=SubModelSeq"
         xmlns:local="clr-namespace:Elmish.WPF.Samples.SubModelSeq"
         Title="SubModelSeq"
         Height="800"
         Width="1100"
-        WindowStartupLocation="CenterScreen">
+        WindowStartupLocation="CenterScreen"
+        mc:Ignorable="d"
+        d:DataContext="{x:Static vm:Program.mainDesignVm}">
   <StackPanel Margin="0,20,0,10">
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
       <Button Command="{Binding AddCounter}" Content="Add counter" Width="150" Margin="10,0,10,20" />

--- a/src/Samples/SubModelSeq.Views/Program.cs
+++ b/src/Samples/SubModelSeq.Views/Program.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Elmish.WPF.Samples.SubModelSeq;
+using static Elmish.WPF.Samples.SubModelSeq.Program;
+
+namespace SubModelSeq.Views {
+  public static class Program {
+    [STAThread]
+    public static void Main() =>
+      main(new MainWindow());
+  }
+}

--- a/src/Samples/SubModelSeq.Views/SubModelSeq.Views.csproj
+++ b/src/Samples/SubModelSeq.Views/SubModelSeq.Views.csproj
@@ -2,7 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <UseWpf>true</UseWpf>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SubModelSeq\SubModelSeq.fsproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Samples/SubModelSeq/Program.fs
+++ b/src/Samples/SubModelSeq/Program.fs
@@ -253,11 +253,11 @@ module Bindings =
     "AddCounter" |> Binding.cmd(fun m -> AddChild m.DummyRoot.Data.Id)
   ]
 
+let mainDesignVm = ViewModel.designInstance (App.init ()) (Bindings.rootBindings ())
 
-[<EntryPoint; STAThread>]
-let main _ =
+let main window =
   Program.mkSimpleWpf App.init App.update Bindings.rootBindings
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
     { ElmConfig.Default with LogConsole = true; Measure = true }
-    (MainWindow())
+    window

--- a/src/Samples/SubModelSeq/SubModelSeq.fsproj
+++ b/src/Samples/SubModelSeq/SubModelSeq.fsproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -13,7 +12,6 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\Elmish.WPF\Elmish.WPF.fsproj" />
-    <ProjectReference Include="..\SubModelSeq.Views\SubModelSeq.Views.csproj" />
   </ItemGroup>
   
 </Project>

--- a/src/Samples/UiBoundCmdParam.Views/MainWindow.xaml
+++ b/src/Samples/UiBoundCmdParam.Views/MainWindow.xaml
@@ -1,10 +1,15 @@
 ﻿<Window x:Class="Elmish.WPF.Samples.UiBoundCmdParam.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:Elmish.WPF.Samples.UiBoundCmdParam;assembly=UiBoundCmdParam"
         Title="UI-bound CommandParameter"
         Height="350"
         Width="500"
-        WindowStartupLocation="CenterScreen">
+        WindowStartupLocation="CenterScreen"
+        mc:Ignorable="d"
+        d:DataContext="{x:Static vm:Program.designVm}">
   <StackPanel>
     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,25,0,0">
       <Button

--- a/src/Samples/UiBoundCmdParam.Views/Program.cs
+++ b/src/Samples/UiBoundCmdParam.Views/Program.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Elmish.WPF.Samples.UiBoundCmdParam;
+using static Elmish.WPF.Samples.UiBoundCmdParam.Program;
+
+namespace UiBoundCmdParam.Views {
+  public static class Program {
+    [STAThread]
+    public static void Main() =>
+      main(new MainWindow());
+  }
+}

--- a/src/Samples/UiBoundCmdParam.Views/UiBoundCmdParam.Views.csproj
+++ b/src/Samples/UiBoundCmdParam.Views/UiBoundCmdParam.Views.csproj
@@ -2,7 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <UseWpf>true</UseWpf>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\UiBoundCmdParam\UiBoundCmdParam.fsproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Samples/UiBoundCmdParam/Program.fs
+++ b/src/Samples/UiBoundCmdParam/Program.fs
@@ -1,6 +1,5 @@
 ﻿module Elmish.WPF.Samples.UiBoundCmdParam.Program
 
-open System
 open Elmish
 open Elmish.WPF
 
@@ -31,11 +30,12 @@ let bindings () : Binding<Model, Msg> list = [
     true)
 ]
 
+let designVm = ViewModel.designInstance (init ()) (bindings ())
 
-[<EntryPoint; STAThread>]
-let main _ =
+
+let main window =
   Program.mkSimpleWpf init update bindings
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
     { ElmConfig.Default with LogConsole = true; Measure = true }
-    (MainWindow())
+    window

--- a/src/Samples/UiBoundCmdParam/UiBoundCmdParam.fsproj
+++ b/src/Samples/UiBoundCmdParam/UiBoundCmdParam.fsproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -13,7 +12,6 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\Elmish.WPF\Elmish.WPF.fsproj" />
-    <ProjectReference Include="..\UiBoundCmdParam.Views\UiBoundCmdParam.Views.csproj" />
   </ItemGroup>
   
 </Project>

--- a/src/Samples/Validation.Views/MainWindow.xaml
+++ b/src/Samples/Validation.Views/MainWindow.xaml
@@ -1,10 +1,15 @@
 ﻿<Window x:Class="Elmish.WPF.Samples.Validation.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:Elmish.WPF.Samples.Validation;assembly=Validation"
         Title="Validation"
         Height="300"
         Width="500"
-        WindowStartupLocation="CenterScreen">
+        WindowStartupLocation="CenterScreen"
+        mc:Ignorable="d"
+        d:DataContext="{x:Static vm:Program.designVm}">
   <Window.Resources>
     <Style x:Key="textBoxInError" TargetType="Control">
       <Setter Property="Validation.ErrorTemplate">

--- a/src/Samples/Validation.Views/Program.cs
+++ b/src/Samples/Validation.Views/Program.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Elmish.WPF.Samples.Validation;
+using static Elmish.WPF.Samples.Validation.Program;
+
+namespace Validation.Views {
+  public static class Program {
+    [STAThread]
+    public static void Main() =>
+      main(new MainWindow());
+  }
+}

--- a/src/Samples/Validation.Views/Validation.Views.csproj
+++ b/src/Samples/Validation.Views/Validation.Views.csproj
@@ -2,7 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <UseWpf>true</UseWpf>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Validation\Validation.fsproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Samples/Validation/Program.fs
+++ b/src/Samples/Validation/Program.fs
@@ -46,11 +46,12 @@ let bindings () : Binding<Model, Msg> list = [
     fun m -> validateInt42 m.RawValue |> Result.map Submit)
 ]
 
+let designVm = ViewModel.designInstance (init ()) (bindings ())
 
-[<EntryPoint; STAThread>]
-let main _ =
+
+let main window =
   Program.mkSimpleWpf init update bindings
   |> Program.withConsoleTrace
   |> Program.runWindowWithConfig
     { ElmConfig.Default with LogConsole = true; Measure = true }
-    (MainWindow())
+    window

--- a/src/Samples/Validation/Validation.fsproj
+++ b/src/Samples/Validation/Validation.fsproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -13,7 +12,6 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\Elmish.WPF\Elmish.WPF.fsproj" />
-    <ProjectReference Include="..\Validation.Views\Validation.Views.csproj" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
Resolves #246 

This branch adds design-time view models to each sample.

There were a couple that didn't work as I expected.  For example, data isn't showing up for `CounterWithClock.xaml` in the `SubModel` sample.  Not sure why.  I will look into it more.

This branch also includes some minor formatting adjustments near where I made some changes.  I think I will extract those changes, merge them into `master`, and then rebase this branch so that the diff is cleaner.

I am open to feedback now.  I marked the PR as a draft while I address the two things I mentioned above. 