### PR TITLE
Optimize SubModelSeq

### DIFF
--- a/src/Samples/SubModelSeq/Program.fs
+++ b/src/Samples/SubModelSeq/Program.fs
@@ -1,4 +1,4 @@
-﻿module Elmish.WPF.Samples.SubModelSeq.Program
+module Elmish.WPF.Samples.SubModelSeq.Program
 
 open System
 open Elmish
@@ -17,7 +17,7 @@ module FuncOption =
 
   let inputIfNone f a = a |> f |> Option.defaultValue a
 
-  let bindFunc (f: 'b -> 'a -> 'c) (mb: 'a -> 'b option) a =
+  let bind (f: 'b -> 'a -> 'c) (mb: 'a -> 'b option) a =
     mb a |> Option.bind (fun b -> Some(f b a))
 
 
@@ -98,7 +98,6 @@ module RoseTree =
   module RoseTree =
 
     let getData m = m.Data
-    let setData v m = { Data = v; Children = m.Children }
     let rec mapData f t =
       { Data = t.Data |> f
         Children = t.Children |> (f |> mapData |> List.map) }
@@ -168,7 +167,7 @@ module App =
     nId
     |> hasId
     |> List.tryFindIndex
-    |> FuncOption.bindFunc swap
+    |> FuncOption.bind swap
     |> FuncOption.inputIfNone
     |> RoseTree.mapChildren
 

--- a/src/Samples/SubModelSeq/Program.fs
+++ b/src/Samples/SubModelSeq/Program.fs
@@ -227,7 +227,7 @@ module Bindings =
 
   let rec subtreeBindings () : Binding<Model * (RoseTree<Identifiable<Counter>> * RoseTree<Identifiable<Counter>>), RoseTreeMsg<Guid, SubtreeMsg>> list = [
     "CounterIdText" |> Binding.oneWay(fun (_, (_, c)) -> c.Data.Id)
-  
+
     "CounterValue" |> Binding.oneWay(fun (_, (_, c)) -> c.Data.Value.Count)
     "Increment" |> Binding.cmd(Increment |> CounterMsg |> LeafMsg)
     "Decrement" |> Binding.cmd(Decrement |> CounterMsg |> LeafMsg)
@@ -237,15 +237,15 @@ module Bindings =
     "Reset" |> Binding.cmdIf(
       Reset |> CounterMsg |> LeafMsg,
       (fun (_, (_, c)) -> Counter.canReset c.Data.Value))
-  
+
     "Remove" |> Binding.cmd(fun (_, (_, c)) -> c.Data.Id |> Remove |> LeafMsg)
     "AddChild" |> Binding.cmd(AddChild |> LeafMsg)
-  
+
     "MoveUp" |> Binding.cmdIf(canMoveUp |> FuncOption.map LeafMsg)
     "MoveDown" |> Binding.cmdIf(canMoveDown |> FuncOption.map LeafMsg)
-  
+
     "GlobalState" |> Binding.oneWay(fun (m, _) -> m.SomeGlobalState)
-  
+
     "ChildCounters" |> Binding.subModelSeq(
       (fun (_, (_, c)) -> c.Children |> Seq.map (fun gc -> (c, gc))),
       (fun ((m, _), childCounter) -> (m, childCounter)),
@@ -260,9 +260,9 @@ module Bindings =
       (fun (_, c) -> c.Data.Id),
       (fun (id, msg) -> msg |> RoseTree.branchMsg id |> adjustMsgToParent |> SubtreeMsg),
       subtreeBindings)
-    
+
     "ToggleGlobalState" |> Binding.cmd ToggleGlobalState
-    
+
     "AddCounter" |> Binding.cmd (AddChild |> LeafMsg |> SubtreeMsg)
   ]
 

--- a/src/Samples/SubModelSeq/Program.fs
+++ b/src/Samples/SubModelSeq/Program.fs
@@ -210,13 +210,13 @@ module Bindings =
     { Self: 'a
       Parent: 'a }
 
-  let canMoveUp (_, { Parent = p; Self = s }) =
+  let moveUpMsg (_, { Parent = p; Self = s }) =
     match p.Children |> List.tryHead with
     | Some c when c.Data.Id <> s.Data.Id ->
         s.Data.Id |> MoveUp |> Some
     | _ -> None
 
-  let canMoveDown (_, { Parent = p; Self = s }) =
+  let moveDownMsg (_, { Parent = p; Self = s }) =
     match p.Children |> List.tryLast with
     | Some c when c.Data.Id <> s.Data.Id ->
         s.Data.Id |> MoveDown |> Some
@@ -245,8 +245,8 @@ module Bindings =
     "Remove" |> Binding.cmd(fun (_, { Self = s }) -> s.Data.Id |> Remove |> LeafMsg)
     "AddChild" |> Binding.cmd(AddChild |> LeafMsg)
 
-    "MoveUp" |> Binding.cmdIf(canMoveUp |> FuncOption.map LeafMsg)
-    "MoveDown" |> Binding.cmdIf(canMoveDown |> FuncOption.map LeafMsg)
+    "MoveUp" |> Binding.cmdIf(moveUpMsg |> FuncOption.map LeafMsg)
+    "MoveDown" |> Binding.cmdIf(moveDownMsg |> FuncOption.map LeafMsg)
 
     "GlobalState" |> Binding.oneWay(fun (m, _) -> m.SomeGlobalState)
 

--- a/src/Samples/SubModelSeq/Program.fs
+++ b/src/Samples/SubModelSeq/Program.fs
@@ -127,8 +127,6 @@ module RoseTree =
     let setChildren c t = { t with Children = c }
     let mapChildren f = map getChildren setChildren f
 
-    let branchMsg a t = BranchMsg (a, t)
-
     let addSubtree t = t |> List.cons |> mapChildren
     let addChildData a = a |> createLeaf |> addSubtree
 
@@ -254,7 +252,7 @@ module Bindings =
       (fun (_, { Self = p }) -> p.Children |> Seq.map (fun c -> { Self = c; Parent = p })),
       (fun ((m, _), selfAndParent) -> (m, selfAndParent)),
       (fun (_, { Self = c }) -> c.Data.Id),
-      (fun (id, msg) -> msg |> RoseTree.branchMsg id |> adjustMsgToParent),
+      BranchMsg >> adjustMsgToParent,
       subtreeBindings)
   ]
 
@@ -262,7 +260,7 @@ module Bindings =
     "Counters" |> Binding.subModelSeq(
       (fun m -> m.DummyRoot.Children |> Seq.map (fun c -> { Self = c; Parent = m.DummyRoot })),
       (fun { Self = c } -> c.Data.Id),
-      (fun (id, msg) -> msg |> RoseTree.branchMsg id |> adjustMsgToParent |> SubtreeMsg),
+      BranchMsg >> adjustMsgToParent >> SubtreeMsg,
       subtreeBindings)
 
     "ToggleGlobalState" |> Binding.cmd ToggleGlobalState

--- a/src/Samples/SubModelSeq/Program.fs
+++ b/src/Samples/SubModelSeq/Program.fs
@@ -207,18 +207,16 @@ module Bindings =
   open App
 
   let canMoveUp (_, (p, c)) =
-    p.Children
-    |> List.tryHead
-    |> Option.map (fun c -> c.Data.Id)
-    |> Option.filter ((<>) c.Data.Id)
-    |> Option.set (MoveUp c.Data.Id)
+    match p.Children |> List.tryHead with
+    | Some first when first.Data.Id <> c.Data.Id ->
+        c.Data.Id |> MoveUp |> Some
+    | _ -> None
 
   let canMoveDown (_, (p, c)) =
-    p.Children
-    |> List.tryLast
-    |> Option.map (fun c -> c.Data.Id)
-    |> Option.filter ((<>) c.Data.Id)
-    |> Option.set (MoveDown c.Data.Id)
+    match p.Children |> List.tryLast with
+    | Some first when first.Data.Id <> c.Data.Id ->
+        c.Data.Id |> MoveDown |> Some
+    | _ -> None
     
   let adjustMsgToParent msg =
     match msg with

--- a/src/Samples/SubModelSeq/Program.fs
+++ b/src/Samples/SubModelSeq/Program.fs
@@ -247,8 +247,8 @@ module Bindings =
     "GlobalState" |> Binding.oneWay(fun (m, _) -> m.SomeGlobalState)
 
     "ChildCounters" |> Binding.subModelSeq(
-      (fun (_, (_, c)) -> c.Children |> Seq.map (fun gc -> (c, gc))),
-      (fun ((m, _), childCounter) -> (m, childCounter)),
+      (fun (_, (_, p)) -> p.Children |> Seq.map (fun c -> (p, c))),
+      (fun ((m, _), (p, c)) -> (m, (p, c))),
       (fun (_, (_, c)) -> c.Data.Id),
       (fun (id, msg) -> msg |> RoseTree.branchMsg id |> adjustMsgToParent),
       subtreeBindings)


### PR DESCRIPTION
Fixes #236

This PR greatly improves the performance of the SubModelSeq sample.

The first improvement is to maintain the tree structure when providing the data to Elmish.WPF and WPF.  In particular, each child is now given in a pair with its parent.  This makes going from a child to a parent a constant-time operation.  Previously, the entire tree was traversed to find the parent.

The second improvement is to maintain as much of the immutable tree data structure when making a change to the tree.  The process to make a change in the tree now traverses the tree directly to the change point, makes the change, then rebuilds the traversed parts of the tree.  Previously, the entire tree was traversed to find the change point, so the whole tree had to be rebuilt.