### PR TITLE
Add GetDynamicMemberNames override to make debugging easier

### DIFF
--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -592,6 +592,10 @@ and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
           log.LogError("[{BindingNameChain}] TrySetMember FAILED: Binding {BindingName} is read-only", nameChain, binder.Name)
         success
 
+  override _.GetDynamicMemberNames () =
+    log.LogTrace("[{BindingNameChain}] GetDynamicMemberNames", nameChain)
+    bindings.Keys
+
 
   interface INotifyPropertyChanged with
     [<CLIEvent>]


### PR DESCRIPTION
This gives a list of member names in the debugger window along with the values. It makes debugging much easier.

I based this branch off of beta-41 because that's what our project uses, and beta-42 breaks a bunch of things in our project. It should work in both places though.