### PR TITLE
Add withErrorHandler and withMsgErrorHandler

### DIFF
--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -11,7 +11,7 @@ type WpfProgram<'model, 'msg> =
     ElmishProgram: Program<unit, 'model, 'msg, unit>
     Bindings: Binding<'model, 'msg> list
     LoggerFactory: ILoggerFactory
-    ErrorHandler: string * exn -> 'msg list
+    ErrorHandler: string -> exn -> 'msg list
     /// Only log calls that take at least this many milliseconds. Default 1.
     PerformanceLogThreshold: int
   }
@@ -25,7 +25,7 @@ module WpfProgram =
     { ElmishProgram = program
       Bindings = getBindings ()
       LoggerFactory = NullLoggerFactory.Instance
-      ErrorHandler = fun _ -> []
+      ErrorHandler = fun _ _ -> []
       PerformanceLogThreshold = 1 }
 
 
@@ -96,7 +96,7 @@ module WpfProgram =
 
     let errorHandler (msg: string, ex: exn) =
       updateLogger.LogError(ex, msg)
-      program.ErrorHandler (msg, ex) |> List.iter dispatch
+      program.ErrorHandler msg ex |> List.iter dispatch
 
     program.ElmishProgram
     |> if updateLogger.IsEnabled LogLevel.Trace then Program.withTrace logMsgAndModel else id

--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -164,7 +164,7 @@ module WpfProgram =
   /// message case.
   ///
   /// The update handler for the dispatched messages MUST NOT cause exceptions themselves,
-  /// or the app will enter into an infinite loop.
+  /// or the app may enter into an infinite loop.
   let withErrorHandler onError program =
     { program with ErrorHandler = onError }
 

--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -160,10 +160,14 @@ module WpfProgram =
 
   /// Calls the specified function for unhandled exceptions in the Elmish
   /// dispatch loop (e.g. in commands or the update function). This essentially
-  /// delegates to Elmish's Program.withErrorHandler. The first (string)
-  /// argument of onError is a message from Elmish describing the context of the
-  /// exception. Note that this may contain a rendered message case with all
-  /// data ("%A" formatting).
+  /// delegates to Elmish's Program.withErrorHandler.
+  ///
+  /// The first (string) argument of onError is a message from Elmish describing
+  /// the context of the exception. Note that this may contain a rendered
+  /// message case with all data ("%A" formatting).
+  ///
+  /// Note that exceptions passed to onError are also logged to the logger
+  /// specified using WpfProgram.withLogger.
   let withElmishErrorHandler onError program =
     { program with ErrorHandler = onError }
 

--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -11,8 +11,7 @@ type WpfProgram<'model, 'msg> =
     ElmishProgram: Program<unit, 'model, 'msg, unit>
     Bindings: Binding<'model, 'msg> list
     LoggerFactory: ILoggerFactory
-    ErrorHandler: string * exn -> unit
-    MsgErrorHandler: string * exn -> 'msg list
+    ErrorHandler: string * exn -> 'msg list
     /// Only log calls that take at least this many milliseconds. Default 1.
     PerformanceLogThreshold: int
   }
@@ -26,8 +25,7 @@ module WpfProgram =
     { ElmishProgram = program
       Bindings = getBindings ()
       LoggerFactory = NullLoggerFactory.Instance
-      ErrorHandler = ignore
-      MsgErrorHandler = fun _ -> []
+      ErrorHandler = fun _ -> []
       PerformanceLogThreshold = 1 }
 
 
@@ -98,8 +96,7 @@ module WpfProgram =
 
     let errorHandler (msg: string, ex: exn) =
       updateLogger.LogError(ex, msg)
-      program.ErrorHandler (msg, ex)
-      program.MsgErrorHandler (msg, ex) |> List.iter dispatch
+      program.ErrorHandler (msg, ex) |> List.iter dispatch
 
     program.ElmishProgram
     |> if updateLogger.IsEnabled LogLevel.Trace then Program.withTrace logMsgAndModel else id
@@ -161,19 +158,15 @@ module WpfProgram =
     { program with LoggerFactory = loggerFactory }
 
 
-  /// Uses the specified handler for dispatch loop exceptions. The first (string) argument
-  /// of onError is message from Elmish describing the context of the exception, and may
-  /// contain a rendered message case.
-  let withErrorHandler onError program =
-    { program with ErrorHandler = onError }
-
-
   /// Uses the specified handler for dispatch loop exceptions, dispatching the returned
   /// messages when an exception occurs. The first (string) argument of onError is message
   /// from Elmish describing the context of the exception, and may contain a rendered
   /// message case.
-  let withMsgErrorHandler onError program =
-    { program with MsgErrorHandler = onError }
+  ///
+  /// The update handler for the dispatched messages MUST NOT cause exceptions themselves,
+  /// or the app will enter into an infinite loop.
+  let withErrorHandler onError program =
+    { program with ErrorHandler = onError }
 
 
   /// Subscribe to an external source of events. The subscribe function is called once,

--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -159,11 +159,12 @@ module WpfProgram =
 
 
   /// Calls the specified function for unhandled exceptions in the Elmish
-  /// dispatch loop (e.g. in commands or the update function). The first
-  /// (string) argument of onError is a message from Elmish describing the
-  /// context of the exception. Note that this may contain a rendered message
-  /// case with all data ("%A" formatting).
-  let withErrorHandler onError program =
+  /// dispatch loop (e.g. in commands or the update function). This essentially
+  /// delegates to Elmish's Program.withErrorHandler. The first (string)
+  /// argument of onError is a message from Elmish describing the context of the
+  /// exception. Note that this may contain a rendered message case with all
+  /// data ("%A" formatting).
+  let withElmishErrorHandler onError program =
     { program with ErrorHandler = onError }
 
 


### PR DESCRIPTION
Fixes #426

I also added `withMsgErrorHandler`, where you supply a handler that returns `'msg list` instead of `unit`, and the returned messages are then dispatched by Elmish.WPF. As I said in https://github.com/elmish/Elmish.WPF/issues/426#issuecomment-916045586, this functionality can be implemented in user code, but it requires more boilerplate impure code (events/subscriptions) and was so trivial to implement in Elmish.WPF that I see no compelling reason not to support it.