### PR TITLE
stop subscriptions on window close, which is before dispatcher is disposed

### DIFF
--- a/src/Samples/FileDialogs.Core/Program.fs
+++ b/src/Samples/FileDialogs.Core/Program.fs
@@ -1,6 +1,9 @@
 module Elmish.WPF.Samples.FileDialogs.Program
 
 open System
+open System.Threading
+open System.Threading.Tasks
+open System.Windows
 open System.IO
 open Serilog
 open Serilog.Extensions.Logging
@@ -84,13 +87,7 @@ let bindings () : Binding<Model, Msg> list = [
 let designVm = ViewModel.designInstance (init () |> fst) (bindings ())
 
 
-let timerTick dispatch =
-  let timer = new Timers.Timer(1000.)
-  timer.Elapsed.Add (fun _ -> dispatch (SetTime DateTimeOffset.Now))
-  timer.Start()
-
-
-let main window =
+let main (window: Window) =
 
   let logger =
     LoggerConfiguration()
@@ -99,6 +96,25 @@ let main window =
       .MinimumLevel.Override("Elmish.WPF.Performance", Events.LogEventLevel.Verbose)
       .WriteTo.Console()
       .CreateLogger()
+
+  let tcs = TaskCompletionSource<unit> ()
+  let cts = new CancellationTokenSource ()
+
+  let timerTick dispatch =
+    let async =
+      async {
+        use! d = Async.OnCancel (tcs.TrySetResult >> ignore)
+        while true do
+          do! Async.Sleep 1000
+          DateTimeOffset.Now |> SetTime |> dispatch
+      }
+    Async.Start(async, cts.Token)
+
+  let onClosing (args: System.ComponentModel.CancelEventArgs) =
+    cts.Cancel ()
+    tcs.Task |> Async.AwaitTask |> Async.RunSynchronously
+
+  window.Closing.Subscribe onClosing |> ignore
 
   WpfProgram.mkProgram init update bindings
   |> WpfProgram.withSubscription (fun _ -> Cmd.ofSub timerTick)


### PR DESCRIPTION
Fixes #353

The only changes are in the samples.  The new code stops the infinite loops inside the subscriptions that would otherwise dispatch a message to a disposed `Dispatcher`.

Issue #353 becomes perfectly repeatable for me (in my experience) after decreasing the sleep time `1000` to `10`.  Do that as well as comment out the subscription to `Window.OnClosing` to confirm that the issue also becomes perfectly repeatable for you.  Then comment that line back in to verify that this fix works.

@BentTranberg, I think this fixes #353.  Do you agree? 