### PR TITLE
Close window and dispatch messages via Dispatcher.InovkeAsync

### DIFF
--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -6,6 +6,7 @@ open System.Collections.Generic
 open System.Collections.ObjectModel
 open System.ComponentModel
 open System.Windows
+open System.Windows.Threading
 open Microsoft.Extensions.Logging
 
 open Elmish
@@ -368,7 +369,13 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
             | true, w ->
                 log.LogTrace("[{BindingNameChain}] Closing window", winPropChain)
                 b.WinRef.SetTarget null
-                w.Dispatcher.Invoke(fun () -> w.Close ())
+                (*
+                 * The Window might be in the process of closing,
+                 * so instead of immediately exeucting Window.Close via Dispatcher.Invoke,
+                 * queue a call to Window.Close via Dispatcher.BeginInvoke.
+                 * https://github.com/elmish/Elmish.WPF/issues/330
+                 *)
+                w.Dispatcher.BeginInvoke(DispatcherPriority.Normal, Action(w.Close)) |> ignore
             b.WinRef.SetTarget null
 
           let hide () =

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -6,7 +6,6 @@ open System.Collections.Generic
 open System.Collections.ObjectModel
 open System.ComponentModel
 open System.Windows
-open System.Windows.Threading
 open Microsoft.Extensions.Logging
 
 open Elmish
@@ -372,10 +371,10 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
                 (*
                  * The Window might be in the process of closing,
                  * so instead of immediately exeucting Window.Close via Dispatcher.Invoke,
-                 * queue a call to Window.Close via Dispatcher.BeginInvoke.
+                 * queue a call to Window.Close via Dispatcher.InvokeAsync.
                  * https://github.com/elmish/Elmish.WPF/issues/330
                  *)
-                w.Dispatcher.BeginInvoke(DispatcherPriority.Normal, Action(w.Close)) |> ignore
+                w.Dispatcher.InvokeAsync(w.Close) |> ignore
             b.WinRef.SetTarget null
 
           let hide () =

--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -1,8 +1,6 @@
 ﻿namespace Elmish.WPF
 
-open System
 open System.Windows
-open System.Windows.Threading
 open Microsoft.Extensions.Logging
 open Microsoft.Extensions.Logging.Abstractions
 open Elmish
@@ -69,9 +67,7 @@ module WpfProgram =
           vm.UpdateModel model
 
     let uiDispatch (innerDispatch: Dispatch<'msg>) : Dispatch<'msg> =
-      fun msg ->
-        let f () = innerDispatch msg
-        element.Dispatcher.BeginInvoke(DispatcherPriority.Normal, Action(f)) |> ignore
+      fun msg -> element.Dispatcher.InvokeAsync(fun () -> innerDispatch msg) |> ignore
 
     let logMsgAndModel (msg: 'msg) (model: 'model) = 
       updateLogger.LogTrace("New message: {Message}\nUpdated state:\n{Model}", msg, model)

--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -1,6 +1,8 @@
 ﻿namespace Elmish.WPF
 
+open System
 open System.Windows
+open System.Windows.Threading
 open Microsoft.Extensions.Logging
 open Microsoft.Extensions.Logging.Abstractions
 open Elmish
@@ -67,7 +69,9 @@ module WpfProgram =
           vm.UpdateModel model
 
     let uiDispatch (innerDispatch: Dispatch<'msg>) : Dispatch<'msg> =
-      fun msg -> element.Dispatcher.Invoke(fun () -> innerDispatch msg)
+      fun msg ->
+        let f () = innerDispatch msg
+        element.Dispatcher.BeginInvoke(DispatcherPriority.Normal, Action(f)) |> ignore
 
     let logMsgAndModel (msg: 'msg) (model: 'model) = 
       updateLogger.LogTrace("New message: {Message}\nUpdated state:\n{Model}", msg, model)


### PR DESCRIPTION
Fixes #330
Fixes #353
Closes #355
Closes #358

Calling `Window.Close` is not allowed when the `Window` in question is in the process of closing.  In case that is the situation, we can avoid this below slightly delaying our call to `Window.Close` by using `Dispatcher.BeginInvoke`.