### PR TITLE
removed UseWpf in samples

### DIFF
--- a/src/Samples/EventBindingsAndBehaviors.Core/EventBindingsAndBehaviors.Core.fsproj
+++ b/src/Samples/EventBindingsAndBehaviors.Core/EventBindingsAndBehaviors.Core.fsproj
@@ -2,7 +2,6 @@
   
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   

--- a/src/Samples/FileDialogs.Core/FileDialogs.Core.fsproj
+++ b/src/Samples/FileDialogs.Core/FileDialogs.Core.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   

--- a/src/Samples/FileDialogsCmdMsg.Core/FileDialogsCmdMsg.Core.fsproj
+++ b/src/Samples/FileDialogsCmdMsg.Core/FileDialogsCmdMsg.Core.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   

--- a/src/Samples/NewWindow.Core/NewWindow.Core.fsproj
+++ b/src/Samples/NewWindow.Core/NewWindow.Core.fsproj
@@ -2,7 +2,6 @@
   
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   

--- a/src/Samples/OneWaySeq.Core/OneWaySeq.Core.fsproj
+++ b/src/Samples/OneWaySeq.Core/OneWaySeq.Core.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   

--- a/src/Samples/SingleCounter.Core/SingleCounter.Core.fsproj
+++ b/src/Samples/SingleCounter.Core/SingleCounter.Core.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   

--- a/src/Samples/Sticky.Core/Sticky.Core.fsproj
+++ b/src/Samples/Sticky.Core/Sticky.Core.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   

--- a/src/Samples/SubModel.Core/SubModel.Core.fsproj
+++ b/src/Samples/SubModel.Core/SubModel.Core.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   

--- a/src/Samples/SubModelOpt.Core/SubModelOpt.Core.fsproj
+++ b/src/Samples/SubModelOpt.Core/SubModelOpt.Core.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   

--- a/src/Samples/SubModelSelectedItem.Core/SubModelSelectedItem.Core.fsproj
+++ b/src/Samples/SubModelSelectedItem.Core/SubModelSelectedItem.Core.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   

--- a/src/Samples/SubModelSeq.Core/SubModelSeq.Core.fsproj
+++ b/src/Samples/SubModelSeq.Core/SubModelSeq.Core.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   

--- a/src/Samples/UiBoundCmdParam.Core/UiBoundCmdParam.Core.fsproj
+++ b/src/Samples/UiBoundCmdParam.Core/UiBoundCmdParam.Core.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   

--- a/src/Samples/Validation.Core/Validation.Core.fsproj
+++ b/src/Samples/Validation.Core/Validation.Core.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
-    <UseWpf>true</UseWpf>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   


### PR DESCRIPTION
Replaces #282

This PR removes the line
```xml
<UseWpf>true</UseWpf>
```
from all of `Core` sample projects.

Removing this line from these projects was not possible when PR #282 was created because we were still targeting .NET Core 3 (`netcoreapp3.0` or `netcoreapp3.1`).  Now we are targeting .NET 5 (`net5.0-windows`).  When this change was made in 77635638db374328b1d091d75ea38ca2d39e5989, the SDK was simplified.  I have now realized that we could have also removed this line as well.

@cmeeren, since you previously said in https://github.com/elmish/Elmish.WPF/pull/282#issuecomment-705178872 that you were indifferent to this kind of change, I will merge when the build successfully completes.