### PR TITLE
Restore the wrapDispatch parameter

### DIFF
--- a/src/Elmish.WPF.Tests/BindingTests.fs
+++ b/src/Elmish.WPF.Tests/BindingTests.fs
@@ -1857,7 +1857,7 @@ module cmdParamIf =
     let ``sets the correct binding name`` () =
       Property.check <| property {
         let! bindingName = GenX.auto<string>
-        let binding = bindingName |> Binding.cmdParamIf(fail, fail)
+        let binding = bindingName |> Binding.cmdParamIf(fail, fail, id)
         test <@ binding.Name = bindingName @>
       }
 
@@ -1891,7 +1891,7 @@ module cmdParamIf =
     [<Fact>]
     let ``final autoRequery defaults to false`` () =
       Property.check <| property {
-        let d = Binding.cmdParamIf(fail, fail) |> getCmdData
+        let d = Binding.cmdParamIf(fail, fail, id) |> getCmdData
         test <@ d.AutoRequery = false @>
       }
 
@@ -1900,7 +1900,7 @@ module cmdParamIf =
     let ``final autoRequery equals original uiBoundCmdParam`` () =
       Property.check <| property {
         let! uiBoundCmdParam = GenX.auto<bool>
-        let d = Binding.cmdParamIf(fail, fail, uiBoundCmdParam = uiBoundCmdParam) |> getCmdData
+        let d = Binding.cmdParamIf(fail, fail, uiBoundCmdParam, id) |> getCmdData
         test <@ d.AutoRequery = uiBoundCmdParam @>
       }
 

--- a/src/Elmish.WPF.Tests/BindingTests.fs
+++ b/src/Elmish.WPF.Tests/BindingTests.fs
@@ -1891,7 +1891,7 @@ module cmdParamIf =
     [<Fact>]
     let ``final autoRequery defaults to false`` () =
       Property.check <| property {
-        let d = Binding.cmdParamIf(fail, fail, id) |> getCmdData
+        let d = Binding.cmdParamIf(fail, fail, false) |> getCmdData
         test <@ d.AutoRequery = false @>
       }
 
@@ -1900,7 +1900,7 @@ module cmdParamIf =
     let ``final autoRequery equals original uiBoundCmdParam`` () =
       Property.check <| property {
         let! uiBoundCmdParam = GenX.auto<bool>
-        let d = Binding.cmdParamIf(fail, fail, uiBoundCmdParam, id) |> getCmdData
+        let d = Binding.cmdParamIf(fail, fail, uiBoundCmdParam) |> getCmdData
         test <@ d.AutoRequery = uiBoundCmdParam @>
       }
 

--- a/src/Elmish.WPF.Tests/BindingTests.fs
+++ b/src/Elmish.WPF.Tests/BindingTests.fs
@@ -1699,7 +1699,7 @@ module cmdIf =
     let ``sets the correct binding name`` () =
       Property.check <| property {
         let! bindingName = GenX.auto<string>
-        let binding = bindingName |> Binding.cmdIf(fail, fail)
+        let binding = bindingName |> Binding.cmdIf(fail, fail, id)
         test <@ binding.Name = bindingName @>
       }
 

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -2155,6 +2155,26 @@ type Binding private () =
   /// </summary>
   /// <param name="exec">Returns the message to dispatch.</param>
   /// <param name="canExec">Indicates whether the command can execute.</param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member cmdParamIf
+      (exec: obj -> 'model -> 'msg,
+       canExec: obj -> 'model -> bool,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.cmdParamIf (exec, canExec)
+    >> Binding.alterMsgStream wrapDispatch
+
+  /// <summary>
+  ///   Creates a <c>Command</c> binding that depends on the
+  ///   <c>CommandParameter</c>
+  ///   and can execute if <paramref name="canExec" /> returns <c>true</c>.
+  /// </summary>
+  /// <param name="exec">Returns the message to dispatch.</param>
+  /// <param name="canExec">Indicates whether the command can execute.</param>
   /// <param name="uiBoundCmdParam">
   ///   If <c>true</c>, <c>CanExecuteChanged</c> will trigger every time WPF's
   ///   <c>CommandManager</c>
@@ -2171,11 +2191,11 @@ type Binding private () =
   static member cmdParamIf
       (exec: obj -> 'model -> 'msg,
        canExec: obj -> 'model -> bool,
-       ?uiBoundCmdParam: bool,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       uiBoundCmdParam: bool,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
       : string -> Binding<'model, 'msg> =
-    Binding.cmdParamIf (exec, canExec, defaultArg uiBoundCmdParam false)
-    >> (wrapDispatch |> Option.map Binding.alterMsgStream |> Option.defaultValue id)
+    Binding.cmdParamIf (exec, canExec, uiBoundCmdParam)
+    >> Binding.alterMsgStream wrapDispatch
 
 
   /// <summary>
@@ -2207,6 +2227,24 @@ type Binding private () =
   ///   and can execute if <paramref name="exec" /> returns <c>ValueSome</c>.
   /// </summary>
   /// <param name="exec">Returns the message to dispatch.</param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member cmdParamIf
+      (exec: obj -> 'model -> 'msg voption,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.cmdParamIf exec
+    >> Binding.alterMsgStream wrapDispatch
+
+  /// <summary>
+  ///   Creates a conditional <c>Command</c> binding that depends on the
+  ///   <c>CommandParameter</c>
+  ///   and can execute if <paramref name="exec" /> returns <c>ValueSome</c>.
+  /// </summary>
+  /// <param name="exec">Returns the message to dispatch.</param>
   /// <param name="uiBoundCmdParam">
   ///   If <c>true</c>, <c>CanExecuteChanged</c> will trigger every time WPF's
   ///   <c>CommandManager</c>
@@ -2222,11 +2260,11 @@ type Binding private () =
   [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
   static member cmdParamIf
       (exec: obj -> 'model -> 'msg voption,
-       ?uiBoundCmdParam: bool,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       uiBoundCmdParam: bool,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
       : string -> Binding<'model, 'msg> =
-    Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
-    >> (wrapDispatch |> Option.map Binding.alterMsgStream |> Option.defaultValue id)
+    Binding.cmdParamIf (exec, uiBoundCmdParam)
+    >> Binding.alterMsgStream wrapDispatch
 
 
   /// <summary>
@@ -2258,6 +2296,24 @@ type Binding private () =
   ///   and can execute if <paramref name="exec" /> returns <c>Some</c>.
   /// </summary>
   /// <param name="exec">Returns the message to dispatch.</param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member cmdParamIf
+      (exec: obj -> 'model -> 'msg option,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.cmdParamIf exec
+    >> Binding.alterMsgStream wrapDispatch
+
+  /// <summary>
+  ///   Creates a conditional <c>Command</c> binding that depends on the
+  ///   <c>CommandParameter</c>
+  ///   and can execute if <paramref name="exec" /> returns <c>Some</c>.
+  /// </summary>
+  /// <param name="exec">Returns the message to dispatch.</param>
   /// <param name="uiBoundCmdParam">
   ///   If <c>true</c>, <c>CanExecuteChanged</c> will trigger every time WPF's
   ///   <c>CommandManager</c>
@@ -2273,11 +2329,11 @@ type Binding private () =
   [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
   static member cmdParamIf
       (exec: obj -> 'model -> 'msg option,
-       ?uiBoundCmdParam: bool,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       uiBoundCmdParam: bool,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
       : string -> Binding<'model, 'msg> =
-    Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
-    >> (wrapDispatch |> Option.map Binding.alterMsgStream |> Option.defaultValue id)
+    Binding.cmdParamIf (exec, uiBoundCmdParam)
+    >> Binding.alterMsgStream wrapDispatch
 
 
   /// <summary>
@@ -2315,6 +2371,27 @@ type Binding private () =
   ///   for inputs and commands.
   /// </summary>
   /// <param name="exec">Returns the message to dispatch.</param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member cmdParamIf
+      (exec: obj -> 'model -> Result<'msg, 'ignored>,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.cmdParamIf exec
+    >> Binding.alterMsgStream wrapDispatch
+
+  /// <summary>
+  ///   Creates a conditional <c>Command</c> binding that depends on the
+  ///   <c>CommandParameter</c>
+  ///   and can execute if <paramref name="exec" /> returns <c>Ok</c>.
+  ///
+  ///   This overload allows more easily re-using the same validation functions
+  ///   for inputs and commands.
+  /// </summary>
+  /// <param name="exec">Returns the message to dispatch.</param>
   /// <param name="uiBoundCmdParam">
   ///   If <c>true</c>, <c>CanExecuteChanged</c> will trigger every time WPF's
   ///   <c>CommandManager</c>
@@ -2330,11 +2407,11 @@ type Binding private () =
   [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
   static member cmdParamIf
       (exec: obj -> 'model -> Result<'msg, 'ignored>,
-       ?uiBoundCmdParam: bool,
-       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+       uiBoundCmdParam: bool,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
       : string -> Binding<'model, 'msg> =
-    Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
-    >> (wrapDispatch |> Option.map Binding.alterMsgStream |> Option.defaultValue id)
+    Binding.cmdParamIf (exec, uiBoundCmdParam)
+    >> Binding.alterMsgStream wrapDispatch
 
 
   /// <summary>
@@ -4010,6 +4087,24 @@ module Extensions =
     ///   and can execute if <paramref name="exec" /> returns <c>ValueSome</c>.
     /// </summary>
     /// <param name="exec">Returns the message to dispatch.</param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member cmdParamIf
+        (exec: obj -> 'msg voption,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.cmdParamIf exec
+      >> Binding.alterMsgStream wrapDispatch
+
+    /// <summary>
+    ///   Creates a conditional <c>Command</c> binding that depends on the
+    ///   <c>CommandParameter</c>
+    ///   and can execute if <paramref name="exec" /> returns <c>ValueSome</c>.
+    /// </summary>
+    /// <param name="exec">Returns the message to dispatch.</param>
     /// <param name="uiBoundCmdParam">
     ///   If <c>true</c>, <c>CanExecuteChanged</c> will trigger every time WPF's
     ///   <c>CommandManager</c>
@@ -4025,11 +4120,11 @@ module Extensions =
     [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
     static member cmdParamIf
         (exec: obj -> 'msg voption,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>,
-         ?uiBoundCmdParam: bool)
+         uiBoundCmdParam: bool,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
         : string -> Binding<'model, 'msg> =
-      Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
-      >> (wrapDispatch |> Option.map Binding.alterMsgStream |> Option.defaultValue id)
+      Binding.cmdParamIf (exec, uiBoundCmdParam)
+      >> Binding.alterMsgStream wrapDispatch
 
 
     /// <summary>
@@ -4061,6 +4156,24 @@ module Extensions =
     ///   and can execute if <paramref name="exec" /> returns <c>Some</c>.
     /// </summary>
     /// <param name="exec">Returns the message to dispatch.</param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member cmdParamIf
+        (exec: obj -> 'msg option,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.cmdParamIf exec
+      >> Binding.alterMsgStream wrapDispatch
+
+    /// <summary>
+    ///   Creates a conditional <c>Command</c> binding that depends on the
+    ///   <c>CommandParameter</c>
+    ///   and can execute if <paramref name="exec" /> returns <c>Some</c>.
+    /// </summary>
+    /// <param name="exec">Returns the message to dispatch.</param>
     /// <param name="uiBoundCmdParam">
     ///   If <c>true</c>, <c>CanExecuteChanged</c> will trigger every time WPF's
     ///   <c>CommandManager</c>
@@ -4076,11 +4189,11 @@ module Extensions =
     [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
     static member cmdParamIf
         (exec: obj -> 'msg option,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>,
-         ?uiBoundCmdParam: bool)
+         uiBoundCmdParam: bool,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
         : string -> Binding<'model, 'msg> =
-      Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
-      >> (wrapDispatch |> Option.map Binding.alterMsgStream |> Option.defaultValue id)
+      Binding.cmdParamIf (exec, uiBoundCmdParam)
+      >> Binding.alterMsgStream wrapDispatch
 
 
     /// <summary>
@@ -4118,6 +4231,27 @@ module Extensions =
     ///   functions for inputs and commands.
     /// </summary>
     /// <param name="exec">Returns the message to dispatch.</param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member cmdParamIf
+        (exec: obj -> Result<'msg, 'ignored>,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.cmdParamIf exec
+      >> Binding.alterMsgStream wrapDispatch
+
+    /// <summary>
+    ///   Creates a conditional <c>Command</c> binding that depends on the
+    ///   <c>CommandParameter</c>
+    ///   and can execute if <paramref name="exec" /> returns <c>Ok</c>.
+    ///
+    ///   This overload allows more easily re-using the same validation
+    ///   functions for inputs and commands.
+    /// </summary>
+    /// <param name="exec">Returns the message to dispatch.</param>
     /// <param name="uiBoundCmdParam">
     ///   If <c>true</c>, <c>CanExecuteChanged</c> will trigger every time WPF's
     ///   <c>CommandManager</c>
@@ -4133,11 +4267,11 @@ module Extensions =
     [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
     static member cmdParamIf
         (exec: obj -> Result<'msg, 'ignored>,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>,
-         ?uiBoundCmdParam: bool)
+         uiBoundCmdParam: bool,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
         : string -> Binding<'model, 'msg> =
-      Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
-      >> (wrapDispatch |> Option.map Binding.alterMsgStream |> Option.defaultValue id)
+      Binding.cmdParamIf (exec, uiBoundCmdParam)
+      >> Binding.alterMsgStream wrapDispatch
 
 
     /// <summary>
@@ -4172,6 +4306,26 @@ module Extensions =
     /// </summary>
     /// <param name="exec">Returns the message to dispatch.</param>
     /// <param name="canExec">Indicates whether the command can execute.</param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member cmdParamIf
+        (exec: obj -> 'msg,
+         canExec: obj -> bool,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.cmdParamIf (exec, canExec)
+      >> Binding.alterMsgStream wrapDispatch
+
+    /// <summary>
+    ///   Creates a <c>Command</c> binding that depends on the
+    ///   <c>CommandParameter</c>
+    ///   and can execute if <paramref name="canExec" /> returns <c>true</c>.
+    /// </summary>
+    /// <param name="exec">Returns the message to dispatch.</param>
+    /// <param name="canExec">Indicates whether the command can execute.</param>
     /// <param name="uiBoundCmdParam">
     ///   If <c>true</c>, <c>CanExecuteChanged</c> will trigger every time WPF's
     ///   <c>CommandManager</c>
@@ -4188,11 +4342,11 @@ module Extensions =
     static member cmdParamIf
         (exec: obj -> 'msg,
          canExec: obj -> bool,
-         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>,
-         ?uiBoundCmdParam: bool)
+         uiBoundCmdParam: bool,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
         : string -> Binding<'model, 'msg> =
-      Binding.cmdParamIf (exec, canExec, defaultArg uiBoundCmdParam false)
-      >> (wrapDispatch |> Option.map Binding.alterMsgStream |> Option.defaultValue id)
+      Binding.cmdParamIf (exec, canExec, uiBoundCmdParam)
+      >> Binding.alterMsgStream wrapDispatch
 
 
     /// <summary>

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -3924,6 +3924,33 @@ module Extensions =
         (fun p _ -> exec p |> ValueOption.isSome)
         (defaultArg uiBoundCmdParam false)
 
+    /// <summary>
+    ///   Creates a conditional <c>Command</c> binding that depends on the
+    ///   <c>CommandParameter</c>
+    ///   and can execute if <paramref name="exec" /> returns <c>ValueSome</c>.
+    /// </summary>
+    /// <param name="exec">Returns the message to dispatch.</param>
+    /// <param name="uiBoundCmdParam">
+    ///   If <c>true</c>, <c>CanExecuteChanged</c> will trigger every time WPF's
+    ///   <c>CommandManager</c>
+    ///   detects UI changes that could potentially influence the command's
+    ///   ability to execute. This will likely lead to many more triggers than
+    ///   necessary, but is needed if you have bound the <c>CommandParameter</c>
+    ///   to another UI property.
+    /// </param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member cmdParamIf
+        (exec: obj -> 'msg voption,
+         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>,
+         ?uiBoundCmdParam: bool)
+        : string -> Binding<'model, 'msg> =
+      Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
+      >> Binding.alterMsgStream (defaultArg wrapDispatch id)
+
 
     /// <summary>
     ///   Creates a conditional <c>Command</c> binding that depends on the
@@ -3947,6 +3974,33 @@ module Extensions =
         (fun p _ -> exec p |> ValueOption.ofOption)
         (fun p _ -> exec p |> Option.isSome)
         (defaultArg uiBoundCmdParam false)
+
+    /// <summary>
+    ///   Creates a conditional <c>Command</c> binding that depends on the
+    ///   <c>CommandParameter</c>
+    ///   and can execute if <paramref name="exec" /> returns <c>Some</c>.
+    /// </summary>
+    /// <param name="exec">Returns the message to dispatch.</param>
+    /// <param name="uiBoundCmdParam">
+    ///   If <c>true</c>, <c>CanExecuteChanged</c> will trigger every time WPF's
+    ///   <c>CommandManager</c>
+    ///   detects UI changes that could potentially influence the command's
+    ///   ability to execute. This will likely lead to many more triggers than
+    ///   necessary, but is needed if you have bound the <c>CommandParameter</c>
+    ///   to another UI property.
+    /// </param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member cmdParamIf
+        (exec: obj -> 'msg option,
+         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>,
+         ?uiBoundCmdParam: bool)
+        : string -> Binding<'model, 'msg> =
+      Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
+      >> Binding.alterMsgStream (defaultArg wrapDispatch id)
 
 
     /// <summary>
@@ -3975,6 +4029,36 @@ module Extensions =
         (fun p _ -> exec p |> Result.isOk)
         (defaultArg uiBoundCmdParam false)
 
+    /// <summary>
+    ///   Creates a conditional <c>Command</c> binding that depends on the
+    ///   <c>CommandParameter</c>
+    ///   and can execute if <paramref name="exec" /> returns <c>Ok</c>.
+    ///
+    ///   This overload allows more easily re-using the same validation
+    ///   functions for inputs and commands.
+    /// </summary>
+    /// <param name="exec">Returns the message to dispatch.</param>
+    /// <param name="uiBoundCmdParam">
+    ///   If <c>true</c>, <c>CanExecuteChanged</c> will trigger every time WPF's
+    ///   <c>CommandManager</c>
+    ///   detects UI changes that could potentially influence the command's
+    ///   ability to execute. This will likely lead to many more triggers than
+    ///   necessary, but is needed if you have bound the <c>CommandParameter</c>
+    ///   to another UI property.
+    /// </param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member cmdParamIf
+        (exec: obj -> Result<'msg, 'ignored>,
+         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>,
+         ?uiBoundCmdParam: bool)
+        : string -> Binding<'model, 'msg> =
+      Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
+      >> Binding.alterMsgStream (defaultArg wrapDispatch id)
+
 
     /// <summary>
     ///   Creates a <c>Command</c> binding that depends on the
@@ -4000,6 +4084,35 @@ module Extensions =
         (fun p _ -> exec p |> ValueSome)
         (fun p _ -> canExec p)
         (defaultArg uiBoundCmdParam false)
+
+    /// <summary>
+    ///   Creates a <c>Command</c> binding that depends on the
+    ///   <c>CommandParameter</c>
+    ///   and can execute if <paramref name="canExec" /> returns <c>true</c>.
+    /// </summary>
+    /// <param name="exec">Returns the message to dispatch.</param>
+    /// <param name="canExec">Indicates whether the command can execute.</param>
+    /// <param name="uiBoundCmdParam">
+    ///   If <c>true</c>, <c>CanExecuteChanged</c> will trigger every time WPF's
+    ///   <c>CommandManager</c>
+    ///   detects UI changes that could potentially influence the command's
+    ///   ability to execute. This will likely lead to many more triggers than
+    ///   necessary, but is needed if you have bound the <c>CommandParameter</c>
+    ///   to another UI property.
+    /// </param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member cmdParamIf
+        (exec: obj -> 'msg,
+         canExec: obj -> bool,
+         ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>,
+         ?uiBoundCmdParam: bool)
+        : string -> Binding<'model, 'msg> =
+      Binding.cmdParamIf (exec, canExec, defaultArg uiBoundCmdParam false)
+      >> Binding.alterMsgStream (defaultArg wrapDispatch id)
 
 
     /// <summary>

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -1374,6 +1374,29 @@ type Binding private () =
     >> Binding.mapMsgWithModel set
     >> Binding.addValidation validate
 
+  /// <summary>
+  ///   Creates a two-way binding with validation using
+  ///   <c>INotifyDataErrorInfo</c>.
+  /// </summary>
+  /// <param name="get">Gets the value from the model.</param>
+  /// <param name="set">Returns the message to dispatch.</param>
+  /// <param name="validate">
+  ///   Returns the validation messages from the updated model.
+  /// </param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member twoWayValidate
+      (get: 'model -> 'a,
+       set: 'a -> 'model -> 'msg,
+       validate: 'model -> string list,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.twoWayValidate (get, set, validate)
+    >> Binding.alterMsgStream wrapDispatch
+
 
   /// <summary>
   ///   Creates a two-way binding with validation using
@@ -1394,6 +1417,29 @@ type Binding private () =
     >> Binding.mapModel get
     >> Binding.mapMsgWithModel set
     >> Binding.addValidation (validate >> ValueOption.toList)
+
+  /// <summary>
+  ///   Creates a two-way binding with validation using
+  ///   <c>INotifyDataErrorInfo</c>.
+  /// </summary>
+  /// <param name="get">Gets the value from the model.</param>
+  /// <param name="set">Returns the message to dispatch.</param>
+  /// <param name="validate">
+  ///   Returns the validation message from the updated model.
+  /// </param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member twoWayValidate
+      (get: 'model -> 'a,
+       set: 'a -> 'model -> 'msg,
+       validate: 'model -> string voption,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.twoWayValidate (get, set, validate)
+    >> Binding.alterMsgStream wrapDispatch
 
 
   /// <summary>
@@ -1416,6 +1462,29 @@ type Binding private () =
     >> Binding.mapMsgWithModel set
     >> Binding.addValidation (validate >> Option.toList)
 
+  /// <summary>
+  ///   Creates a two-way binding with validation using
+  ///   <c>INotifyDataErrorInfo</c>.
+  /// </summary>
+  /// <param name="get">Gets the value from the model.</param>
+  /// <param name="set">Returns the message to dispatch.</param>
+  /// <param name="validate">
+  ///   Returns the validation message from the updated model.
+  /// </param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member twoWayValidate
+      (get: 'model -> 'a,
+       set: 'a -> 'model -> 'msg,
+       validate: 'model -> string option,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.twoWayValidate (get, set, validate)
+    >> Binding.alterMsgStream wrapDispatch
+
 
   /// <summary>
   ///   Creates a two-way binding with validation using
@@ -1436,6 +1505,29 @@ type Binding private () =
     >> Binding.mapModel get
     >> Binding.mapMsgWithModel set
     >> Binding.addValidation (validate >> ValueOption.ofError >> ValueOption.toList)
+
+  /// <summary>
+  ///   Creates a two-way binding with validation using
+  ///   <c>INotifyDataErrorInfo</c>.
+  /// </summary>
+  /// <param name="get">Gets the value from the model.</param>
+  /// <param name="set">Returns the message to dispatch.</param>
+  /// <param name="validate">
+  ///   Returns the validation message from the updated model.
+  /// </param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member twoWayValidate
+      (get: 'model -> 'a,
+       set: 'a -> 'model -> 'msg,
+       validate: 'model -> Result<'ignored, string>,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.twoWayValidate (get, set, validate)
+    >> Binding.alterMsgStream wrapDispatch
 
 
   /// <summary>
@@ -2743,6 +2835,29 @@ module Extensions =
       >> Binding.mapMsg set
       >> Binding.addValidation validate
 
+    /// <summary>
+    ///   Creates a two-way binding with validation using
+    ///   <c>INotifyDataErrorInfo</c>.
+    /// </summary>
+    /// <param name="get">Gets the value from the model.</param>
+    /// <param name="set">Returns the message to dispatch.</param>
+    /// <param name="validate">
+    ///   Returns the validation messages from the updated model.
+    /// </param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member twoWayValidate
+        (get: 'model -> 'a,
+         set: 'a -> 'msg,
+         validate: 'model -> string list,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.twoWayValidate (get, set, validate)
+      >> Binding.alterMsgStream wrapDispatch
+
 
     /// <summary>
     ///   Creates a two-way binding with validation using
@@ -2763,6 +2878,29 @@ module Extensions =
       >> Binding.mapModel get
       >> Binding.mapMsg set
       >> Binding.addValidation (validate >> ValueOption.toList)
+
+    /// <summary>
+    ///   Creates a two-way binding with validation using
+    ///   <c>INotifyDataErrorInfo</c>.
+    /// </summary>
+    /// <param name="get">Gets the value from the model.</param>
+    /// <param name="set">Returns the message to dispatch.</param>
+    /// <param name="validate">
+    ///   Returns the validation message from the updated model.
+    /// </param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member twoWayValidate
+        (get: 'model -> 'a,
+         set: 'a -> 'msg,
+         validate: 'model -> string voption,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.twoWayValidate (get, set, validate)
+      >> Binding.alterMsgStream wrapDispatch
 
 
     /// <summary>
@@ -2785,6 +2923,29 @@ module Extensions =
       >> Binding.mapMsg set
       >> Binding.addValidation (validate >> Option.toList)
 
+    /// <summary>
+    ///   Creates a two-way binding with validation using
+    ///   <c>INotifyDataErrorInfo</c>.
+    /// </summary>
+    /// <param name="get">Gets the value from the model.</param>
+    /// <param name="set">Returns the message to dispatch.</param>
+    /// <param name="validate">
+    ///   Returns the validation message from the updated model.
+    /// </param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member twoWayValidate
+        (get: 'model -> 'a,
+         set: 'a -> 'msg,
+         validate: 'model -> string option,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.twoWayValidate (get, set, validate)
+      >> Binding.alterMsgStream wrapDispatch
+
 
     /// <summary>
     ///   Creates a two-way binding with validation using
@@ -2805,6 +2966,29 @@ module Extensions =
       >> Binding.mapModel get
       >> Binding.mapMsg set
       >> Binding.addValidation (validate >> ValueOption.ofError >> ValueOption.toList)
+
+    /// <summary>
+    ///   Creates a two-way binding with validation using
+    ///   <c>INotifyDataErrorInfo</c>.
+    /// </summary>
+    /// <param name="get">Gets the value from the model.</param>
+    /// <param name="set">Returns the message to dispatch.</param>
+    /// <param name="validate">
+    ///   Returns the validation message from the updated model.
+    /// </param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member twoWayValidate
+        (get: 'model -> 'a,
+         set: 'a -> 'msg,
+         validate: 'model -> Result<'ignored, string>,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.twoWayValidate (get, set, validate)
+      >> Binding.alterMsgStream wrapDispatch
 
 
     /// <summary>

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -1296,6 +1296,26 @@ type Binding private () =
     >> Binding.mapModel get
     >> Binding.mapMsgWithModel set
 
+  /// <summary>
+  ///   Creates a two-way binding to an optional value. The binding
+  ///   automatically converts between the optional source value and an
+  ///   unwrapped (possibly <c>null</c>) value on the view side.
+  /// </summary>
+  /// <param name="get">Gets the value from the model.</param>
+  /// <param name="set">Returns the message to dispatch.</param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member twoWayOpt
+      (get: 'model -> 'a option,
+       set: 'a option -> 'model -> 'msg,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.twoWayOpt (get, set)
+    >> Binding.alterMsgStream wrapDispatch
+
 
   /// <summary>
   ///   Creates a two-way binding to an optional value. The binding
@@ -1312,6 +1332,26 @@ type Binding private () =
     >> Binding.addLazy (=)
     >> Binding.mapModel get
     >> Binding.mapMsgWithModel set
+
+  /// <summary>
+  ///   Creates a two-way binding to an optional value. The binding
+  ///   automatically converts between the optional source value and an
+  ///   unwrapped (possibly <c>null</c>) value on the view side.
+  /// </summary>
+  /// <param name="get">Gets the value from the model.</param>
+  /// <param name="set">Returns the message to dispatch.</param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member twoWayOpt
+      (get: 'model -> 'a voption,
+       set: 'a voption -> 'model -> 'msg,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.twoWayOpt (get, set)
+    >> Binding.alterMsgStream wrapDispatch
 
 
   /// <summary>
@@ -2632,6 +2672,27 @@ module Extensions =
     /// </summary>
     /// <param name="get">Gets the value from the model.</param>
     /// <param name="set">Returns the message to dispatch.</param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member twoWayOpt
+        (get: 'model -> 'a option,
+         set: 'a option -> 'msg,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.twoWayOpt (get, set)
+      >> Binding.alterMsgStream wrapDispatch
+
+
+    /// <summary>
+    ///   Creates a two-way binding to an optional value. The binding
+    ///   automatically converts between the optional source value and an
+    ///   unwrapped (possibly <c>null</c>) value on the view side.
+    /// </summary>
+    /// <param name="get">Gets the value from the model.</param>
+    /// <param name="set">Returns the message to dispatch.</param>
     static member twoWayOpt
         (get: 'model -> 'a voption,
          set: 'a voption -> 'msg)
@@ -2640,6 +2701,26 @@ module Extensions =
       >> Binding.addLazy (=)
       >> Binding.mapModel get
       >> Binding.mapMsg set
+
+    /// <summary>
+    ///   Creates a two-way binding to an optional value. The binding
+    ///   automatically converts between the optional source value and an
+    ///   unwrapped (possibly <c>null</c>) value on the view side.
+    /// </summary>
+    /// <param name="get">Gets the value from the model.</param>
+    /// <param name="set">Returns the message to dispatch.</param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member twoWayOpt
+        (get: 'model -> 'a voption,
+         set: 'a voption -> 'msg,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.twoWayOpt (get, set)
+      >> Binding.alterMsgStream wrapDispatch
 
 
     /// <summary>

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -886,7 +886,7 @@ module Binding =
 
 
   module SubModelSelectedItem =
-
+  
     /// <summary>
     ///   Creates a two-way binding to a <c>SelectedItem</c>-like property where
     ///   the
@@ -913,7 +913,7 @@ module Binding =
       |> createBinding
       >> mapModel (ValueOption.map box)
       >> mapMsg (ValueOption.map unbox)
-
+  
     /// <summary>
     ///   Creates a two-way binding to a <c>SelectedItem</c>-like property where
     ///   the
@@ -3091,7 +3091,7 @@ module Extensions =
       >> Binding.mapModel get
       >> Binding.mapMsg set
       >> Binding.addCaching
-
+        
 
     /// <summary>
     ///   Creates a two-way binding to a <c>SelectedItem</c>-like property where

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -1926,6 +1926,23 @@ type Binding private () =
       (exec >> ValueSome)
       (fun _ -> true)
 
+  /// <summary>
+  ///   Creates a <c>Command</c> binding that depends only on the model (not the
+  ///   <c>CommandParameter</c>) and can always execute.
+  /// </summary>
+  /// <param name="exec">Returns the message to dispatch.</param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member cmd
+      (exec: 'model -> 'msg,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.cmd exec
+    >> Binding.alterMsgStream wrapDispatch
+
 
   /// <summary>
   ///   Creates a conditional <c>Command</c> binding that depends only on the
@@ -3586,6 +3603,23 @@ module Extensions =
       BindingData.Cmd.create
         (fun _ -> exec |> ValueSome)
         (fun _ -> true)
+
+    /// <summary>
+    ///   Creates a <c>Command</c> binding that dispatches the specified message
+    ///   and can always execute.
+    /// </summary>
+    /// <param name="exec">Returns the message to dispatch.</param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member cmd
+        (exec: 'msg,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.cmd exec
+      >> Binding.alterMsgStream wrapDispatch
 
 
     /// <summary>

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -2148,6 +2148,35 @@ type Binding private () =
       canExec
       (defaultArg uiBoundCmdParam false)
 
+  /// <summary>
+  ///   Creates a <c>Command</c> binding that depends on the
+  ///   <c>CommandParameter</c>
+  ///   and can execute if <paramref name="canExec" /> returns <c>true</c>.
+  /// </summary>
+  /// <param name="exec">Returns the message to dispatch.</param>
+  /// <param name="canExec">Indicates whether the command can execute.</param>
+  /// <param name="uiBoundCmdParam">
+  ///   If <c>true</c>, <c>CanExecuteChanged</c> will trigger every time WPF's
+  ///   <c>CommandManager</c>
+  ///   detects UI changes that could potentially influence the command's
+  ///   ability to execute. This will likely lead to many more triggers than
+  ///   necessary, but is needed if you have bound the <c>CommandParameter</c>
+  ///   to another UI property.
+  /// </param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member cmdParamIf
+      (exec: obj -> 'model -> 'msg,
+       canExec: obj -> 'model -> bool,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>,
+       ?uiBoundCmdParam: bool)
+      : string -> Binding<'model, 'msg> =
+    Binding.cmdParamIf (exec, canExec, defaultArg uiBoundCmdParam false)
+    >> Binding.alterMsgStream wrapDispatch
+
 
   /// <summary>
   ///   Creates a conditional <c>Command</c> binding that depends on the
@@ -2172,6 +2201,33 @@ type Binding private () =
       (fun p m -> exec p m |> ValueOption.isSome)
       (defaultArg uiBoundCmdParam false)
 
+  /// <summary>
+  ///   Creates a conditional <c>Command</c> binding that depends on the
+  ///   <c>CommandParameter</c>
+  ///   and can execute if <paramref name="exec" /> returns <c>ValueSome</c>.
+  /// </summary>
+  /// <param name="exec">Returns the message to dispatch.</param>
+  /// <param name="uiBoundCmdParam">
+  ///   If <c>true</c>, <c>CanExecuteChanged</c> will trigger every time WPF's
+  ///   <c>CommandManager</c>
+  ///   detects UI changes that could potentially influence the command's
+  ///   ability to execute. This will likely lead to many more triggers than
+  ///   necessary, but is needed if you have bound the <c>CommandParameter</c>
+  ///   to another UI property.
+  /// </param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member cmdParamIf
+      (exec: obj -> 'model -> 'msg voption,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>,
+       ?uiBoundCmdParam: bool)
+      : string -> Binding<'model, 'msg> =
+    Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
+    >> Binding.alterMsgStream wrapDispatch
+
 
   /// <summary>
   ///   Creates a conditional <c>Command</c> binding that depends on the
@@ -2195,6 +2251,33 @@ type Binding private () =
       (fun p m -> exec p m |> ValueOption.ofOption)
       (fun p m -> exec p m |> Option.isSome)
       (defaultArg uiBoundCmdParam false)
+
+  /// <summary>
+  ///   Creates a conditional <c>Command</c> binding that depends on the
+  ///   <c>CommandParameter</c>
+  ///   and can execute if <paramref name="exec" /> returns <c>Some</c>.
+  /// </summary>
+  /// <param name="exec">Returns the message to dispatch.</param>
+  /// <param name="uiBoundCmdParam">
+  ///   If <c>true</c>, <c>CanExecuteChanged</c> will trigger every time WPF's
+  ///   <c>CommandManager</c>
+  ///   detects UI changes that could potentially influence the command's
+  ///   ability to execute. This will likely lead to many more triggers than
+  ///   necessary, but is needed if you have bound the <c>CommandParameter</c>
+  ///   to another UI property.
+  /// </param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member cmdParamIf
+      (exec: obj -> 'model -> 'msg option,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>,
+       ?uiBoundCmdParam: bool)
+      : string -> Binding<'model, 'msg> =
+    Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
+    >> Binding.alterMsgStream wrapDispatch
 
 
   /// <summary>
@@ -2222,6 +2305,36 @@ type Binding private () =
       (fun p m -> exec p m |> ValueOption.ofOk)
       (fun p m -> exec p m |> Result.isOk)
       (defaultArg uiBoundCmdParam false)
+
+  /// <summary>
+  ///   Creates a conditional <c>Command</c> binding that depends on the
+  ///   <c>CommandParameter</c>
+  ///   and can execute if <paramref name="exec" /> returns <c>Ok</c>.
+  ///
+  ///   This overload allows more easily re-using the same validation functions
+  ///   for inputs and commands.
+  /// </summary>
+  /// <param name="exec">Returns the message to dispatch.</param>
+  /// <param name="uiBoundCmdParam">
+  ///   If <c>true</c>, <c>CanExecuteChanged</c> will trigger every time WPF's
+  ///   <c>CommandManager</c>
+  ///   detects UI changes that could potentially influence the command's
+  ///   ability to execute. This will likely lead to many more triggers than
+  ///   necessary, but is needed if you have bound the <c>CommandParameter</c>
+  ///   to another UI property.
+  /// </param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member cmdParamIf
+      (exec: obj -> 'model -> Result<'msg, 'ignored>,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>,
+       ?uiBoundCmdParam: bool)
+      : string -> Binding<'model, 'msg> =
+    Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
+    >> Binding.alterMsgStream wrapDispatch
 
 
   /// <summary>

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -2104,6 +2104,24 @@ type Binding private () =
       (fun _ _ -> true)
       false
 
+  /// <summary>
+  ///   Creates a <c>Command</c> binding that depends on the
+  ///   <c>CommandParameter</c>
+  ///   and can always execute.
+  /// </summary>
+  /// <param name="exec">Returns the message to dispatch.</param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member cmdParam
+      (exec: obj -> 'model -> 'msg,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.cmdParam exec
+    >> Binding.alterMsgStream wrapDispatch
+
 
   /// <summary>
   ///   Creates a <c>Command</c> binding that depends on the
@@ -3750,6 +3768,24 @@ module Extensions =
         (fun p _ -> exec p |> ValueSome)
         (fun _ _ -> true)
         false
+
+    /// <summary>
+    ///   Creates a <c>Command</c> binding that depends on the
+    ///   <c>CommandParameter</c>
+    ///   and can always execute.
+    /// </summary>
+    /// <param name="exec">Returns the message to dispatch.</param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member cmdParam
+        (exec: obj -> 'msg,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.cmdParam exec
+      >> Binding.alterMsgStream wrapDispatch
 
 
     /// <summary>

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -1552,6 +1552,31 @@ type Binding private () =
     >> Binding.mapMsgWithModel set
     >> Binding.addValidation validate
 
+  /// <summary>
+  ///   Creates a two-way binding to an optional value with validation using
+  ///   <c>INotifyDataErrorInfo</c>. The binding automatically converts between
+  ///   the optional source value and an unwrapped (possibly <c>null</c>) value
+  ///   on the view side.
+  /// </summary>
+  /// <param name="get">Gets the value from the model.</param>
+  /// <param name="set">Returns the message to dispatch.</param>
+  /// <param name="validate">
+  ///   Returns the validation messages from the updated model.
+  /// </param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member twoWayOptValidate
+      (get: 'model -> 'a voption,
+       set: 'a voption -> 'model -> 'msg,
+       validate: 'model -> string list,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.twoWayOptValidate (get, set, validate)
+    >> Binding.alterMsgStream wrapDispatch
+
 
   /// <summary>
   ///   Creates a two-way binding to an optional value with validation using
@@ -1574,6 +1599,31 @@ type Binding private () =
     >> Binding.mapModel get
     >> Binding.mapMsgWithModel set
     >> Binding.addValidation (validate >> ValueOption.toList)
+
+  /// <summary>
+  ///   Creates a two-way binding to an optional value with validation using
+  ///   <c>INotifyDataErrorInfo</c>. The binding automatically converts between
+  ///   the optional source value and an unwrapped (possibly <c>null</c>) value
+  ///   on the view side.
+  /// </summary>
+  /// <param name="get">Gets the value from the model.</param>
+  /// <param name="set">Returns the message to dispatch.</param>
+  /// <param name="validate">
+  ///   Returns the validation message from the updated model.
+  /// </param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member twoWayOptValidate
+      (get: 'model -> 'a voption,
+       set: 'a voption -> 'model -> 'msg,
+       validate: 'model -> string voption,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.twoWayOptValidate (get, set, validate)
+    >> Binding.alterMsgStream wrapDispatch
 
 
   /// <summary>
@@ -1598,6 +1648,31 @@ type Binding private () =
     >> Binding.mapMsgWithModel set
     >> Binding.addValidation (validate >> Option.toList)
 
+  /// <summary>
+  ///   Creates a two-way binding to an optional value with validation using
+  ///   <c>INotifyDataErrorInfo</c>. The binding automatically converts between
+  ///   the optional source value and an unwrapped (possibly <c>null</c>) value
+  ///   on the view side.
+  /// </summary>
+  /// <param name="get">Gets the value from the model.</param>
+  /// <param name="set">Returns the message to dispatch.</param>
+  /// <param name="validate">
+  ///   Returns the validation message from the updated model.
+  /// </param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member twoWayOptValidate
+      (get: 'model -> 'a voption,
+       set: 'a voption -> 'model -> 'msg,
+       validate: 'model -> string option,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.twoWayOptValidate (get, set, validate)
+    >> Binding.alterMsgStream wrapDispatch
+
 
   /// <summary>
   ///   Creates a two-way binding to an optional value with validation using
@@ -1620,6 +1695,31 @@ type Binding private () =
     >> Binding.mapModel get
     >> Binding.mapMsgWithModel set
     >> Binding.addValidation (validate >> ValueOption.ofError >> ValueOption.toList)
+
+  /// <summary>
+  ///   Creates a two-way binding to an optional value with validation using
+  ///   <c>INotifyDataErrorInfo</c>. The binding automatically converts between
+  ///   the optional source value and an unwrapped (possibly <c>null</c>) value
+  ///   on the view side.
+  /// </summary>
+  /// <param name="get">Gets the value from the model.</param>
+  /// <param name="set">Returns the message to dispatch.</param>
+  /// <param name="validate">
+  ///   Returns the validation message from the updated model.
+  /// </param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member twoWayOptValidate
+      (get: 'model -> 'a voption,
+       set: 'a voption -> 'model -> 'msg,
+       validate: 'model -> Result<'ignored, string>,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.twoWayOptValidate (get, set, validate)
+    >> Binding.alterMsgStream wrapDispatch
 
 
   /// <summary>
@@ -1644,6 +1744,31 @@ type Binding private () =
     >> Binding.mapMsgWithModel set
     >> Binding.addValidation validate
 
+  /// <summary>
+  ///   Creates a two-way binding to an optional value with validation using
+  ///   <c>INotifyDataErrorInfo</c>. The binding automatically converts between
+  ///   the optional source value and an unwrapped (possibly <c>null</c>) value
+  ///   on the view side.
+  /// </summary>
+  /// <param name="get">Gets the value from the model.</param>
+  /// <param name="set">Returns the message to dispatch.</param>
+  /// <param name="validate">
+  ///   Returns the validation messages from the updated model.
+  /// </param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member twoWayOptValidate
+      (get: 'model -> 'a option,
+       set: 'a option -> 'model -> 'msg,
+       validate: 'model -> string list,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.twoWayOptValidate (get, set, validate)
+    >> Binding.alterMsgStream wrapDispatch
+
 
   /// <summary>
   ///   Creates a two-way binding to an optional value with validation using
@@ -1666,6 +1791,31 @@ type Binding private () =
     >> Binding.mapModel get
     >> Binding.mapMsgWithModel set
     >> Binding.addValidation (validate >> ValueOption.toList)
+
+  /// <summary>
+  ///   Creates a two-way binding to an optional value with validation using
+  ///   <c>INotifyDataErrorInfo</c>. The binding automatically converts between
+  ///   the optional source value and an unwrapped (possibly <c>null</c>) value
+  ///   on the view side.
+  /// </summary>
+  /// <param name="get">Gets the value from the model.</param>
+  /// <param name="set">Returns the message to dispatch.</param>
+  /// <param name="validate">
+  ///   Returns the validation message from the updated model.
+  /// </param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member twoWayOptValidate
+      (get: 'model -> 'a option,
+       set: 'a option -> 'model -> 'msg,
+       validate: 'model -> string voption,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.twoWayOptValidate (get, set, validate)
+    >> Binding.alterMsgStream wrapDispatch
 
 
   /// <summary>
@@ -1690,6 +1840,31 @@ type Binding private () =
     >> Binding.mapMsgWithModel set
     >> Binding.addValidation (validate >> Option.toList)
 
+  /// <summary>
+  ///   Creates a two-way binding to an optional value with validation using
+  ///   <c>INotifyDataErrorInfo</c>. The binding automatically converts between
+  ///   the optional source value and an unwrapped (possibly <c>null</c>) value
+  ///   on the view side.
+  /// </summary>
+  /// <param name="get">Gets the value from the model.</param>
+  /// <param name="set">Returns the message to dispatch.</param>
+  /// <param name="validate">
+  ///   Returns the validation message from the updated model.
+  /// </param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member twoWayOptValidate
+      (get: 'model -> 'a option,
+       set: 'a option -> 'model -> 'msg,
+       validate: 'model -> string option,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.twoWayOptValidate (get, set, validate)
+    >> Binding.alterMsgStream wrapDispatch
+
 
   /// <summary>
   ///   Creates a two-way binding to an optional value with validation using
@@ -1712,6 +1887,31 @@ type Binding private () =
     >> Binding.mapModel get
     >> Binding.mapMsgWithModel set
     >> Binding.addValidation (validate >> ValueOption.ofError >> ValueOption.toList)
+
+  /// <summary>
+  ///   Creates a two-way binding to an optional value with validation using
+  ///   <c>INotifyDataErrorInfo</c>. The binding automatically converts between
+  ///   the optional source value and an unwrapped (possibly <c>null</c>) value
+  ///   on the view side.
+  /// </summary>
+  /// <param name="get">Gets the value from the model.</param>
+  /// <param name="set">Returns the message to dispatch.</param>
+  /// <param name="validate">
+  ///   Returns the validation message from the updated model.
+  /// </param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member twoWayOptValidate
+      (get: 'model -> 'a option,
+       set: 'a option -> 'model -> 'msg,
+       validate: 'model -> Result<'ignored, string>,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.twoWayOptValidate (get, set, validate)
+    >> Binding.alterMsgStream wrapDispatch
 
 
   /// <summary>
@@ -3013,6 +3213,31 @@ module Extensions =
       >> Binding.mapMsg set
       >> Binding.addValidation validate
 
+    /// <summary>
+    ///   Creates a two-way binding to an optional value with validation using
+    ///   <c>INotifyDataErrorInfo</c>. The binding automatically converts
+    ///   between the optional source value and an unwrapped (possibly
+    ///   <c>null</c>) value on the view side.
+    /// </summary>
+    /// <param name="get">Gets the value from the model.</param>
+    /// <param name="set">Returns the message to dispatch.</param>
+    /// <param name="validate">
+    ///   Returns the validation messages from the updated model.
+    /// </param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member twoWayOptValidate
+        (get: 'model -> 'a voption,
+         set: 'a voption -> 'msg,
+         validate: 'model -> string list,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.twoWayOptValidate (get, set, validate)
+      >> Binding.alterMsgStream wrapDispatch
+
 
     /// <summary>
     ///   Creates a two-way binding to an optional value with validation using
@@ -3035,6 +3260,31 @@ module Extensions =
       >> Binding.mapModel get
       >> Binding.mapMsg set
       >> Binding.addValidation (validate >> ValueOption.toList)
+
+    /// <summary>
+    ///   Creates a two-way binding to an optional value with validation using
+    ///   <c>INotifyDataErrorInfo</c>. The binding automatically converts
+    ///   between the optional source value and an unwrapped (possibly
+    ///   <c>null</c>) value on the view side.
+    /// </summary>
+    /// <param name="get">Gets the value from the model.</param>
+    /// <param name="set">Returns the message to dispatch.</param>
+    /// <param name="validate">
+    ///   Returns the validation message from the updated model.
+    /// </param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member twoWayOptValidate
+        (get: 'model -> 'a voption,
+         set: 'a voption -> 'msg,
+         validate: 'model -> string voption,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.twoWayOptValidate (get, set, validate)
+      >> Binding.alterMsgStream wrapDispatch
 
 
     /// <summary>
@@ -3059,6 +3309,31 @@ module Extensions =
       >> Binding.mapMsg set
       >> Binding.addValidation (validate >> Option.toList)
 
+    /// <summary>
+    ///   Creates a two-way binding to an optional value with validation using
+    ///   <c>INotifyDataErrorInfo</c>. The binding automatically converts
+    ///   between the optional source value and an unwrapped (possibly
+    ///   <c>null</c>) value on the view side.
+    /// </summary>
+    /// <param name="get">Gets the value from the model.</param>
+    /// <param name="set">Returns the message to dispatch.</param>
+    /// <param name="validate">
+    ///   Returns the validation message from the updated model.
+    /// </param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member twoWayOptValidate
+        (get: 'model -> 'a voption,
+         set: 'a voption -> 'msg,
+         validate: 'model -> string option,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.twoWayOptValidate (get, set, validate)
+      >> Binding.alterMsgStream wrapDispatch
+
 
     /// <summary>
     ///   Creates a two-way binding to an optional value with validation using
@@ -3081,6 +3356,31 @@ module Extensions =
       >> Binding.mapModel get
       >> Binding.mapMsg set
       >> Binding.addValidation (validate >> ValueOption.ofError >> ValueOption.toList)
+
+    /// <summary>
+    ///   Creates a two-way binding to an optional value with validation using
+    ///   <c>INotifyDataErrorInfo</c>. The binding automatically converts
+    ///   between the optional source value and an unwrapped (possibly
+    ///   <c>null</c>) value on the view side.
+    /// </summary>
+    /// <param name="get">Gets the value from the model.</param>
+    /// <param name="set">Returns the message to dispatch.</param>
+    /// <param name="validate">
+    ///   Returns the validation message from the updated model.
+    /// </param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member twoWayOptValidate
+        (get: 'model -> 'a voption,
+         set: 'a voption -> 'msg,
+         validate: 'model -> Result<'ignored, string>,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.twoWayOptValidate (get, set, validate)
+      >> Binding.alterMsgStream wrapDispatch
 
 
     /// <summary>
@@ -3105,6 +3405,31 @@ module Extensions =
       >> Binding.mapMsg set
       >> Binding.addValidation validate
 
+    /// <summary>
+    ///   Creates a two-way binding to an optional value with validation using
+    ///   <c>INotifyDataErrorInfo</c>. The binding automatically converts
+    ///   between the optional source value and an unwrapped (possibly
+    ///   <c>null</c>) value on the view side.
+    /// </summary>
+    /// <param name="get">Gets the value from the model.</param>
+    /// <param name="set">Returns the message to dispatch.</param>
+    /// <param name="validate">
+    ///   Returns the validation messages from the updated model.
+    /// </param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member twoWayOptValidate
+        (get: 'model -> 'a option,
+         set: 'a option -> 'msg,
+         validate: 'model -> string list,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.twoWayOptValidate (get, set, validate)
+      >> Binding.alterMsgStream wrapDispatch
+
 
     /// <summary>
     ///   Creates a two-way binding to an optional value with validation using
@@ -3127,6 +3452,31 @@ module Extensions =
       >> Binding.mapModel get
       >> Binding.mapMsg set
       >> Binding.addValidation (validate >> ValueOption.toList)
+
+    /// <summary>
+    ///   Creates a two-way binding to an optional value with validation using
+    ///   <c>INotifyDataErrorInfo</c>. The binding automatically converts
+    ///   between the optional source value and an unwrapped (possibly
+    ///   <c>null</c>) value on the view side.
+    /// </summary>
+    /// <param name="get">Gets the value from the model.</param>
+    /// <param name="set">Returns the message to dispatch.</param>
+    /// <param name="validate">
+    ///   Returns the validation message from the updated model.
+    /// </param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member twoWayOptValidate
+        (get: 'model -> 'a option,
+         set: 'a option -> 'msg,
+         validate: 'model -> string voption,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.twoWayOptValidate (get, set, validate)
+      >> Binding.alterMsgStream wrapDispatch
 
 
     /// <summary>
@@ -3151,6 +3501,31 @@ module Extensions =
       >> Binding.mapMsg set
       >> Binding.addValidation (validate >> Option.toList)
 
+    /// <summary>
+    ///   Creates a two-way binding to an optional value with validation using
+    ///   <c>INotifyDataErrorInfo</c>. The binding automatically converts
+    ///   between the optional source value and an unwrapped (possibly
+    ///   <c>null</c>) value on the view side.
+    /// </summary>
+    /// <param name="get">Gets the value from the model.</param>
+    /// <param name="set">Returns the message to dispatch.</param>
+    /// <param name="validate">
+    ///   Returns the validation message from the updated model.
+    /// </param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member twoWayOptValidate
+        (get: 'model -> 'a option,
+         set: 'a option -> 'msg,
+         validate: 'model -> string option,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.twoWayOptValidate (get, set, validate)
+      >> Binding.alterMsgStream wrapDispatch
+
 
     /// <summary>
     ///   Creates a two-way binding to an optional value with validation using
@@ -3173,6 +3548,31 @@ module Extensions =
       >> Binding.mapModel get
       >> Binding.mapMsg set
       >> Binding.addValidation (validate >> ValueOption.ofError >> ValueOption.toList)
+
+    /// <summary>
+    ///   Creates a two-way binding to an optional value with validation using
+    ///   <c>INotifyDataErrorInfo</c>. The binding automatically converts
+    ///   between the optional source value and an unwrapped (possibly
+    ///   <c>null</c>) value on the view side.
+    /// </summary>
+    /// <param name="get">Gets the value from the model.</param>
+    /// <param name="set">Returns the message to dispatch.</param>
+    /// <param name="validate">
+    ///   Returns the validation message from the updated model.
+    /// </param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member twoWayOptValidate
+        (get: 'model -> 'a option,
+         set: 'a option -> 'msg,
+         validate: 'model -> Result<'ignored, string>,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.twoWayOptValidate (get, set, validate)
+      >> Binding.alterMsgStream wrapDispatch
 
 
     /// <summary>

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -1960,6 +1960,27 @@ type Binding private () =
       (exec >> ValueSome)
       canExec
 
+  /// <summary>
+  ///   Creates a conditional <c>Command</c> binding that depends only on the
+  ///   model (not the <c>CommandParameter</c>) and can execute if <paramref
+  ///   name="canExec" />
+  ///   returns <c>true</c>.
+  /// </summary>
+  /// <param name="exec">Returns the message to dispatch.</param>
+  /// <param name="canExec">Indicates whether the command can execute.</param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member cmdIf
+      (exec: 'model -> 'msg,
+       canExec: 'model -> bool,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.cmdIf (exec, canExec)
+    >> Binding.alterMsgStream wrapDispatch
+
 
   /// <summary>
   ///   Creates a conditional <c>Command</c> binding that depends only on the
@@ -1975,6 +1996,25 @@ type Binding private () =
       exec
       (exec >> ValueOption.isSome)
 
+  /// <summary>
+  ///   Creates a conditional <c>Command</c> binding that depends only on the
+  ///   model (not the <c>CommandParameter</c>) and can execute if <paramref
+  ///   name="exec" />
+  ///   returns <c>ValueSome</c>.
+  /// </summary>
+  /// <param name="exec">Returns the message to dispatch.</param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member cmdIf
+      (exec: 'model -> 'msg voption,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.cmdIf exec
+    >> Binding.alterMsgStream wrapDispatch
+
 
   /// <summary>
   ///   Creates a conditional <c>Command</c> binding that depends only on the
@@ -1989,6 +2029,25 @@ type Binding private () =
     BindingData.Cmd.create
       (exec >> ValueOption.ofOption)
       (exec >> Option.isSome)
+
+  /// <summary>
+  ///   Creates a conditional <c>Command</c> binding that depends only on the
+  ///   model (not the <c>CommandParameter</c>) and can execute if <paramref
+  ///   name="exec" />
+  ///   returns <c>Some</c>.
+  /// </summary>
+  /// <param name="exec">Returns the message to dispatch.</param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member cmdIf
+      (exec: 'model -> 'msg option,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.cmdIf exec
+    >> Binding.alterMsgStream wrapDispatch
 
 
   /// <summary>
@@ -2007,6 +2066,28 @@ type Binding private () =
     BindingData.Cmd.create
       (exec >> ValueOption.ofOk)
       (exec >> Result.isOk)
+
+  /// <summary>
+  ///   Creates a conditional <c>Command</c> binding that depends only on the
+  ///   model (not the <c>CommandParameter</c>) and can execute if <paramref
+  ///   name="exec" />
+  ///   returns <c>Ok</c>.
+  ///
+  ///   This overload allows more easily re-using the same validation functions
+  ///   for inputs and commands.
+  /// </summary>
+  /// <param name="exec">Returns the message to dispatch.</param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member cmdIf
+      (exec: 'model -> Result<'msg, 'ignored>,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.cmdIf exec
+    >> Binding.alterMsgStream wrapDispatch
 
 
   /// <summary>
@@ -3635,6 +3716,25 @@ module Extensions =
       BindingData.Cmd.create
         (fun _ -> exec |> ValueSome)
         canExec
+
+    /// <summary>
+    ///   Creates a <c>Command</c> binding that dispatches the specified message
+    ///   and can execute if <paramref name="canExec" /> returns <c>true</c>.
+    /// </summary>
+    /// <param name="exec">Returns the message to dispatch.</param>
+    /// <param name="canExec">Indicates whether the command can execute.</param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member cmdIf
+        (exec: 'msg,
+         canExec: 'model -> bool,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.cmdIf (exec, canExec)
+      >> Binding.alterMsgStream wrapDispatch
 
 
     /// <summary>

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -886,7 +886,7 @@ module Binding =
 
 
   module SubModelSelectedItem =
-  
+
     /// <summary>
     ///   Creates a two-way binding to a <c>SelectedItem</c>-like property where
     ///   the
@@ -913,7 +913,7 @@ module Binding =
       |> createBinding
       >> mapModel (ValueOption.map box)
       >> mapMsg (ValueOption.map unbox)
-  
+
     /// <summary>
     ///   Creates a two-way binding to a <c>SelectedItem</c>-like property where
     ///   the
@@ -1262,6 +1262,22 @@ type Binding private () =
     >> Binding.addLazy (=)
     >> Binding.mapModel get
     >> Binding.mapMsgWithModel set
+
+  /// <summary>Creates a two-way binding.</summary>
+  /// <param name="get">Gets the value from the model.</param>
+  /// <param name="set">Returns the message to dispatch.</param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member twoWay
+      (get: 'model -> 'a,
+       set: 'a -> 'model -> 'msg,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.twoWay (get, set)
+    >> Binding.alterMsgStream wrapDispatch
 
 
   /// <summary>
@@ -2576,6 +2592,22 @@ module Extensions =
       >> Binding.mapModel get
       >> Binding.mapMsg set
 
+    /// <summary>Creates a two-way binding.</summary>
+    /// <param name="get">Gets the value from the model.</param>
+    /// <param name="set">Returns the message to dispatch.</param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member twoWay
+        (get: 'model -> 'a,
+         set: 'a -> 'msg,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.twoWay (get, set)
+      >> Binding.alterMsgStream wrapDispatch
+
 
     /// <summary>
     ///   Creates a two-way binding to an optional value. The binding
@@ -3059,7 +3091,7 @@ module Extensions =
       >> Binding.mapModel get
       >> Binding.mapMsg set
       >> Binding.addCaching
-        
+
 
     /// <summary>
     ///   Creates a two-way binding to a <c>SelectedItem</c>-like property where

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -886,7 +886,7 @@ module Binding =
 
 
   module SubModelSelectedItem =
-  
+
     /// <summary>
     ///   Creates a two-way binding to a <c>SelectedItem</c>-like property where
     ///   the
@@ -913,7 +913,7 @@ module Binding =
       |> createBinding
       >> mapModel (ValueOption.map box)
       >> mapMsg (ValueOption.map unbox)
-  
+
     /// <summary>
     ///   Creates a two-way binding to a <c>SelectedItem</c>-like property where
     ///   the
@@ -2175,7 +2175,7 @@ type Binding private () =
        ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
       : string -> Binding<'model, 'msg> =
     Binding.cmdParamIf (exec, canExec, defaultArg uiBoundCmdParam false)
-    >> Binding.alterMsgStream (defaultArg wrapDispatch id)
+    >> (wrapDispatch |> Option.map Binding.alterMsgStream |> Option.defaultValue id)
 
 
   /// <summary>
@@ -2226,7 +2226,7 @@ type Binding private () =
        ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
       : string -> Binding<'model, 'msg> =
     Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
-    >> Binding.alterMsgStream (defaultArg wrapDispatch id)
+    >> (wrapDispatch |> Option.map Binding.alterMsgStream |> Option.defaultValue id)
 
 
   /// <summary>
@@ -2277,7 +2277,7 @@ type Binding private () =
        ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
       : string -> Binding<'model, 'msg> =
     Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
-    >> Binding.alterMsgStream (defaultArg wrapDispatch id)
+    >> (wrapDispatch |> Option.map Binding.alterMsgStream |> Option.defaultValue id)
 
 
   /// <summary>
@@ -2334,7 +2334,7 @@ type Binding private () =
        ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
       : string -> Binding<'model, 'msg> =
     Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
-    >> Binding.alterMsgStream (defaultArg wrapDispatch id)
+    >> (wrapDispatch |> Option.map Binding.alterMsgStream |> Option.defaultValue id)
 
 
   /// <summary>
@@ -4029,7 +4029,7 @@ module Extensions =
          ?uiBoundCmdParam: bool)
         : string -> Binding<'model, 'msg> =
       Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
-      >> Binding.alterMsgStream (defaultArg wrapDispatch id)
+      >> (wrapDispatch |> Option.map Binding.alterMsgStream |> Option.defaultValue id)
 
 
     /// <summary>
@@ -4080,7 +4080,7 @@ module Extensions =
          ?uiBoundCmdParam: bool)
         : string -> Binding<'model, 'msg> =
       Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
-      >> Binding.alterMsgStream (defaultArg wrapDispatch id)
+      >> (wrapDispatch |> Option.map Binding.alterMsgStream |> Option.defaultValue id)
 
 
     /// <summary>
@@ -4137,7 +4137,7 @@ module Extensions =
          ?uiBoundCmdParam: bool)
         : string -> Binding<'model, 'msg> =
       Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
-      >> Binding.alterMsgStream (defaultArg wrapDispatch id)
+      >> (wrapDispatch |> Option.map Binding.alterMsgStream |> Option.defaultValue id)
 
 
     /// <summary>
@@ -4192,7 +4192,7 @@ module Extensions =
          ?uiBoundCmdParam: bool)
         : string -> Binding<'model, 'msg> =
       Binding.cmdParamIf (exec, canExec, defaultArg uiBoundCmdParam false)
-      >> Binding.alterMsgStream (defaultArg wrapDispatch id)
+      >> (wrapDispatch |> Option.map Binding.alterMsgStream |> Option.defaultValue id)
 
 
     /// <summary>

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -3062,6 +3062,46 @@ type Binding private () =
     >> Binding.mapMsgWithModel set
     >> Binding.addCaching
 
+  /// <summary>
+  ///   Creates a two-way binding to a <c>SelectedItem</c>-like property where
+  ///   the
+  ///   <c>ItemsSource</c>-like property is a <see cref="subModelSeq" />
+  ///   binding. Automatically converts the dynamically created Elmish.WPF view
+  ///   models to/from their corresponding IDs, so the Elmish user code only has
+  ///   to work with the IDs.
+  ///
+  ///   Only use this if you are unable to use some kind of <c>SelectedValue</c>
+  ///   or
+  ///   <c>SelectedIndex</c> property with a normal <see cref="twoWay" />
+  ///   binding. This binding is less type-safe. It will throw when initializing
+  ///   the bindings if <paramref name="subModelSeqBindingName" />
+  ///   does not correspond to a <see cref="subModelSeq" /> binding, and it will
+  ///   throw at runtime if the inferred <c>'id</c> type does not match the
+  ///   actual ID type used in that binding.
+  /// </summary>
+  /// <param name="subModelSeqBindingName">
+  ///   The name of the <see cref="subModelSeq" /> binding used as the items
+  ///   source.
+  /// </param>
+  /// <param name="get">Gets the selected sub-model/sub-binding ID from the
+  /// model.</param>
+  /// <param name="set">
+  ///   Returns the message to dispatch on selections/de-selections.
+  /// </param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member subModelSelectedItem
+      (subModelSeqBindingName: string,
+       get: 'model -> 'id voption,
+       set: 'id voption -> 'model -> 'msg,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.subModelSelectedItem (subModelSeqBindingName, get, set)
+    >> Binding.alterMsgStream wrapDispatch
+
 
   /// <summary>
   ///   Creates a two-way binding to a <c>SelectedItem</c>-like property where
@@ -3099,6 +3139,46 @@ type Binding private () =
     >> Binding.mapModel get
     >> Binding.mapMsgWithModel set
     >> Binding.addCaching
+
+  /// <summary>
+  ///   Creates a two-way binding to a <c>SelectedItem</c>-like property where
+  ///   the
+  ///   <c>ItemsSource</c>-like property is a <see cref="subModelSeq" />
+  ///   binding. Automatically converts the dynamically created Elmish.WPF view
+  ///   models to/from their corresponding IDs, so the Elmish user code only has
+  ///   to work with the IDs.
+  ///
+  ///   Only use this if you are unable to use some kind of <c>SelectedValue</c>
+  ///   or
+  ///   <c>SelectedIndex</c> property with a normal <see cref="twoWay" />
+  ///   binding. This binding is less type-safe. It will throw when initializing
+  ///   the bindings if <paramref name="subModelSeqBindingName" />
+  ///   does not correspond to a <see cref="subModelSeq" /> binding, and it will
+  ///   throw at runtime if the inferred <c>'id</c> type does not match the
+  ///   actual ID type used in that binding.
+  /// </summary>
+  /// <param name="subModelSeqBindingName">
+  ///   The name of the <see cref="subModelSeq" /> binding used as the items
+  ///   source.
+  /// </param>
+  /// <param name="get">Gets the selected sub-model/sub-binding ID from the
+  /// model.</param>
+  /// <param name="set">
+  ///   Returns the message to dispatch on selections/de-selections.
+  /// </param>
+  /// <param name="wrapDispatch">
+  ///   Wraps the dispatch function with additional behavior, such as
+  ///   throttling, debouncing, or limiting.
+  /// </param>
+  [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+  static member subModelSelectedItem
+      (subModelSeqBindingName: string,
+       get: 'model -> 'id option,
+       set: 'id option -> 'model -> 'msg,
+       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+      : string -> Binding<'model, 'msg> =
+    Binding.subModelSelectedItem (subModelSeqBindingName, get, set)
+    >> Binding.alterMsgStream wrapDispatch
 
 
 
@@ -4152,7 +4232,48 @@ module Extensions =
       >> Binding.mapModel get
       >> Binding.mapMsg set
       >> Binding.addCaching
-        
+
+    /// <summary>
+    ///   Creates a two-way binding to a <c>SelectedItem</c>-like property where
+    ///   the
+    ///   <c>ItemsSource</c>-like property is a <see cref="subModelSeq" />
+    ///   binding. Automatically converts the dynamically created Elmish.WPF
+    ///   view models to/from their corresponding IDs, so the Elmish user code
+    ///   only has to work with the IDs.
+    ///
+    ///   Only use this if you are unable to use some kind of
+    ///   <c>SelectedValue</c> or
+    ///   <c>SelectedIndex</c> property with a normal <see cref="twoWay" />
+    ///   binding. This binding is less type-safe. It will throw when
+    ///   initializing the bindings if <paramref name="subModelSeqBindingName"
+    ///   />
+    ///   does not correspond to a <see cref="subModelSeq" /> binding, and it
+    ///   will throw at runtime if the inferred <c>'id</c> type does not
+    ///   match the actual ID type used in that binding.
+    /// </summary>
+    /// <param name="subModelSeqBindingName">
+    ///   The name of the <see cref="subModelSeq" /> binding used as the items
+    ///   source.
+    /// </param>
+    /// <param name="get">Gets the selected sub-model/sub-binding ID from the
+    /// model.</param>
+    /// <param name="set">
+    ///   Returns the message to dispatch on selections/de-selections.
+    /// </param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member subModelSelectedItem
+        (subModelSeqBindingName: string,
+         get: 'model -> 'id voption,
+         set: 'id voption -> 'msg,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.subModelSelectedItem (subModelSeqBindingName, get, set)
+      >> Binding.alterMsgStream wrapDispatch
+
 
     /// <summary>
     ///   Creates a two-way binding to a <c>SelectedItem</c>-like property where
@@ -4191,3 +4312,44 @@ module Extensions =
       >> Binding.mapModel get
       >> Binding.mapMsg set
       >> Binding.addCaching
+
+    /// <summary>
+    ///   Creates a two-way binding to a <c>SelectedItem</c>-like property where
+    ///   the
+    ///   <c>ItemsSource</c>-like property is a <see cref="subModelSeq" />
+    ///   binding. Automatically converts the dynamically created Elmish.WPF
+    ///   view models to/from their corresponding IDs, so the Elmish user code
+    ///   only has to work with the IDs.
+    ///
+    ///   Only use this if you are unable to use some kind of
+    ///   <c>SelectedValue</c> or
+    ///   <c>SelectedIndex</c> property with a normal <see cref="twoWay" />
+    ///   binding. This binding is less type-safe. It will throw when
+    ///   initializing the bindings if <paramref name="subModelSeqBindingName"
+    ///   />
+    ///   does not correspond to a <see cref="subModelSeq" /> binding, and it
+    ///   will throw at runtime if the inferred <c>'id</c> type does not
+    ///   match the actual ID type used in that binding.
+    /// </summary>
+    /// <param name="subModelSeqBindingName">
+    ///   The name of the <see cref="subModelSeq" /> binding used as the items
+    ///   source.
+    /// </param>
+    /// <param name="get">Gets the selected sub-model/sub-binding ID from the
+    /// model.</param>
+    /// <param name="set">
+    ///   Returns the message to dispatch on selections/de-selections.
+    /// </param>
+    /// <param name="wrapDispatch">
+    ///   Wraps the dispatch function with additional behavior, such as
+    ///   throttling, debouncing, or limiting.
+    /// </param>
+    [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
+    static member subModelSelectedItem
+        (subModelSeqBindingName: string,
+         get: 'model -> 'id option,
+         set: 'id option -> 'msg,
+         wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
+        : string -> Binding<'model, 'msg> =
+      Binding.subModelSelectedItem (subModelSeqBindingName, get, set)
+      >> Binding.alterMsgStream wrapDispatch

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -2171,11 +2171,11 @@ type Binding private () =
   static member cmdParamIf
       (exec: obj -> 'model -> 'msg,
        canExec: obj -> 'model -> bool,
-       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>,
-       ?uiBoundCmdParam: bool)
+       ?uiBoundCmdParam: bool,
+       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
       : string -> Binding<'model, 'msg> =
     Binding.cmdParamIf (exec, canExec, defaultArg uiBoundCmdParam false)
-    >> Binding.alterMsgStream wrapDispatch
+    >> Binding.alterMsgStream (defaultArg wrapDispatch id)
 
 
   /// <summary>
@@ -2222,11 +2222,11 @@ type Binding private () =
   [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
   static member cmdParamIf
       (exec: obj -> 'model -> 'msg voption,
-       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>,
-       ?uiBoundCmdParam: bool)
+       ?uiBoundCmdParam: bool,
+       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
       : string -> Binding<'model, 'msg> =
     Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
-    >> Binding.alterMsgStream wrapDispatch
+    >> Binding.alterMsgStream (defaultArg wrapDispatch id)
 
 
   /// <summary>
@@ -2273,11 +2273,11 @@ type Binding private () =
   [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
   static member cmdParamIf
       (exec: obj -> 'model -> 'msg option,
-       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>,
-       ?uiBoundCmdParam: bool)
+       ?uiBoundCmdParam: bool,
+       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
       : string -> Binding<'model, 'msg> =
     Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
-    >> Binding.alterMsgStream wrapDispatch
+    >> Binding.alterMsgStream (defaultArg wrapDispatch id)
 
 
   /// <summary>
@@ -2330,11 +2330,11 @@ type Binding private () =
   [<System.Obsolete("In version 5, this method will be removed.  Use the overload without the \"wrapDispatch\" parameter followed by a call to \"Binding.alterMsgStream\".  For an example, see how this method is implemented.")>]
   static member cmdParamIf
       (exec: obj -> 'model -> Result<'msg, 'ignored>,
-       wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>,
-       ?uiBoundCmdParam: bool)
+       ?uiBoundCmdParam: bool,
+       ?wrapDispatch: Dispatch<'msg> -> Dispatch<'msg>)
       : string -> Binding<'model, 'msg> =
     Binding.cmdParamIf (exec, defaultArg uiBoundCmdParam false)
-    >> Binding.alterMsgStream wrapDispatch
+    >> Binding.alterMsgStream (defaultArg wrapDispatch id)
 
 
   /// <summary>

--- a/src/Samples/UiBoundCmdParam.Core/Program.fs
+++ b/src/Samples/UiBoundCmdParam.Core/Program.fs
@@ -27,7 +27,7 @@ let bindings () : Binding<Model, Msg> list = [
   "Limit" |> Binding.twoWay((fun m -> float m.EnabledMaxLimit), int >> SetLimit)
   "Command" |> Binding.cmdParamIf(
     (fun p m -> Command),
-    (fun p m -> not (isNull p) && p :?> int <= m.EnabledMaxLimit),
+    (fun (p: obj) m -> not (isNull p) && p :?> int <= m.EnabledMaxLimit),
     true)
 ]
 


### PR DESCRIPTION
This restored function is marked as obsolete with a suggestion to use the newly added alternate overload without the parameter.

Fixes #413