### PR TITLE
#157 one way seq via one way seq lazy

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 * **Breaking:** Removed all occurrences of the argument `wrapDispatch` from the methods used to create a binding. There is currently no migration path. Please create an issue if this is a negative impact for you.
 * **Breaking:** App initialization is now done using the `WpfProgram` module instead of the `Program` module
 * **Breaking:** Removed `ElmConfig`. For controlling logging, see below. For specifying a binding performance log threshold (corresponding to the old `ElmConfig.MeasureLimitMs` field), use `WpfProgram.withBindingPerformanceLogThreshold`
+* **Breaking:** The method `Binding.oneWaySeq` is implemented by calling the method `Binding.oneWaySeqLazy` with `equals` = `refEq` and `map` = `id`. This is a breaking change when using a mutable data structure for the sequence. Compensate by directly calling `Binding.oneWaySeqLazy` with `equals` = `fun _ _ = false`.
 * Added binding mapping functions
   * Added `mapModel`, `mapMsg`, and `mapMsgWithModel` in both the `Binding` and `Bindings` modules
   * These functions enable common model and message mapping logic to be extracted

--- a/src/Elmish.WPF.Tests/BindingTests.fs
+++ b/src/Elmish.WPF.Tests/BindingTests.fs
@@ -367,14 +367,14 @@ module oneWaySeq =
 
 
   [<Fact>]
-  let ``final map returns value from original get`` () =
+  let ``final map returns the seq its given`` () =
     Property.check <| property {
-      let! x = GenX.auto<string>
+      let! array = Gen.guid |> Gen.array (Range.constant 1 50)
 
-      let get : string -> char list = Seq.toList
-      let d = Binding.oneWaySeq(get, fail2, fail) |> getOneWaySeqLazyData
+      let list = array |> Array.toList
+      let d = Binding.oneWaySeq(fail, fail2, fail) |> getOneWaySeqLazyData
 
-      test <@ d.Map (box x) |> Seq.map unbox |> Seq.toList = get x @>
+      test <@ list |> Seq.map box |> box |> d.Map |> Seq.map unbox |> Seq.toList = list @>
     }
 
 

--- a/src/Elmish.WPF.Tests/BindingTests.fs
+++ b/src/Elmish.WPF.Tests/BindingTests.fs
@@ -355,13 +355,14 @@ module oneWaySeq =
 
 
   [<Fact>]
-  let ``final get passes through model`` () =
+  let ``final get returns value from original get`` () =
     Property.check <| property {
       let! x = GenX.auto<int>
 
-      let d = Binding.oneWaySeq(fail, fail2, fail) |> getOneWaySeqLazyData
+      let get = string
+      let d = Binding.oneWaySeq(get, fail2, fail) |> getOneWaySeqLazyData
 
-      test <@ d.Get x |> unbox = x @>
+      test <@ d.Get x |> unbox = get x @>
     }
 
 

--- a/src/Elmish.WPF.Tests/BindingTests.fs
+++ b/src/Elmish.WPF.Tests/BindingTests.fs
@@ -379,14 +379,28 @@ module oneWaySeq =
 
 
   [<Fact>]
-  let ``final equals returns false`` () =
+  let ``final equals returns true for the same sequence references`` () =
     Property.check <| property {
-      let! x = GenX.auto<int>
-      let! y = GenX.auto<int>
+      let! array = Gen.guid |> Gen.array (Range.constant 1 50)
 
+      let list = array |> Seq.map box |> Seq.toList
       let d = Binding.oneWaySeq(fail, fail2, fail) |> getOneWaySeqLazyData
 
-      test <@ d.Equals (box x) (box y) = false @>
+      test <@ d.Equals (box list) (box list) = true @>
+    }
+
+
+  [<Fact>]
+  let ``final equals returns false for different reference sequences`` () =
+    Property.check <| property {
+      let! array = Gen.guid |> Gen.array (Range.constant 1 50)
+
+      let list1 = array |> Seq.map box |> Seq.toList
+      let list2 = list1 |> Seq.map id |> Seq.toList
+      let d = Binding.oneWaySeq(fail, fail2, fail) |> getOneWaySeqLazyData
+
+      test <@ refEq list1 list2 = false @> // ensure lists are not reference equal
+      test <@ d.Equals (box list1) (box list2) = false @>
     }
 
 

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -426,8 +426,8 @@ type Binding private () =
   /// <summary>
   ///   Creates a one-way binding to a sequence of items, each uniquely
   ///   identified by the value returned by <paramref name="getId"/>. The
-  ///   binding will only be updated if the output of <paramref name="get" />
-  ///   changes, as determined by <paramref name="equals" />. The binding is
+  ///   binding will not be updated if the output of <paramref name="get"/>
+  ///   does not change, as determined by <paramref name="equals"/>. The binding is
   ///   backed by a persistent
   ///   <c>ObservableCollection</c>, so only changed items (as determined by
   ///   <paramref name="itemEquals" />) will be replaced. If the items are

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -427,12 +427,11 @@ type Binding private () =
   ///   Creates a one-way binding to a sequence of items, each uniquely
   ///   identified by the value returned by <paramref name="getId"/>. The
   ///   binding will not be updated if the output of <paramref name="get"/>
-  ///   does not change, as determined by <paramref name="equals"/>. The binding is
-  ///   backed by a persistent
-  ///   <c>ObservableCollection</c>, so only changed items (as determined by
-  ///   <paramref name="itemEquals" />) will be replaced. If the items are
-  ///   complex and you want them updated instead of replaced, consider using
-  ///   <see cref="subModelSeq" />.
+  ///   does not change, as determined by <paramref name="equals"/>.
+  ///   The binding is backed by a persistent <c>ObservableCollection</c>, so
+  ///   only changed items (as determined by <paramref name="itemEquals"/>)
+  ///   will be replaced. If the items are complex and you want them updated
+  ///   instead of replaced, consider using <see cref="subModelSeq"/>.
   /// </summary>
   /// <param name="get">Gets the intermediate value from the model.</param>
   /// <param name="equals">

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -426,35 +426,6 @@ type Binding private () =
   /// <summary>
   ///   Creates a one-way binding to a sequence of items, each uniquely
   ///   identified by the value returned by <paramref name="getId"/>. The
-  ///   binding is backed by a persistent <c>ObservableCollection</c>, so only
-  ///   changed items (as determined by <paramref name="itemEquals" />) will be
-  ///   replaced. If the items are complex and you want them updated instead of
-  ///   replaced, consider using <see cref="subModelSeq" />.
-  /// </summary>
-  /// <param name="get">Gets the collection from the model.</param>
-  /// <param name="itemEquals">
-  ///   Indicates whether two collection items are equal. Good candidates are
-  ///   <c>elmEq</c>, <c>refEq</c>, or simply <c>(=)</c>.
-  /// </param>
-  /// <param name="getId">Gets a unique identifier for a collection
-  /// item.</param>
-  static member oneWaySeq
-      (get: 'model -> #seq<'a>,
-       itemEquals: 'a -> 'a -> bool,
-       getId: 'a -> 'id)
-      : string -> Binding<'model, 'msg> =
-    OneWaySeqLazyData {
-      Get = box
-      Map = unbox<'model> >> get >> Seq.map box
-      Equals = fun _ _ -> false
-      GetId = unbox<'a> >> getId >> box
-      ItemEquals = fun a b -> itemEquals (unbox<'a> a) (unbox<'a> b)
-    } |> createBinding
-
-
-  /// <summary>
-  ///   Creates a one-way binding to a sequence of items, each uniquely
-  ///   identified by the value returned by <paramref name="getId"/>. The
   ///   binding will only be updated if the output of <paramref name="get" />
   ///   changes, as determined by <paramref name="equals" />. The binding is
   ///   backed by a persistent
@@ -488,6 +459,35 @@ type Binding private () =
       Equals = fun x y -> equals (unbox<'a> x) (unbox<'a> y)
       GetId = unbox<'b> >> getId >> box
       ItemEquals = fun x y -> itemEquals (unbox<'b> x) (unbox<'b> y)
+    } |> createBinding
+
+
+  /// <summary>
+  ///   Creates a one-way binding to a sequence of items, each uniquely
+  ///   identified by the value returned by <paramref name="getId"/>. The
+  ///   binding is backed by a persistent <c>ObservableCollection</c>, so only
+  ///   changed items (as determined by <paramref name="itemEquals" />) will be
+  ///   replaced. If the items are complex and you want them updated instead of
+  ///   replaced, consider using <see cref="subModelSeq" />.
+  /// </summary>
+  /// <param name="get">Gets the collection from the model.</param>
+  /// <param name="itemEquals">
+  ///   Indicates whether two collection items are equal. Good candidates are
+  ///   <c>elmEq</c>, <c>refEq</c>, or simply <c>(=)</c>.
+  /// </param>
+  /// <param name="getId">Gets a unique identifier for a collection
+  /// item.</param>
+  static member oneWaySeq
+      (get: 'model -> #seq<'a>,
+       itemEquals: 'a -> 'a -> bool,
+       getId: 'a -> 'id)
+      : string -> Binding<'model, 'msg> =
+    OneWaySeqLazyData {
+      Get = box
+      Map = unbox<'model> >> get >> Seq.map box
+      Equals = fun _ _ -> false
+      GetId = unbox<'a> >> getId >> box
+      ItemEquals = fun a b -> itemEquals (unbox<'a> a) (unbox<'a> b)
     } |> createBinding
 
 

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -461,14 +461,18 @@ type Binding private () =
       ItemEquals = fun x y -> itemEquals (unbox<'b> x) (unbox<'b> y)
     } |> createBinding
 
-
+    
   /// <summary>
   ///   Creates a one-way binding to a sequence of items, each uniquely
   ///   identified by the value returned by <paramref name="getId"/>. The
-  ///   binding is backed by a persistent <c>ObservableCollection</c>, so only
-  ///   changed items (as determined by <paramref name="itemEquals" />) will be
-  ///   replaced. If the items are complex and you want them updated instead of
-  ///   replaced, consider using <see cref="subModelSeq" />.
+  ///   binding will not be updated if the output of <paramref name="get"/>
+  ///   is referentially equal. This is the same as calling
+  ///   <see cref="oneWaySeqLazy"/> with <c>equals = refEq</c> and
+  ///   <c>map = id</c>. The binding is backed by a persistent
+  ///   <c>ObservableCollection</c>, so only changed items (as determined by
+  ///   <paramref name="itemEquals"/>) will be replaced. If the items are
+  ///   complex and you want them updated instead of replaced, consider using
+  ///   <see cref="subModelSeq"/>.
   /// </summary>
   /// <param name="get">Gets the collection from the model.</param>
   /// <param name="itemEquals">
@@ -482,13 +486,7 @@ type Binding private () =
        itemEquals: 'a -> 'a -> bool,
        getId: 'a -> 'id)
       : string -> Binding<'model, 'msg> =
-    OneWaySeqLazyData {
-      Get = box
-      Map = unbox<'model> >> get >> Seq.map box
-      Equals = fun _ _ -> false
-      GetId = unbox<'a> >> getId >> box
-      ItemEquals = fun a b -> itemEquals (unbox<'a> a) (unbox<'a> b)
-    } |> createBinding
+    Binding.oneWaySeqLazy(get, refEq, id, itemEquals, getId)
 
 
   /// <summary>Creates a two-way binding.</summary>

--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -33,8 +33,8 @@
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="InternalUtils.fs" />
     <Compile Include="InternalTypes.fs" />
-    <Compile Include="Binding.fs" />
     <Compile Include="Utils.fs" />
+    <Compile Include="Binding.fs" />
     <Compile Include="ViewModel.fs" />
     <Compile Include="ViewModelModule.fs" />
     <Compile Include="WpfProgram.fs" />


### PR DESCRIPTION
This PR implements the `oneWaySeq` binding method via the `oneWaySeqLazy` method with `equals` = `refEq` and `map` = `id`.

I described more about this branch in https://github.com/elmish/Elmish.WPF/issues/253#issuecomment-671707215.

The only documentation I changed was in the `///`-style documentation above the relevant binding method.