### PR TITLE
removed workaround for DataContext bug in .NET 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,25 +258,6 @@ Then use the following attributes wherever you need a design-time VM:
 
 When targeting legacy .NET Framework, “Project code” must be enabled in the XAML designer for this to work.
 
-##### .NET Core 3 workaround
-
-When targeting .NET Core 3, a bug in the XAML designer causes design-time data to not be displayed through `DataContext` bindings. See [this issue](https://developercommunity.visualstudio.com/content/problem/1133390/design-time-data-in-datacontext-binding-not-displa.html) for details. One workaround is to add a `d:DataContext` binding alongside your normal `DataContext` binding. Another workaround is to change
-
-```xaml
-<local:MyControl DataContext="{Binding Child}" />
-```
-
-to
-
-```xaml
-<local:MyControl
-  DataContext="{Binding Child}"
-  d:DataContext="{Binding DataContext.Child,
-                          RelativeSource={RelativeSource AncestorType=T}}" />
-```
-
-where `T` is the type of the parent object that contains `local:MyControl` (or a more distant ancestor, though there are issues with using `Window` as the type).
-
 #### Can I open new windows/dialogs?
 
 Sure! Just use `Binding.subModelWin`. It works like `Binding.subModel`, but has a `WindowState` wrapper around the returned model to control whether the window is closed, hidden, or visible. You can use both modal and non-modal windows/dialogs, and everything is a part of the Elmish core loop. Check out the [NewWindow sample](https://github.com/elmish/Elmish.WPF/tree/master/src/Samples).

--- a/src/Samples/SubModel/CounterWithClock.xaml
+++ b/src/Samples/SubModel/CounterWithClock.xaml
@@ -8,7 +8,7 @@
              mc:Ignorable="d"
              d:DataContext="{x:Static vm:Program.counterWithClockDesignVm}">
   <StackPanel>
-    <local:Counter DataContext="{Binding Counter}" d:DataContext="{Binding DataContext.Counter, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />
-    <local:Clock DataContext="{Binding Clock}" d:DataContext="{Binding DataContext.Clock, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />
+    <local:Counter DataContext="{Binding Counter}" HorizontalAlignment="Center" />
+    <local:Clock DataContext="{Binding Clock}" HorizontalAlignment="Center" />
   </StackPanel>
 </UserControl>

--- a/src/Samples/SubModel/MainWindow.xaml
+++ b/src/Samples/SubModel/MainWindow.xaml
@@ -13,8 +13,8 @@
         d:DataContext="{x:Static vm:Program.mainDesignVm}">
   <StackPanel>
     <TextBlock Text="Counter with clock 1" FontSize="18" FontWeight="Bold" Margin="0,25,0,0" HorizontalAlignment="Center" />
-    <local:CounterWithClock DataContext="{Binding ClockCounter1}" d:DataContext="{Binding DataContext.ClockCounter1, RelativeSource={RelativeSource AncestorType=StackPanel}}"/>
+    <local:CounterWithClock DataContext="{Binding ClockCounter1}" />
     <TextBlock Text="Counter with clock 2" FontSize="18" FontWeight="Bold" Margin="0,25,0,0" HorizontalAlignment="Center" />
-    <local:CounterWithClock DataContext="{Binding ClockCounter2}" d:DataContext="{Binding DataContext.ClockCounter2, RelativeSource={RelativeSource AncestorType=StackPanel}}"/>
+    <local:CounterWithClock DataContext="{Binding ClockCounter2}" />
   </StackPanel>
 </Window>

--- a/src/Samples/SubModelOpt/MainWindow.xaml
+++ b/src/Samples/SubModelOpt/MainWindow.xaml
@@ -34,13 +34,11 @@
       <StackPanel Background="White">
         <local:Form1
             DataContext="{Binding Form1}"
-            d:DataContext="{Binding DataContext.Form1, RelativeSource={RelativeSource AncestorType=StackPanel}}"
             Visibility="{Binding DataContext.Form1Visible,
                          RelativeSource={RelativeSource AncestorType=StackPanel},
                          Converter={StaticResource VisibilityConverter}}" />
         <local:Form2
             DataContext="{Binding Form2}"
-            d:DataContext="{Binding DataContext.Form2, RelativeSource={RelativeSource AncestorType=StackPanel}}"
             Visibility="{Binding DataContext.Form2Visible,
                          RelativeSource={RelativeSource AncestorType=StackPanel},
                          Converter={StaticResource VisibilityConverter}}" />


### PR DESCRIPTION
The `DataContext` binding bug at design-time seems to be fixed now.  This PR removes the workaround we were using.  I verified that the binding is working correctly at design-time in all of those cases.