### PR TITLE
changed some intermediate uses of List to Seq in merge

### DIFF
--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -136,14 +136,14 @@ module internal BindingLogic =
 
     let moves =
       additions
-      |> Seq.toList
-      |> List.collect (fun (Kvp (id, (sIdx, s))) ->
+      |> Seq.collect (fun (Kvp (id, (sIdx, s))) ->
         match removals.TryGetValue id with
-        | (false, _) -> []
+        | (false, _) -> Seq.empty
         | (true, (tIdx, t)) ->
             removals.Remove id |> ignore
             additions.Remove id |> ignore
-            (tIdx, sIdx, t, s) |> List.singleton)
+            (tIdx, sIdx, t, s) |> Seq.singleton)
+      |> Seq.toList
 
     let actuallyRemove () =
       Seq.empty


### PR DESCRIPTION
This is a minor change.  I am making the PR into `v4` instead of `master` to avoid a future conflict since this change is in code that code moved.

I think I used `List` before because I knew that `[]` is an empty list but didn't know an equivalent expression for `Seq`.  Now I know about `Seq.empty` (and `List.empty`).

The purpose for making a PR of this minor change instead of just pushing it straight to `master` is a get some more eyes on it.  This is technically a small optimization in code that is already designed to be very efficient.

The diff seems a bit more complicated to me that the actual change, which is
- moved `Seq.toList` to the end,
- changed `List.collect` to `Seq.collect`,
- changed `[]` to `Seq.empty`, and
- changed `List.singleton` to `Seq.singleton`.