### PR TITLE
removed direct references to WPF DLLs

### DIFF
--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -46,12 +46,6 @@
     <PackageReference Include="Elmish" Version="[3.0.3, 4)" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-  
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="4.6.2" />
   </ItemGroup>


### PR DESCRIPTION
This PR is similar to PR #254

This PR removes direct references to the WPF DLLs in the project file of the main project since these dependencies are also being picked up via `<UseWpf>true</UseWpf>`.

I will complete this PR after the automated build finishes successfully.