### PR TITLE
removed explicit dependency on WPF from sample F# project

### DIFF
--- a/src/Samples/SingleCounter/SingleCounter.fsproj
+++ b/src/Samples/SingleCounter/SingleCounter.fsproj
@@ -1,8 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   


### PR DESCRIPTION
After we completed PR #249, it seems that we could have removed an explicit dependency on WPF from the sample F# projects.  The `SingleCounter` sample still works after making this change.

I tried making the same change to the sample C# projects and the `Elmish.WPF` project, but then the code doesn't compile.

How about I make this change to all the sample F# projects?