### PR TITLE
Support for multiple validation errors #314

### DIFF
--- a/src/Elmish.WPF.Tests/BindingTests.fs
+++ b/src/Elmish.WPF.Tests/BindingTests.fs
@@ -866,7 +866,7 @@ module twoWayValidate =
         let! x = GenX.auto<int>
         let! err = GenX.auto<string>
 
-        let validate x = if x < 0 then ValueSome err else ValueNone
+        let validate x = if x < 0 then [ err ] else []
         let d = Binding.twoWayValidate(fail, fail2, validate) |> getTwoWayValidateData
 
         test <@ d.Validate x |> unbox = validate x @>
@@ -917,10 +917,10 @@ module twoWayValidate =
         let! x = GenX.auto<int>
         let! err = GenX.auto<string>
 
-        let validate x = if x < 0 then Some err else None
+        let validate x = if x < 0 then [ err ] else []
         let d = Binding.twoWayValidate(fail, fail2, validate) |> getTwoWayValidateData
 
-        test <@ d.Validate x |> unbox = (validate x |> ValueOption.ofOption) @>
+        test <@ d.Validate x |> unbox = validate x @>
       }
 
 
@@ -966,13 +966,12 @@ module twoWayValidate =
     let ``final validate returns value from original validate`` () =
       Property.check <| property {
         let! x = GenX.auto<int>
-        let! ok = GenX.auto<byte>
         let! err = GenX.auto<string>
 
-        let validate x = if x < 0 then Ok ok else Error err
+        let validate x = if x < 0 then [] else [ err ]
         let d = Binding.twoWayValidate(fail, fail2, validate) |> getTwoWayValidateData
 
-        test <@ d.Validate x |> unbox = (validate x |> ValueOption.ofError) @>
+        test <@ d.Validate x |> unbox = validate x @>
       }
 
 
@@ -1020,7 +1019,7 @@ module twoWayValidate =
         let! x = GenX.auto<int>
         let! err = GenX.auto<string>
 
-        let validate x = if x < 0 then ValueSome err else ValueNone
+        let validate x = if x < 0 then [ err ] else []
         let d = Binding.twoWayValidate(fail, (fail: string -> int), validate) |> getTwoWayValidateData
 
         test <@ d.Validate x |> unbox = validate x @>
@@ -1071,10 +1070,10 @@ module twoWayValidate =
         let! x = GenX.auto<int>
         let! err = GenX.auto<string>
 
-        let validate x = if x < 0 then Some err else None
+        let validate x = if x < 0 then [ err ] else []
         let d = Binding.twoWayValidate(fail, (fail: string -> int), validate) |> getTwoWayValidateData
 
-        test <@ d.Validate x |> unbox = (validate x |> ValueOption.ofOption) @>
+        test <@ d.Validate x |> unbox = validate x @>
       }
 
 
@@ -1120,13 +1119,12 @@ module twoWayValidate =
     let ``final validate returns value from original validate`` () =
       Property.check <| property {
         let! x = GenX.auto<int>
-        let! ok = GenX.auto<byte>
         let! err = GenX.auto<string>
 
-        let validate x = if x < 0 then Ok ok else Error err
+        let validate x = if x < 0 then [] else [ err ]
         let d = Binding.twoWayValidate(fail, (fail: string -> int), validate) |> getTwoWayValidateData
 
-        test <@ d.Validate x |> unbox = (validate x |> ValueOption.ofError) @>
+        test <@ d.Validate x |> unbox = validate x @>
       }
 
 
@@ -1201,7 +1199,7 @@ module twoWayOptValidate =
         let! x = GenX.auto<int>
         let! err = GenX.auto<string>
 
-        let validate x = if x < 0 then ValueSome err else ValueNone
+        let validate x = if x < 0 then [ err ] else []
         let d = Binding.twoWayOptValidate((fail: _ -> _ voption), fail2, validate) |> getTwoWayValidateData
 
         test <@ d.Validate x |> unbox = validate x @>
@@ -1276,10 +1274,10 @@ module twoWayOptValidate =
         let! x = GenX.auto<int>
         let! err = GenX.auto<string>
 
-        let validate x = if x < 0 then Some err else None
+        let validate x = if x < 0 then [ err ] else []
         let d = Binding.twoWayOptValidate((fail: _ -> _ voption), fail2, validate) |> getTwoWayValidateData
 
-        test <@ d.Validate x |> unbox = (validate x |> ValueOption.ofOption) @>
+        test <@ d.Validate x |> unbox = validate x @>
       }
 
 
@@ -1349,13 +1347,12 @@ module twoWayOptValidate =
     let ``final validate returns value from original validate`` () =
       Property.check <| property {
         let! x = GenX.auto<int>
-        let! ok = GenX.auto<byte>
         let! err = GenX.auto<string>
 
-        let validate x = if x < 0 then Ok ok else Error err
+        let validate x = if x < 0 then [] else [ err ]
         let d = Binding.twoWayOptValidate((fail: _ -> _ voption), fail2, validate) |> getTwoWayValidateData
 
-        test <@ d.Validate x |> unbox = (validate x |> ValueOption.ofError) @>
+        test <@ d.Validate x |> unbox = validate x @>
       }
 
 
@@ -1427,7 +1424,7 @@ module twoWayOptValidate =
         let! x = GenX.auto<int>
         let! err = GenX.auto<string>
 
-        let validate x = if x < 0 then ValueSome err else ValueNone
+        let validate x = if x < 0 then [ err ] else []
         let d = Binding.twoWayOptValidate((fail: _ -> _ option), fail2, validate) |> getTwoWayValidateData
 
         test <@ d.Validate x |> unbox = validate x @>
@@ -1502,10 +1499,10 @@ module twoWayOptValidate =
         let! x = GenX.auto<int>
         let! err = GenX.auto<string>
 
-        let validate x = if x < 0 then Some err else None
+        let validate x = if x < 0 then [ err ] else []
         let d = Binding.twoWayOptValidate((fail: _ -> _ option), fail2, validate) |> getTwoWayValidateData
 
-        test <@ d.Validate x |> unbox = (validate x |> ValueOption.ofOption) @>
+        test <@ d.Validate x |> unbox = validate x @>
       }
 
 
@@ -1575,13 +1572,12 @@ module twoWayOptValidate =
     let ``final validate returns value from original validate`` () =
       Property.check <| property {
         let! x = GenX.auto<int>
-        let! ok = GenX.auto<byte>
         let! err = GenX.auto<string>
 
-        let validate x = if x < 0 then Ok ok else Error err
+        let validate x = if x < 0 then [] else [ err ]
         let d = Binding.twoWayOptValidate((fail: _ -> _ option), fail2, validate) |> getTwoWayValidateData
 
-        test <@ d.Validate x |> unbox = (validate x |> ValueOption.ofError) @>
+        test <@ d.Validate x |> unbox = validate x @>
       }
 
 
@@ -1653,7 +1649,7 @@ module twoWayOptValidate =
         let! x = GenX.auto<int>
         let! err = GenX.auto<string>
 
-        let validate x = if x < 0 then ValueSome err else ValueNone
+        let validate x = if x < 0 then [ err ] else []
         let d = Binding.twoWayOptValidate((fail: _ -> _ voption), (fail: _ -> int), validate) |> getTwoWayValidateData
 
         test <@ d.Validate x |> unbox = validate x @>
@@ -1728,10 +1724,10 @@ module twoWayOptValidate =
         let! x = GenX.auto<int>
         let! err = GenX.auto<string>
 
-        let validate x = if x < 0 then Some err else None
+        let validate x = if x < 0 then [ err ] else []
         let d = Binding.twoWayOptValidate((fail: _ -> _ voption), (fail: _ -> int), validate) |> getTwoWayValidateData
 
-        test <@ d.Validate x |> unbox = (validate x |> ValueOption.ofOption) @>
+        test <@ d.Validate x |> unbox = validate x @>
       }
 
 
@@ -1801,13 +1797,12 @@ module twoWayOptValidate =
     let ``final validate returns value from original validate`` () =
       Property.check <| property {
         let! x = GenX.auto<int>
-        let! ok = GenX.auto<byte>
         let! err = GenX.auto<string>
 
-        let validate x = if x < 0 then Ok ok else Error err
+        let validate x = if x < 0 then [] else [ err ]
         let d = Binding.twoWayOptValidate((fail: _ -> _ voption), (fail: _ -> int), validate) |> getTwoWayValidateData
 
-        test <@ d.Validate x |> unbox = (validate x |> ValueOption.ofError) @>
+        test <@ d.Validate x |> unbox = validate x @>
       }
 
 
@@ -1879,7 +1874,7 @@ module twoWayOptValidate =
         let! x = GenX.auto<int>
         let! err = GenX.auto<string>
 
-        let validate x = if x < 0 then ValueSome err else ValueNone
+        let validate x = if x < 0 then [ err ] else []
         let d = Binding.twoWayOptValidate((fail: _ -> _ option), (fail: _ -> int), validate) |> getTwoWayValidateData
 
         test <@ d.Validate x |> unbox = validate x @>
@@ -1954,10 +1949,10 @@ module twoWayOptValidate =
         let! x = GenX.auto<int>
         let! err = GenX.auto<string>
 
-        let validate x = if x < 0 then Some err else None
+        let validate x = if x < 0 then [ err ] else []
         let d = Binding.twoWayOptValidate((fail: _ -> _ option), (fail: _ -> int), validate) |> getTwoWayValidateData
 
-        test <@ d.Validate x |> unbox = (validate x |> ValueOption.ofOption) @>
+        test <@ d.Validate x |> unbox = validate x @>
       }
 
 
@@ -2027,13 +2022,12 @@ module twoWayOptValidate =
     let ``final validate returns value from original validate`` () =
       Property.check <| property {
         let! x = GenX.auto<int>
-        let! ok = GenX.auto<byte>
         let! err = GenX.auto<string>
 
-        let validate x = if x < 0 then Ok ok else Error err
+        let validate x = if x < 0 then [] else [ err ]
         let d = Binding.twoWayOptValidate((fail: _ -> _ option), (fail: _ -> int), validate) |> getTwoWayValidateData
 
-        test <@ d.Validate x |> unbox = (validate x |> ValueOption.ofError) @>
+        test <@ d.Validate x |> unbox = validate x @>
       }
 
 

--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -153,7 +153,7 @@ module Helpers =
     name |> createBinding (TwoWayValidateData {
       Get = get >> box
       Set = unbox<'a> >> set
-      Validate = validate
+      Validate = validate >> ValueOption.toList
       WrapDispatch = id
     })
 

--- a/src/Samples/Validation.Views/MainWindow.xaml
+++ b/src/Samples/Validation.Views/MainWindow.xaml
@@ -36,11 +36,11 @@
   <StackPanel HorizontalAlignment="Center" Margin="0,25,0,0">
     <StackPanel Orientation="Horizontal">
       <TextBlock Text="Value:         "/>
-      <TextBox Style="{StaticResource textBoxInError}" Text="{Binding Value, UpdateSourceTrigger=PropertyChanged}" Width="150" Margin="0,5,0,25" />
+      <TextBox Style="{StaticResource textBoxInError}" Text="{Binding Value, UpdateSourceTrigger=PropertyChanged}" Width="200" Margin="0,5,0,25" />
     </StackPanel>
     <StackPanel Orientation="Horizontal">
       <TextBlock Text="Password:   "/>
-      <TextBox Style="{StaticResource textBoxInError}" Text="{Binding Password, UpdateSourceTrigger=PropertyChanged}" Width="150" Margin="0,5,0,25" />
+      <TextBox Style="{StaticResource textBoxInError}" Text="{Binding Password, UpdateSourceTrigger=PropertyChanged}" Width="200" Margin="0,5,0,25" />
     </StackPanel>
     <Button Command="{Binding Submit}" Content="Submit" Margin="0,40,10,5" Width="50" />
   </StackPanel>

--- a/src/Samples/Validation.Views/MainWindow.xaml
+++ b/src/Samples/Validation.Views/MainWindow.xaml
@@ -11,30 +11,7 @@
         mc:Ignorable="d"
         d:DataContext="{x:Static vm:Program.designVm}">
   <Window.Resources>
-    <Style x:Key="textBoxInErrorSingle" TargetType="Control">
-      <Setter Property="Validation.ErrorTemplate">
-        <Setter.Value>
-          <ControlTemplate>
-            <DockPanel>
-              <TextBlock DockPanel.Dock="Left" Foreground="Red" FontWeight="Bold">*</TextBlock>
-              <TextBlock Text="{Binding ErrorContent}" DockPanel.Dock="Bottom" Foreground="Red"/>
-              <Border BorderBrush="Red" BorderThickness="2">
-                <AdornedElementPlaceholder/>
-              </Border>
-            </DockPanel>
-          </ControlTemplate>
-        </Setter.Value>
-      </Setter>
-      <Style.Triggers>
-        <Trigger Property="Validation.HasError" Value="True">
-          <Setter
-            Property="ToolTip"
-            Value="{Binding RelativeSource={x:Static RelativeSource.Self},
-            Path=(Validation.Errors)/ErrorContent}" />
-        </Trigger>
-      </Style.Triggers>
-    </Style>
-    <Style x:Key="textBoxInErrorMultiple" TargetType="Control">
+    <Style x:Key="textBoxInError" TargetType="Control">
       <Setter Property="Validation.ErrorTemplate">
         <Setter.Value>
           <ControlTemplate>
@@ -59,11 +36,11 @@
   <StackPanel HorizontalAlignment="Center" Margin="0,25,0,0">
     <StackPanel Orientation="Horizontal">
       <TextBlock Text="Value:         "/>
-      <TextBox Style="{StaticResource textBoxInErrorSingle}"   Text="{Binding Value,    UpdateSourceTrigger=PropertyChanged}" Width="150" Margin="0,5,0,25" />
+      <TextBox Style="{StaticResource textBoxInError}"   Text="{Binding Value,    UpdateSourceTrigger=PropertyChanged}" Width="150" Margin="0,5,0,25" />
     </StackPanel>
     <StackPanel Orientation="Horizontal">
       <TextBlock Text="Password:   "/>
-      <TextBox Style="{StaticResource textBoxInErrorMultiple}" Text="{Binding Password, UpdateSourceTrigger=PropertyChanged}" Width="150" Margin="0,5,0,25" />
+      <TextBox Style="{StaticResource textBoxInError}" Text="{Binding Password, UpdateSourceTrigger=PropertyChanged}" Width="150" Margin="0,5,0,25" />
     </StackPanel>
     <Button Command="{Binding Submit}" Content="Submit" Margin="0,40,10,5" Width="50" />
   </StackPanel>

--- a/src/Samples/Validation.Views/MainWindow.xaml
+++ b/src/Samples/Validation.Views/MainWindow.xaml
@@ -36,7 +36,7 @@
   <StackPanel HorizontalAlignment="Center" Margin="0,25,0,0">
     <StackPanel Orientation="Horizontal">
       <TextBlock Text="Value:         "/>
-      <TextBox Style="{StaticResource textBoxInError}"   Text="{Binding Value,    UpdateSourceTrigger=PropertyChanged}" Width="150" Margin="0,5,0,25" />
+      <TextBox Style="{StaticResource textBoxInError}" Text="{Binding Value, UpdateSourceTrigger=PropertyChanged}" Width="150" Margin="0,5,0,25" />
     </StackPanel>
     <StackPanel Orientation="Horizontal">
       <TextBlock Text="Password:   "/>

--- a/src/Samples/Validation.Views/MainWindow.xaml
+++ b/src/Samples/Validation.Views/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="Elmish.WPF.Samples.Validation.MainWindow"
+<Window x:Class="Elmish.WPF.Samples.Validation.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -11,7 +11,7 @@
         mc:Ignorable="d"
         d:DataContext="{x:Static vm:Program.designVm}">
   <Window.Resources>
-    <Style x:Key="textBoxInError" TargetType="Control">
+    <Style x:Key="textBoxInErrorSingle" TargetType="Control">
       <Setter Property="Validation.ErrorTemplate">
         <Setter.Value>
           <ControlTemplate>
@@ -34,9 +34,37 @@
         </Trigger>
       </Style.Triggers>
     </Style>
+    <Style x:Key="textBoxInErrorMultiple" TargetType="Control">
+      <Setter Property="Validation.ErrorTemplate">
+        <Setter.Value>
+          <ControlTemplate>
+            <DockPanel>
+              <TextBlock DockPanel.Dock="Left" Foreground="Red" FontWeight="Bold">*</TextBlock>
+              <ItemsControl DockPanel.Dock="Bottom" ItemsSource="{Binding ElementName=placeholder, Path=AdornedElement.(Validation.Errors)}">
+                <ItemsControl.ItemTemplate>
+                  <DataTemplate>
+                    <TextBlock Text="{Binding ErrorContent}" Foreground="Red"/>
+                  </DataTemplate>
+                </ItemsControl.ItemTemplate>
+              </ItemsControl>
+              <Border BorderBrush="Red" BorderThickness="2">
+                <AdornedElementPlaceholder x:Name="placeholder"/>
+              </Border>
+            </DockPanel>
+          </ControlTemplate>
+        </Setter.Value>
+      </Setter>
+    </Style>
   </Window.Resources>
-  <StackPanel Margin="0,25,0,0">
-    <TextBox Style="{StaticResource textBoxInError}" Text="{Binding RawValue, UpdateSourceTrigger=PropertyChanged}" Width="150" Margin="0,5,0,25" />
-    <Button Command="{Binding Submit}" Content="Submit" Margin="0,5,10,5" Width="50" />
+  <StackPanel HorizontalAlignment="Center" Margin="0,25,0,0">
+    <StackPanel Orientation="Horizontal">
+      <TextBlock Text="Value:         "/>
+      <TextBox Style="{StaticResource textBoxInErrorSingle}"   Text="{Binding Value,    UpdateSourceTrigger=PropertyChanged}" Width="150" Margin="0,5,0,25" />
+    </StackPanel>
+    <StackPanel Orientation="Horizontal">
+      <TextBlock Text="Password:   "/>
+      <TextBox Style="{StaticResource textBoxInErrorMultiple}" Text="{Binding Password, UpdateSourceTrigger=PropertyChanged}" Width="150" Margin="0,5,0,25" />
+    </StackPanel>
+    <Button Command="{Binding Submit}" Content="Submit" Margin="0,40,10,5" Width="50" />
   </StackPanel>
 </Window>

--- a/src/Samples/Validation/Program.fs
+++ b/src/Samples/Validation/Program.fs
@@ -24,14 +24,14 @@ let validateInt42 =
 
 
 let validatePassword (s: string) =
-  seq {
+  [
     if s.All(fun c -> Char.IsDigit c |> not) then
       "Must contain a digit"
     if s.All(fun c -> Char.IsLower c |> not) then
       "Must contain a lowercase letter"
     if s.All(fun c -> Char.IsUpper c |> not) then
       "Must contain an uppercase letter"
-  } |> Seq.toList
+  ]
 
 
 type Model =


### PR DESCRIPTION
Resolves #314

This PR adds support for multiple validation errors.

Here are some interesting points about this implementation.
- Other than adding to the API support for a list of errors, I left the existing API as is.  Internally, I converted each `Option` and `ValueOption` to a `list`.
- Equality of errors is done by the equality for `string list`.  This means that the order of errors matters.  I think that is reasonable.
- The sample still includes the previous code in which there is only one validation error.  I added another text box that includes multiple validation errors.
- To quickly get this PR working, the `Submit` message in the sample no longer takes in the parsed data.  However, doing so is preferred.  As Mark Seemann [recently said](https://blog.ploeh.dk/2020/12/14/validation-a-solved-problem/), validation is a solve problem via applicative functors.  Unfortunately, F# doesn't include a `Validation<,>` monad.  I have created one in my project at work.  I could add that to the sample but that would also increase the learning curve.  Alternatively, one could just parse the input under the assumption it will succeed (via `int`) because the `canExec` function returned `true`.  This is not a good practice to do everywhere though.
- The red box around the text box containing the password is too long on the right side.  I don't know why and didn't try to fix it either.