### PR TITLE
Replace async CE with InvokeAsync in showNewWindow

### DIFF
--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -154,36 +154,37 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
       initialVisibility =
     let win = getWindow currentModel dispatch
     winRef.SetTarget win
-    win.Dispatcher.Invoke(fun () ->
-      let guiCtx = System.Threading.SynchronizationContext.Current
-      async {
-        win.DataContext <- dataContext
-        win.Closing.Add(fun ev ->
-          ev.Cancel <- !preventClose
-          async {
-            do! Async.SwitchToThreadPool()
-            onCloseRequested currentModel
-          } |> Async.StartImmediate
-        )
-        do! Async.SwitchToContext guiCtx
-        if isDialog then
-          win.ShowDialog () |> ignore
-        else
-          (*
-           * Calling Show achieves the same end result as setting Visibility
-           * property of the Window object to Visible. However, there is a
-           * difference between the two from a timing perspective.
-           *
-           * Calling Show is a synchronous operation that returns only after
-           * the Loaded event on the child window has been raised.
-           *
-           * Setting Visibility, however, is an asynchronous operation that
-           * returns immediately
-           * https://docs.microsoft.com/en-us/dotnet/api/system.windows.window.show
-           *)
-          win.Visibility <- initialVisibility
-      } |> Async.StartImmediate
-    )
+    (*
+     * A different thread might own this Window, so must use its Dispatcher.
+     * Invoking asynchronously since ShowDialog is a blocking call. Otherwise,
+     * invoking ShowDialog synchronously blocks the Elmish dispatch loop.
+     *)
+    win.Dispatcher.InvokeAsync(fun () ->
+      win.DataContext <- dataContext
+      win.Closing.Add(fun ev ->
+        ev.Cancel <- !preventClose
+        async {
+          do! Async.SwitchToThreadPool()
+          onCloseRequested currentModel
+        } |> Async.StartImmediate
+      )
+      if isDialog then
+        win.ShowDialog () |> ignore
+      else
+        (*
+         * Calling Show achieves the same end result as setting Visibility
+         * property of the Window object to Visible. However, there is a
+         * difference between the two from a timing perspective.
+         *
+         * Calling Show is a synchronous operation that returns only after
+         * the Loaded event on the child window has been raised.
+         *
+         * Setting Visibility, however, is an asynchronous operation that
+         * returns immediately
+         * https://docs.microsoft.com/en-us/dotnet/api/system.windows.window.show
+         *)
+        win.Visibility <- initialVisibility
+    ) |> ignore
 
   let initializeBinding name getInitializedBindingByName addValdiationBinding =
     let measure x = x |> measure name


### PR DESCRIPTION
Partially addresses #363.

The indentation changed, so be sure to view the diff while ignoring whitespace changes.

This PR replaces the "outer" use of the `async` computational expression in the `showNewWindow` function.

Contrary to my initial guess in #363, I was wrong about this use of `Dispatcher` being unnecessary.  As I also documented in a comment, `Dispatcher` is required here because the `Window` might be owned by a different thread (which I verified programmatically).

By calling `Async.StartImmediate`, the current thread is used to execute the CE.  That same thread is captured in `guiCtx`, so switching to it does nothing.  Except it does to one thing, which is cause the runtime to stop synchronous execution of this `Async` instance.  Instead of capturing and switching to the already executing thread, it suffices to execute
```fsharp
do! Async.Sleep 1
```
to cause synchronous execution to stop.

There is a more direct way to achieve this behavior, which is to queue this computation with the `Dispatcher` via `InvokeAsync`.