### PR TITLE
Set DataContext before showing window

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 * Improved logging
 * Changed CurrentModel and UpdateModel on ViewModel<_,_> from public to internal
 * Added support for composable binding validation
+* `runWindow` now shows the given window after settings its `DataContext`.  This removes the need to have `Visibility` values default to `Collapsed`.
 
 #### 4.0.0-beta-2
 * Added logging when INotifyDataErrorInfo.HasErrors is called

--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -97,8 +97,8 @@ module WpfProgram =
   /// startElmishLoop.
   let runWindow window program =
     initializeApplication window
-    window.Show ()
     startElmishLoop window program
+    window.Show ()
     Application.Current.Run window
 
 

--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -96,6 +96,15 @@ module WpfProgram =
   /// blocking function. If you are using App.xaml as an implicit entry point, see
   /// startElmishLoop.
   let runWindow window program =
+    (*
+     * This is the correct order for these four statements.
+     * 1. Initialize Application.Current and set its MainWindow in case the
+     *    user code accesses either of these when initializing the bindings.
+     * 2. Start the Elmish loop, which will cause the main view model to be
+     *    created and assigned to the window's DataContext before returning.
+     * 3. Show the window now that the DataContext is set.
+     * 4. Run the current application, which must be last because it is blocking.
+     *)
     initializeApplication window
     startElmishLoop window program
     window.Show ()

--- a/src/Samples/SubModelOpt/MainWindow.xaml
+++ b/src/Samples/SubModelOpt/MainWindow.xaml
@@ -24,13 +24,13 @@
     <Rectangle
         Fill="Black"
         Opacity="0.6"
-        Visibility="{Binding DialogVisible, Converter={StaticResource VisibilityConverter}, FallbackValue=Collapsed}" />
+        Visibility="{Binding DialogVisible, Converter={StaticResource VisibilityConverter}}" />
     <Border
         BorderBrush="Black"
         BorderThickness="2"
         Width="350"
         Height="200"
-        Visibility="{Binding DialogVisible, Converter={StaticResource VisibilityConverter}, FallbackValue=Collapsed}">
+        Visibility="{Binding DialogVisible, Converter={StaticResource VisibilityConverter}}">
       <StackPanel Background="White">
         <local:Form1
             DataContext="{Binding Form1}"


### PR DESCRIPTION
We are showing the window too early.  We should only show the window after we assign our view model to its `DataContext`.

Here is how this can go wrong.  Suppose the binding initialization code takes a long time.  In the following example, I added a two-second delay to the `SubModelOpt` sample.  I also removed the `Visibility` fallbacks to `Collapsed`.  I also changed to entry point to be an explicit `Main` method.  Then this is what happens: both forms are visible during that two-second loading time.

![2021-02-19_13-46-56_523](https://user-images.githubusercontent.com/34664007/108556107-1a901380-72bc-11eb-86a8-70aa3c4fbe57.gif)

After making the change in this PR, which is to start the Elmish dispatch loop first and then show the window, the behavior is good.  Specifically, the window does not open during that two second delay.  When it does open, no forms are visible, which is the correct behavior.

![2021-02-19_13-45-48_521](https://user-images.githubusercontent.com/34664007/108556234-53c88380-72bc-11eb-965f-5af6b9bc14c3.gif)
