### PR TITLE
switched to obtaining WPF dependencies via UseWpf=true in the test project

### DIFF
--- a/src/Elmish.WPF.Tests/Elmish.WPF.Tests.fsproj
+++ b/src/Elmish.WPF.Tests/Elmish.WPF.Tests.fsproj
@@ -1,7 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
+    <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!--Turn on warnings for unused values (arguments and let bindings) -->
     <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>
@@ -30,12 +31,6 @@
   
   <ItemGroup>
     <ProjectReference Include="..\Elmish.WPF\Elmish.WPF.fsproj" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="WindowsBase" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
When I build Elmish.WPF with Visual Studio, the official list of errors and warnings is empty.  However, the build output includes
```
20>------ Build started: Project: Elmish.WPF.Tests, Configuration: Debug Any CPU ------
20>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2081,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "PresentationCore". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors.
20>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2081,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "PresentationFramework". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors.
20>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2081,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "WindowsBase". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors.
20>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2081,5): warning MSB3243: No way to resolve conflict between "PresentationCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" and "PresentationCore". Choosing "PresentationCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" arbitrarily.
20>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2081,5): warning MSB3243: No way to resolve conflict between "PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" and "PresentationFramework". Choosing "PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" arbitrarily.
20>C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(2081,5): warning MSB3243: No way to resolve conflict between "WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" and "WindowsBase". Choosing "WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" arbitrarily.
```

After the change in this PR, these lines are no longer output by the build.

I will complete the PR after the automated build finishes successfully.