### PR TITLE
removed async CE in window closing event

### DIFF
--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -163,10 +163,7 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
       win.DataContext <- dataContext
       win.Closing.Add(fun ev ->
         ev.Cancel <- !preventClose
-        async {
-          do! Async.SwitchToThreadPool()
-          currentModel |> onCloseRequested |> ValueOption.iter dispatch
-        } |> Async.StartImmediate
+        currentModel |> onCloseRequested |> ValueOption.iter dispatch
       )
       if isDialog then
         win.ShowDialog () |> ignore


### PR DESCRIPTION
This PR deletes three lines and changes the indentation of one line, so it helps to view the diff while ignoring whitespace changes.

I think the `async` computational expression is not needed in the callback given to the `Window.Closing` event.  It might have been needed before.  Now though, invoking `dispatch` eventually leads to this asynchronous `Dispatcher` execution.
https://github.com/elmish/Elmish.WPF/blob/cdf421f9ec7c3ec4d6d3e3923cd20786004ed098/src/Elmish.WPF/WpfProgram.fs#L70