### PR TITLE
PROOF OF CONCEPT: Static View Model typing

### DIFF
--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -27,7 +27,7 @@ module Extensions =
 
 
 type internal TestVm<'model, 'msg>(model, bindings) as this =
-  inherit ViewModel<'model, 'msg>(model, (fun x -> this.Dispatch x), bindings, 1, "", NullLogger.Instance, NullLogger.Instance)
+  inherit DynamicViewModel<'model, 'msg>(model, (fun x -> this.Dispatch x), bindings, 1, "", NullLogger.Instance, NullLogger.Instance)
 
   let pcTriggers = ConcurrentDictionary<string, int>()
   let ecTriggers = ConcurrentDictionary<string, int>()

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -978,11 +978,6 @@ module Binding =
       ToMsg = fun m bMsg -> d.ToMsg m (inMapBindingMsg bMsg)
     }
 
-    /// <summary>
-    ///   Creates a binding to a sub-model/component. You typically bind this
-    ///   to the <c>DataContext</c> of a <c>UserControl</c> or similar.
-    /// </summary>
-    /// <param name="bindings">Returns the bindings for the sub-model.</param>
     let vopt (create: 'model * ('msg -> unit) -> IViewModel<'model>)
         : string -> Binding<'model voption, 'msg> =
       { GetModel = id
@@ -993,21 +988,11 @@ module Binding =
       |> BaseBindingData
       |> createBinding
 
-    /// <summary>
-    ///   Creates a binding to a sub-model/component. You typically bind this
-    ///   to the <c>DataContext</c> of a <c>UserControl</c> or similar.
-    /// </summary>
-    /// <param name="bindings">Returns the bindings for the sub-model.</param>
     let opt (create: 'model * ('msg -> unit) -> IViewModel<'model>)
         : string -> Binding<'model option, 'msg> =
       vopt create
       >> mapModel ValueOption.ofOption
 
-    /// <summary>
-    ///   Creates a binding to a sub-model/component. You typically bind this
-    ///   to the <c>DataContext</c> of a <c>UserControl</c> or similar.
-    /// </summary>
-    /// <param name="bindings">Returns the bindings for the sub-model.</param>
     let required (create: 'model * ('msg -> unit) -> IViewModel<'model>)
         : string -> Binding<'model, 'msg> =
       vopt create

--- a/src/Elmish.WPF/ViewModelModule.fs
+++ b/src/Elmish.WPF/ViewModelModule.fs
@@ -4,4 +4,4 @@ open Microsoft.Extensions.Logging.Abstractions
 
 /// Creates a design-time view model using the given model and bindings.
 let designInstance (model: 'model) (bindings: Binding<'model, 'msg> list) =
-  ViewModel(model, ignore, bindings, 1, "main", NullLogger.Instance, NullLogger.Instance) |> box
+  DynamicViewModel(model, ignore, bindings, 1, "main", NullLogger.Instance, NullLogger.Instance) |> box

--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -76,7 +76,7 @@ module WpfProgram =
       match viewModel with
       | None ->
           let uiDispatch msg = element.Dispatcher.Invoke(fun () -> dispatch msg)
-          let vm = ViewModel<'model, 'msg>(model, uiDispatch, program.Bindings, program.PerformanceLogThreshold, "main", bindingsLogger, performanceLogger)
+          let vm = DynamicViewModel<'model, 'msg>(model, uiDispatch, program.Bindings, program.PerformanceLogThreshold, "main", bindingsLogger, performanceLogger)
           element.DataContext <- vm
           viewModel <- Some vm
       | Some vm ->

--- a/src/Samples/SubModel.Core/Program.fs
+++ b/src/Samples/SubModel.Core/Program.fs
@@ -103,12 +103,12 @@ type [<AllowNullLiteral>] public CounterViewModel(initialModel, dispatch) as thi
 
   new() = CounterViewModel(Counter.init, ignore)
 
-  member _.StepSize
-    with get() = this.getValue (fun m -> m.StepSize)
-    and set(v) = this.setValue ((fun v _m -> Counter.Msg.SetStepSize v), v)
   member _.CounterValue = this.getValue (fun m -> m.Count)
   member _.Increment = this.cmd((fun _ _ -> Counter.Increment |> ValueSome), (fun _ _ -> true))
   member _.Decrement = this.cmd((fun _ _ -> Counter.Decrement |> ValueSome), (fun _ _ -> true))
+  member _.StepSize
+    with get() = this.getValue (fun m -> m.StepSize)
+    and set(v) = this.setValue ((fun v _ -> Counter.Msg.SetStepSize v), v)
   member _.Reset = this.cmd((fun _ _ -> Counter.Reset |> ValueSome), (fun _ -> Counter.canReset))
 
 type public CounterViewModel2() as this =

--- a/src/Samples/SubModel.Core/Program.fs
+++ b/src/Samples/SubModel.Core/Program.fs
@@ -169,7 +169,7 @@ type [<AllowNullLiteral>] public ClockViewModel(initialModel, dispatch) as this 
   
   new() = ClockViewModel(Clock.init (), ignore)
 
-  member _.Time = this.getValue (fun m -> m.Time)
+  member _.Time = this.getValue Clock.getTime
   member _.IsLocal = this.getValue (fun m -> m.TimeType = Clock.Local)
   member _.SetLocal = this.cmd ((fun _ _ -> Clock.SetTimeType Clock.Local |> ValueSome), (fun _ _ -> true))
   member _.IsUtc = this.getValue (fun m -> m.TimeType = Clock.Utc)

--- a/src/Samples/SubModel.Core/Program.fs
+++ b/src/Samples/SubModel.Core/Program.fs
@@ -232,7 +232,7 @@ type [<AllowNullLiteral>] public CounterWithClockViewModel(initialModel, dispatc
 
 type public CounterWithClockViewModel2() as this =
   inherit ViewModelBase2<CounterWithClock.Model, CounterWithClock.Msg>()
-  let counterBinding = this.subModel2((fun m -> m.Counter), snd, CounterWithClock.Msg.CounterMsg, (fun (m,d) -> CounterViewModel (m,d)), nameof this.Counter)
+  let counterBinding = this.subModel2((fun m -> m.Counter), snd, CounterWithClock.Msg.CounterMsg, (fun (m,d) -> CounterViewModel (m,d) :> IViewModel<_>), nameof this.Counter)
   let clockBinding = this.subModel((fun m -> m.Clock), snd, CounterWithClock.Msg.ClockMsg, ClockViewModel2(), nameof this.Clock)
 
   member _.Counter = counterBinding

--- a/src/Samples/SubModel.Core/Program.fs
+++ b/src/Samples/SubModel.Core/Program.fs
@@ -44,7 +44,7 @@ type ViewModelBase2<'model, 'msg>() =
     _bindings <- binding::_bindings
     designValue
 
-  member _.subModel(getSubModel: 'model -> 'subModel, toBindingModel: 'model * 'subModel -> 'bindingModel, toMsg: 'bindingMsg -> 'msg, (viewModel: #ViewModelBase2<'bindingModel,'bindingMsg>), [<CallerMemberName>] ?memberName: string) =
+  member _.subModel2(getSubModel: 'model -> 'subModel, toBindingModel: 'model * 'subModel -> 'bindingModel, toMsg: 'bindingMsg -> 'msg, (viewModel: #ViewModelBase2<'bindingModel,'bindingMsg>), [<CallerMemberName>] ?memberName: string) =
     let memberName = Option.defaultValue "" memberName
     let binding = memberName |> (Binding.SubModel.required (fun () -> viewModel.Bindings)
       >> Binding.mapModel (fun m -> toBindingModel (m, getSubModel m))
@@ -53,7 +53,7 @@ type ViewModelBase2<'model, 'msg>() =
     _bindings <- binding::_bindings
     viewModel
 
-  member _.subModel2(getSubModel: 'model -> 'subModel, toBindingModel: 'model * 'subModel -> 'bindingModel, toMsg: 'bindingMsg -> 'msg, (createVm: 'bindingModel * ('bindingMsg -> unit) -> 'viewModel when 'viewModel :> IViewModel<'bindingModel>), [<CallerMemberName>] ?memberName: string) =
+  member _.subModel(getSubModel: 'model -> 'subModel, toBindingModel: 'model * 'subModel -> 'bindingModel, toMsg: 'bindingMsg -> 'msg, (createVm: 'bindingModel * ('bindingMsg -> unit) -> 'viewModel when 'viewModel :> IViewModel<'bindingModel>), [<CallerMemberName>] ?memberName: string) =
     let memberName = Option.defaultValue "" memberName
     let binding = memberName |> (Binding.SubModelVm.required (createVm)
       >> Binding.mapModel (fun m -> toBindingModel (m, getSubModel m))
@@ -232,8 +232,8 @@ type [<AllowNullLiteral>] public CounterWithClockViewModel(initialModel, dispatc
 
 type public CounterWithClockViewModel2() as this =
   inherit ViewModelBase2<CounterWithClock.Model, CounterWithClock.Msg>()
-  let counterBinding = this.subModel2((fun m -> m.Counter), snd, CounterWithClock.Msg.CounterMsg, (fun (m,d) -> CounterViewModel (m,d) :> IViewModel<_>), nameof this.Counter)
-  let clockBinding = this.subModel((fun m -> m.Clock), snd, CounterWithClock.Msg.ClockMsg, ClockViewModel2(), nameof this.Clock)
+  let counterBinding = this.subModel((fun m -> m.Counter), snd, CounterWithClock.Msg.CounterMsg, (fun (m,d) -> CounterViewModel (m,d) :> IViewModel<_>), nameof this.Counter)
+  let clockBinding = this.subModel2((fun m -> m.Clock), snd, CounterWithClock.Msg.ClockMsg, ClockViewModel2(), nameof this.Clock)
 
   member _.Counter = counterBinding
   member _.Clock = clockBinding
@@ -282,8 +282,8 @@ type public MainViewModel(initialModel, dispatch) as this =
 
 type public MainViewModel2() as this =
   inherit ViewModelBase2<App2.Model, App2.Msg>()
-  let clockCounter1Binding = this.subModel((fun m -> m.ClockCounter1), snd, App2.Msg.ClockCounter1Msg, CounterWithClockViewModel2(), nameof this.ClockCounter1)
-  let clockCounter2Binding = this.subModel((fun m -> m.ClockCounter2), snd, App2.Msg.ClockCounter2Msg, CounterWithClockViewModel2(), nameof this.ClockCounter2)
+  let clockCounter1Binding = this.subModel2((fun m -> m.ClockCounter1), snd, App2.Msg.ClockCounter1Msg, CounterWithClockViewModel2(), nameof this.ClockCounter1)
+  let clockCounter2Binding = this.subModel2((fun m -> m.ClockCounter2), snd, App2.Msg.ClockCounter2Msg, CounterWithClockViewModel2(), nameof this.ClockCounter2)
 
   member _.ClockCounter1 = clockCounter1Binding
   member _.ClockCounter2 = clockCounter2Binding

--- a/src/Samples/SubModel/Clock.xaml
+++ b/src/Samples/SubModel/Clock.xaml
@@ -5,7 +5,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModel;assembly=SubModel.Core"
              mc:Ignorable="d"
-             d:DataContext="{x:Static vm:Program.clockDesignVm}">
+             d:DataContext="{d:DesignInstance vm:ClockViewModel}">
   <StackPanel Orientation="Horizontal">
     <TextBlock Text="{Binding Time, StringFormat='Today is {0:MMMM dd, yyyy}. The time is {0:HH:mm:ssK}. It is {0:dddd}.'}" />
     <RadioButton Command="{Binding SetLocal}" IsChecked="{Binding IsLocal, Mode=OneWay}" Content="Local" Margin="10,0,0,0"/>

--- a/src/Samples/SubModel/Clock.xaml
+++ b/src/Samples/SubModel/Clock.xaml
@@ -5,7 +5,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModel;assembly=SubModel.Core"
              mc:Ignorable="d"
-             d:DataContext="{d:DesignInstance vm:ClockViewModel}">
+             d:DataContext="{d:DesignInstance vm:ClockViewModel, IsDesignTimeCreatable=True}">
   <StackPanel Orientation="Horizontal">
     <TextBlock Text="{Binding Time, StringFormat='Today is {0:MMMM dd, yyyy}. The time is {0:HH:mm:ssK}. It is {0:dddd}.'}" />
     <RadioButton Command="{Binding SetLocal}" IsChecked="{Binding IsLocal, Mode=OneWay}" Content="Local" Margin="10,0,0,0"/>

--- a/src/Samples/SubModel/Counter.xaml
+++ b/src/Samples/SubModel/Counter.xaml
@@ -5,7 +5,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModel;assembly=SubModel.Core"
              mc:Ignorable="d"
-             d:DataContext="{d:DesignInstance vm:CounterViewModel2}">
+             d:DataContext="{d:DesignInstance vm:CounterViewModel, IsDesignTimeCreatable=True}">
   <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top">
     <TextBlock Text="{Binding CounterValue, StringFormat='Counter value: {0}'}" Width="110" Margin="0,5,10,5" />
     <Button Command="{Binding Decrement}" Content="-" Margin="0,5,10,5" Width="30" />

--- a/src/Samples/SubModel/Counter.xaml
+++ b/src/Samples/SubModel/Counter.xaml
@@ -5,7 +5,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModel;assembly=SubModel.Core"
              mc:Ignorable="d"
-             d:DataContext="{x:Static vm:Program.counterDesignVm}">
+             d:DataContext="{d:DesignInstance vm:CounterViewModel2}">
   <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top">
     <TextBlock Text="{Binding CounterValue, StringFormat='Counter value: {0}'}" Width="110" Margin="0,5,10,5" />
     <Button Command="{Binding Decrement}" Content="-" Margin="0,5,10,5" Width="30" />

--- a/src/Samples/SubModel/CounterWithClock.xaml
+++ b/src/Samples/SubModel/CounterWithClock.xaml
@@ -6,7 +6,7 @@
              xmlns:local="clr-namespace:Elmish.WPF.Samples.SubModel"
              xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModel;assembly=SubModel.Core"
              mc:Ignorable="d"
-             d:DataContext="{d:DesignInstance vm:CounterWithClockViewModel}">
+             d:DataContext="{d:DesignInstance vm:CounterWithClockViewModel, IsDesignTimeCreatable=True}">
   <StackPanel>
     <local:Counter DataContext="{Binding Counter}" d:DataContext="{Binding DataContext.Counter, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />
     <local:Clock DataContext="{Binding Clock}" d:DataContext="{Binding DataContext.Clock, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />

--- a/src/Samples/SubModel/CounterWithClock.xaml
+++ b/src/Samples/SubModel/CounterWithClock.xaml
@@ -6,7 +6,7 @@
              xmlns:local="clr-namespace:Elmish.WPF.Samples.SubModel"
              xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModel;assembly=SubModel.Core"
              mc:Ignorable="d"
-             d:DataContext="{x:Static vm:Program.counterWithClockDesignVm}">
+             d:DataContext="{d:DesignInstance vm:CounterWithClockViewModel}">
   <StackPanel>
     <local:Counter DataContext="{Binding Counter}" d:DataContext="{Binding DataContext.Counter, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />
     <local:Clock DataContext="{Binding Clock}" d:DataContext="{Binding DataContext.Clock, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />

--- a/src/Samples/SubModel/MainWindow.xaml
+++ b/src/Samples/SubModel/MainWindow.xaml
@@ -10,7 +10,7 @@
         Width="500"
         WindowStartupLocation="CenterScreen"
         mc:Ignorable="d"
-        d:DataContext="{x:Static vm:Program.mainDesignVm}">
+        d:DataContext="{d:DesignInstance vm:MainViewModel, IsDesignTimeCreatable=True}">
   <StackPanel>
     <TextBlock Text="Counter with clock 1" FontSize="18" FontWeight="Bold" Margin="0,25,0,0" HorizontalAlignment="Center" />
     <local:CounterWithClock DataContext="{Binding ClockCounter1}" d:DataContext="{Binding DataContext.ClockCounter1, RelativeSource={RelativeSource AncestorType=StackPanel}}"/>


### PR DESCRIPTION
The purpose of this Pull Request is to show a proof of concept to allow statically typed view models to be used with the Elmish framework.

## Key concepts:
`SubModelVm` and its similarly named cohorts are intended to "bridge" between the dynamic Elmish.WPF bindings and the new `ViewModelBase` bindings that I am proposing. Basically it replaces the `GetBindings` function with a `CreateViewModel` function.

`DynamicViewModel` is just the new name for Elmish.WPF's old underlying view model. Instead of inheriting from `DynamicObject` and overriding `TryGetMember` and `TrySetMember`, we now implement [`IDynamicMetaObjectProvider`](https://docs.microsoft.com/en-us/dotnet/api/system.dynamic.idynamicmetaobjectprovider) which returns a `DynamicViewModelMetaObject` which is actually used for the dynamic dispatch. I believe [`DynamicObject` actually uses this under the hood.](https://referencesource.microsoft.com/#System.Core/Microsoft/Scripting/Actions/DynamicObject.cs)

`ViewModelBase` has helper functions to allow easy get/set implementations on a concrete view model. Note that it also dynamically adds to the list of bindings as each property's getter or setter gets called. What this means is that technically `NotifyPropertyChanged` will never be fired on a property if the WPF framework has not yet called Get or Set on the property. I don't think this ever happens in WPF, and if so it is an extremely rare case and is easily remediable.

## Examples
The Submodel.Core project uses some of these concepts in two different ways.

`ViewModelBase2` is a helper class that exposes an equivalent list of bindings via the `Bindings` property, which can then be piped into the existing Elmish structure. This implementation doesn't require any modification of the `Elmish.WPF` project in order to work, but it is far more verbose as the bindings must be collected before the member definitions, requiring twice as many lines of code.

`MainWindowViewModel` and its submodels are an example of inheriting from the new `ViewModelBase` in the `Elmish.WPF` project. These helpers can be called directly in the getters and setters of the property, reducing the target code complexity while compromising little of the flexibility.