### PR TITLE
simplify SubModelSeq sample by using bindFunc

### DIFF
--- a/src/Samples/SubModelSeq/Program.fs
+++ b/src/Samples/SubModelSeq/Program.fs
@@ -9,10 +9,16 @@ module Func =
 
   let flip f b a = f a b
 
-  let flatten f a = f a a
-
   let applyIf p f a =
     if p a then f a else a
+
+
+module FuncOption =
+
+  let inputIfNone f a = a |> f |> Option.defaultValue a
+
+  let bindFunc (f: 'b -> 'a -> 'c) (mb: 'a -> 'b option) a =
+    mb a |> Option.bind (fun b -> Some(f b a))
 
 
 let map get set f a =
@@ -162,9 +168,8 @@ module App =
     nId
     |> hasId
     |> List.tryFindIndex
-    >> Option.map swap
-    >> Option.defaultValue id
-    |> Func.flatten
+    |> FuncOption.bindFunc swap
+    |> FuncOption.inputIfNone
     |> RoseTree.mapChildren
 
   let update = function


### PR DESCRIPTION
PR #241 recently improved the code of the `SubModelSeq` sample.  One of the more suspicious changes was the existence and use of `Func.Dedup`.  We discussed that in https://github.com/elmish/Elmish.WPF/pull/241#discussion_r459087478.

With help from Twitter, I now know that this function is `flatten` for the function moand.  Specifically, `'a -> 'b` is a monad in `'b`.

There was a concern with the call site of this `flatten`, which was
```F#
let swapCounters swap nId =
  nId
  |> hasId
  |> List.tryFindIndex
  >> Option.map swap
  >> Option.defaultValue id
  |> Func.flatten
  |> RoseTree.mapChildren
```

Quoting https://github.com/elmish/Elmish.WPF/pull/241#discussion_r459484715.
> The call side mixes piping and composition, which I find confusing, so it may be better to rewrite it. We'll see.

I now believe that I understand what is going on there.

The `map` function for the `'a -> 'b` monad in `'b` is the function composition operator `>>`.  Of course `Option.map` is the `map` function is the `map` function for the `Option` monad.  Then `>> Option.map f` is the `map` function for the nested monad `'a -> 'b option`, which is monadic in `'b`.  In general `bind f = map f >> flatten`, and the above code does call `map` and then `flatten`, but they are `map` and `flatten` for different monads.  That is because the type of `swap` is of the form `'a -> 'b -> 'c` instead of `'a -> 'b -> 'c option`.  If it were of the latter form, then we could simply (implement and then) call `FuncOption.bind swap`.

But all is not lost.  We can define a slight variant of `FuncOption.bind` that works the same way except that it accepts a function like `swap`.  This PR creates such a function under the name `FuncOption.bindFunc`.  Then after adding one more function that I named `FuncOption.inputIfNone`, we can simplify the above code to only use pipes...no function composition (mixed with pipes).