### PR TITLE
implemented workaround for .NET Core design-time data binding bug

### DIFF
--- a/src/Samples/SubModel.Views/CounterWithClock.xaml
+++ b/src/Samples/SubModel.Views/CounterWithClock.xaml
@@ -8,7 +8,7 @@
              mc:Ignorable="d"
              d:DataContext="{x:Static vm:Program.counterWithClockDesignVm}">
   <StackPanel>
-    <local:Counter DataContext="{Binding Counter}" HorizontalAlignment="Center" />
-    <local:Clock DataContext="{Binding Clock}" HorizontalAlignment="Center" />
+    <local:Counter DataContext="{Binding Counter}" d:DataContext="{Binding DataContext.Counter, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />
+    <local:Clock DataContext="{Binding Clock}" d:DataContext="{Binding DataContext.Clock, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />
   </StackPanel>
 </UserControl>

--- a/src/Samples/SubModel.Views/MainWindow.xaml
+++ b/src/Samples/SubModel.Views/MainWindow.xaml
@@ -13,8 +13,8 @@
         d:DataContext="{x:Static vm:Program.mainDesignVm}">
   <StackPanel>
     <TextBlock Text="Counter with clock 1" FontSize="18" FontWeight="Bold" Margin="0,25,0,0" HorizontalAlignment="Center" />
-    <local:CounterWithClock DataContext="{Binding ClockCounter1}" />
+    <local:CounterWithClock DataContext="{Binding ClockCounter1}" d:DataContext="{Binding DataContext.ClockCounter1, RelativeSource={RelativeSource AncestorType=StackPanel}}"/>
     <TextBlock Text="Counter with clock 2" FontSize="18" FontWeight="Bold" Margin="0,25,0,0" HorizontalAlignment="Center" />
-    <local:CounterWithClock DataContext="{Binding ClockCounter2}" />
+    <local:CounterWithClock DataContext="{Binding ClockCounter2}" d:DataContext="{Binding DataContext.ClockCounter2, RelativeSource={RelativeSource AncestorType=StackPanel}}"/>
   </StackPanel>
 </Window>

--- a/src/Samples/SubModelOpt.Views/MainWindow.xaml
+++ b/src/Samples/SubModelOpt.Views/MainWindow.xaml
@@ -34,11 +34,13 @@
       <StackPanel Background="White">
         <local:Form1
             DataContext="{Binding Form1}"
+            d:DataContext="{Binding DataContext.Form1, RelativeSource={RelativeSource AncestorType=StackPanel}}"
             Visibility="{Binding DataContext.Form1Visible,
                          RelativeSource={RelativeSource AncestorType=Window},
                          Converter={StaticResource VisibilityConverter}}" />
         <local:Form2
             DataContext="{Binding Form2}"
+            d:DataContext="{Binding DataContext.Form2, RelativeSource={RelativeSource AncestorType=StackPanel}}"
             Visibility="{Binding DataContext.Form2Visible,
                          RelativeSource={RelativeSource AncestorType=Window},
                          Converter={StaticResource VisibilityConverter}}" />


### PR DESCRIPTION
I got a reply on [the issue](https://developercommunity.visualstudio.com/content/problem/1133390/design-time-data-in-datacontext-binding-not-displa.html) I created in the Visual Studio Developer Community.  The same issue was reported three weeks ago, and a workaround was found.  This PR implements that workaround.

Quoting https://github.com/elmish/Elmish.WPF/pull/249#issuecomment-668010074
> I think of Visual Studio Developer Community as the place where issues go to die. I would much rather create an issue on GitHub. However, I think the instruction not to post an issue with the XAML designer is clear and doing so risks angering the people best able to fix the problem.

I need to eat my words.  They did a great job this time.


Quoting https://github.com/elmish/Elmish.WPF/pull/249#issuecomment-667577198
> For good measure, could you see if it works if add a `d:DataContext` binding parallel to the existing `DataContext` binding? E.g.
> 
> ```
> <local:Counter DataContext="{Binding Counter}" d:DataContext="{Binding Counter}" HorizontalAlignment="Center" />
> ```
> 
> Or perhaps mess a little more around with the `d:DataContext` binding if it doesn't work. I'm just throwing stones at the wall here to see what sticks.

You were on the right track @cmeeren!


