### PR TITLE
Dispatch only if dispatcher is active

### DIFF
--- a/src/Elmish.WPF/AutoOpen.fs
+++ b/src/Elmish.WPF/AutoOpen.fs
@@ -3,6 +3,7 @@ module internal AutoOpen
 
 open System
 open System.Collections.Generic
+open System.Threading.Tasks
 open System.Windows.Threading
 
 
@@ -17,5 +18,6 @@ let (|Kvp|) (kvp: KeyValuePair<_,_>) =
 
 type Dispatcher with
   member this.InvokeIfActive(callback: Action) =
-    if not this.HasShutdownStarted then
+    try
       this.Invoke(callback)
+    with :? TaskCanceledException -> ()

--- a/src/Elmish.WPF/AutoOpen.fs
+++ b/src/Elmish.WPF/AutoOpen.fs
@@ -1,7 +1,9 @@
 ﻿[<AutoOpen>]
 module internal AutoOpen
 
+open System
 open System.Collections.Generic
+open System.Windows.Threading
 
 
 let flip f b a = f a b
@@ -11,3 +13,9 @@ let ignore2 _ _ = ()
 /// Deconstructs a KeyValuePair into a tuple.
 let (|Kvp|) (kvp: KeyValuePair<_,_>) =
   Kvp (kvp.Key, kvp.Value)
+
+
+type Dispatcher with
+  member this.InvokeIfActive(callback: Action) =
+    if not this.HasShutdownStarted then
+      this.Invoke(callback)

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -154,7 +154,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
       initialVisibility =
     let win = getWindow currentModel dispatch
     winRef.SetTarget win
-    win.Dispatcher.Invoke(fun () ->
+    win.Dispatcher.InvokeIfActive(fun () ->
       let guiCtx = System.Threading.SynchronizationContext.Current
       async {
         win.DataContext <- dataContext
@@ -368,7 +368,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
             | true, w ->
                 log.LogTrace("[{BindingNameChain}] Closing window", winPropChain)
                 b.WinRef.SetTarget null
-                w.Dispatcher.Invoke(fun () -> w.Close ())
+                w.Dispatcher.InvokeIfActive(fun () -> w.Close ())
             b.WinRef.SetTarget null
 
           let hide () =
@@ -377,7 +377,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
                 log.LogError("[{BindingNameChain}] Attempted to hide window, but did not find window reference", winPropChain)
             | true, w ->
                 log.LogTrace("[{BindingNameChain}] Hiding window", winPropChain)
-                w.Dispatcher.Invoke(fun () -> w.Visibility <- Visibility.Hidden)
+                w.Dispatcher.InvokeIfActive(fun () -> w.Visibility <- Visibility.Hidden)
 
           let showHidden () =
             match b.WinRef.TryGetTarget () with
@@ -385,7 +385,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
                 log.LogError("[{BindingNameChain}] Attempted to show existing hidden window, but did not find window reference", winPropChain)
             | true, w ->
                 log.LogTrace("[{BindingNameChain}] Showing existing hidden window", winPropChain)
-                w.Dispatcher.Invoke(fun () -> w.Visibility <- Visibility.Visible)
+                w.Dispatcher.InvokeIfActive(fun () -> w.Visibility <- Visibility.Visible)
 
           let showNew vm initialVisibility =
             b.PreventClose := true

--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -67,7 +67,7 @@ module WpfProgram =
           vm.UpdateModel model
 
     let uiDispatch (innerDispatch: Dispatch<'msg>) : Dispatch<'msg> =
-      fun msg -> element.Dispatcher.Invoke(fun () -> innerDispatch msg)
+      fun msg -> element.Dispatcher.InvokeIfActive(fun () -> innerDispatch msg)
 
     let logMsgAndModel (msg: 'msg) (model: 'model) = 
       updateLogger.LogTrace("New message: {Message}\nUpdated state:\n{Model}", msg, model)


### PR DESCRIPTION
Closes #355

Fixes #353 
Fixes #330 (as of https://github.com/elmish/Elmish.WPF/pull/358/commits/a0f75c1ef9bc300f5a98e2c2a2a00b0018490600)

From https://github.com/elmish/Elmish.WPF/pull/355#issuecomment-787956342:

> I would also prefer a fix in Elmish.WPF instead. However, as @BentTranberg pointed out in [#353 (comment)](https://github.com/elmish/Elmish.WPF/issues/353#issue-818153279), a fix in Elmish.WPF for #353 would probably also be a fix for #330, but as I said in [#330 (comment)](https://github.com/elmish/Elmish.WPF/issues/330#issuecomment-773346512), I don't have any more ideas for what a fix in Elmish.WPF could be.

I may be missing something, but I just dotted into `Dispatcher` and saw it had an `HasShutdownStarted` property, so I figured I could try guarding `Invoke` behind a check to that property. Seems to work like a charm.

The changes in `ViewModel.fs` are not needed to address #330 and #353, but for good measure I added this everywhere we call `Dispatch`.

~Haven't looked into why this doesn't fix #330. Feel free to investigate.~

Waiting for review and/or further discussion before merging.