### PR TITLE
Simplify FileDialog save/load

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,22 +283,6 @@ Sure! Just use `Binding.subModelWin`. It works like `Binding.subModel`, but has 
 
 Note that if you use `App.xaml` startup, you may want to set `ShutdownMode="OnMainWindowClose"` in `App.xaml` if that’s the desired behavior.
 
-#### How can I use Save File / Open File dialogs?
-
-There’s a few things to remember regarding opening on the UI thread and not blocking the Elmish dispatch loop. Check out the [FileDialogs sample](https://github.com/elmish/Elmish.WPF/tree/master/src/Samples). In short, write a function like below, and call it using `Cmd.OfAsync`.
-
-```f#
-let save text =
-  Application.Current.Dispatcher.Invoke(fun () ->
-    let guiCtx = SynchronizationContext.Current
-    async {
-      do! Async.SwitchToContext guiCtx
-      let dlg = Microsoft.Win32.SaveFileDialog ()
-      // configure dialog (extensions etc.), show it, handle result
-    }
-  )
-```
-
 #### Can I bind to events and use behaviors?
 
 Sure! Check out the [EventBindingsAndBehaviors sample](https://github.com/elmish/Elmish.WPF/tree/master/src/Samples). Note that you have to install the NuGet package `Microsoft.Xaml.Behaviors.Wpf`.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 * Changed CurrentModel and UpdateModel on ViewModel<_,_> from public to internal
 * Added support for composable binding validation
 * `runWindow` now shows the given window after settings its `DataContext`.  This removes the need to have `Visibility` values default to `Collapsed`.
+* Changed minimum Elmish version from 3.0.3 to 3.1.0 (which is currently the latest).  Commands created with `OfAsync` are now executed on a threadpool thread.  For example, it is now easier to show file dialogs without blocking the Elmish dispatch loop.  See [this diff](https://github.com/elmish/Elmish.WPF/commit/d1ec823ccd7f377a860b76bc2358706dc6a70c84).
 
 #### 4.0.0-beta-2
 * Added logging when INotifyDataErrorInfo.HasErrors is called

--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -44,7 +44,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Elmish" Version="[3.0.3, 3.99]" />
+    <PackageReference Include="Elmish" Version="[3.1.0, 3.99]" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.6" />
   </ItemGroup>
   

--- a/src/Samples/FileDialogs.Core/Program.fs
+++ b/src/Samples/FileDialogs.Core/Program.fs
@@ -1,9 +1,7 @@
-﻿module Elmish.WPF.Samples.FileDialogs.Program
+module Elmish.WPF.Samples.FileDialogs.Program
 
 open System
 open System.IO
-open System.Threading
-open System.Windows
 open Serilog
 open Serilog.Extensions.Logging
 open Elmish
@@ -36,36 +34,28 @@ type Msg =
 
 
 let save text =
-  Application.Current.Dispatcher.Invoke(fun () ->
-    let guiCtx = SynchronizationContext.Current
-    async {
-      do! Async.SwitchToContext guiCtx
-      let dlg = Microsoft.Win32.SaveFileDialog ()
-      dlg.Filter <- "Text file (*.txt)|*.txt|Markdown file (*.md)|*.md"
-      let result = dlg.ShowDialog ()
-      if result.HasValue && result.Value then
-        do! File.WriteAllTextAsync(dlg.FileName, text) |> Async.AwaitTask
-        return SaveSuccess
-      else return SaveCanceled
-    }
-  )
+  async {
+    let dlg = Microsoft.Win32.SaveFileDialog ()
+    dlg.Filter <- "Text file (*.txt)|*.txt|Markdown file (*.md)|*.md"
+    let result = dlg.ShowDialog ()
+    if result.HasValue && result.Value then
+      do! File.WriteAllTextAsync(dlg.FileName, text) |> Async.AwaitTask
+      return SaveSuccess
+    else return SaveCanceled
+  }
 
 
 let load () =
-  Application.Current.Dispatcher.Invoke(fun () ->
-    let guiCtx = SynchronizationContext.Current
-    async {
-      do! Async.SwitchToContext guiCtx
-      let dlg = Microsoft.Win32.OpenFileDialog ()
-      dlg.Filter <- "Text file (*.txt)|*.txt|Markdown file (*.md)|*.md"
-      dlg.DefaultExt <- "txt"
-      let result = dlg.ShowDialog ()
-      if result.HasValue && result.Value then
-        let! contents = File.ReadAllTextAsync(dlg.FileName) |> Async.AwaitTask
-        return LoadSuccess contents
-      else return LoadCanceled
-    }
-  )
+  async {
+    let dlg = Microsoft.Win32.OpenFileDialog ()
+    dlg.Filter <- "Text file (*.txt)|*.txt|Markdown file (*.md)|*.md"
+    dlg.DefaultExt <- "txt"
+    let result = dlg.ShowDialog ()
+    if result.HasValue && result.Value then
+      let! contents = File.ReadAllTextAsync(dlg.FileName) |> Async.AwaitTask
+      return LoadSuccess contents
+    else return LoadCanceled
+  }
 
 
 let update msg m =

--- a/src/Samples/FileDialogsCmdMsg.Core/Program.fs
+++ b/src/Samples/FileDialogsCmdMsg.Core/Program.fs
@@ -58,8 +58,6 @@ module Core =
 module Platform =
 
   open System.IO
-  open System.Threading
-  open System.Windows
   open Core
 
 
@@ -73,36 +71,28 @@ module Platform =
 
 
   let save text =
-    Application.Current.Dispatcher.Invoke(fun () ->
-      let guiCtx = SynchronizationContext.Current
-      async {
-        do! Async.SwitchToContext guiCtx
-        let dlg = Microsoft.Win32.SaveFileDialog ()
-        dlg.Filter <- "Text file (*.txt)|*.txt|Markdown file (*.md)|*.md"
-        let result = dlg.ShowDialog ()
-        if result.HasValue && result.Value then
-          do! File.WriteAllTextAsync(dlg.FileName, text) |> Async.AwaitTask
-          return SaveSuccess
-        else return SaveCanceled
-      }
-    )
+    async {
+      let dlg = Microsoft.Win32.SaveFileDialog ()
+      dlg.Filter <- "Text file (*.txt)|*.txt|Markdown file (*.md)|*.md"
+      let result = dlg.ShowDialog ()
+      if result.HasValue && result.Value then
+        do! File.WriteAllTextAsync(dlg.FileName, text) |> Async.AwaitTask
+        return SaveSuccess
+      else return SaveCanceled
+    }
 
 
   let load () =
-    Application.Current.Dispatcher.Invoke(fun () ->
-      let guiCtx = SynchronizationContext.Current
-      async {
-        do! Async.SwitchToContext guiCtx
-        let dlg = Microsoft.Win32.OpenFileDialog ()
-        dlg.Filter <- "Text file (*.txt)|*.txt|Markdown file (*.md)|*.md"
-        dlg.DefaultExt <- "txt"
-        let result = dlg.ShowDialog ()
-        if result.HasValue && result.Value then
-          let! contents = File.ReadAllTextAsync(dlg.FileName) |> Async.AwaitTask
-          return LoadSuccess contents
-        else return LoadCanceled
-      }
-    )
+    async {
+      let dlg = Microsoft.Win32.OpenFileDialog ()
+      dlg.Filter <- "Text file (*.txt)|*.txt|Markdown file (*.md)|*.md"
+      dlg.DefaultExt <- "txt"
+      let result = dlg.ShowDialog ()
+      if result.HasValue && result.Value then
+        let! contents = File.ReadAllTextAsync(dlg.FileName) |> Async.AwaitTask
+        return LoadSuccess contents
+      else return LoadCanceled
+    }
 
 
   let toCmd = function


### PR DESCRIPTION
I don't think the `save` or `load` functions need to be executed on the main thread.  This can be tested by adding the line
```fsharp
do! Async.SwitchToThreadPool ()
```
to the beginning of these CEs on this branch.  Everything still works.