### PR TITLE
Add a BaseViewModel for static view model typing

### DIFF
--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -6,7 +6,6 @@ open System.Collections.ObjectModel
 open System.Collections.Specialized
 open System.ComponentModel
 open System.Windows.Input
-open Microsoft.Extensions.Logging.Abstractions
 open FSharp.Interop.Dynamic
 open Xunit
 open Hedgehog

--- a/src/Elmish.WPF.sln
+++ b/src/Elmish.WPF.sln
@@ -76,6 +76,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Multiselect", "Samples\Mult
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Multiselect.Core", "Samples\Multiselect.Core\Multiselect.Core.fsproj", "{DFF15AD9-337E-4301-9A05-5CFA147C457E}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SubModelStatic", "Samples\SubModelStatic\SubModelStatic.csproj", "{3F50DF04-DE1F-4368-9584-E318FE41AC2C}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "SubModelStatic.Core", "Samples\SubModelStatic.Core\SubModelStatic.Core.fsproj", "{F0064852-8E7F-437B-A414-72EB0FA46711}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -210,6 +214,14 @@ Global
 		{DFF15AD9-337E-4301-9A05-5CFA147C457E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DFF15AD9-337E-4301-9A05-5CFA147C457E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DFF15AD9-337E-4301-9A05-5CFA147C457E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F50DF04-DE1F-4368-9584-E318FE41AC2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F50DF04-DE1F-4368-9584-E318FE41AC2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F50DF04-DE1F-4368-9584-E318FE41AC2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F50DF04-DE1F-4368-9584-E318FE41AC2C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0064852-8E7F-437B-A414-72EB0FA46711}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0064852-8E7F-437B-A414-72EB0FA46711}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0064852-8E7F-437B-A414-72EB0FA46711}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0064852-8E7F-437B-A414-72EB0FA46711}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -245,6 +257,8 @@ Global
 		{BDA46408-691C-47FA-8670-92A5D04663EB} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
 		{57EB1D0A-9182-4A7F-818B-8FDCA58D7321} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
 		{DFF15AD9-337E-4301-9A05-5CFA147C457E} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
+		{3F50DF04-DE1F-4368-9584-E318FE41AC2C} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
+		{F0064852-8E7F-437B-A414-72EB0FA46711} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3125D461-08F4-4071-AAE5-1038EF84A360}

--- a/src/Elmish.WPF/AutoOpen.fs
+++ b/src/Elmish.WPF/AutoOpen.fs
@@ -4,6 +4,32 @@ module internal AutoOpen
 open System.Collections.Generic
 open System.Diagnostics
 
+open System
+open Microsoft.FSharp.Reflection
+open Microsoft.FSharp.Quotations.Patterns
+
+/// Evaluates expression untyped
+let rec eval = function
+    | Value(v,_t) -> v
+    | Coerce(e,_t) -> eval e
+    | NewObject(ci,args) -> ci.Invoke(evalAll args)
+    | NewArray(t,args) -> 
+        let array = Array.CreateInstance(t, args.Length) 
+        args |> List.iteri (fun i arg -> array.SetValue(eval arg, i))
+        box array
+    | NewUnionCase(case,args) -> FSharpValue.MakeUnion(case, evalAll args)
+    | NewRecord(t,args) -> FSharpValue.MakeRecord(t, evalAll args)
+    | NewTuple(args) ->
+        let t = FSharpType.MakeTupleType [|for arg in args -> arg.Type|]
+        FSharpValue.MakeTuple(evalAll args, t)
+    | FieldGet(Some(Value(v,_)),fi) -> fi.GetValue(v)
+    | PropertyGet(None, pi, args) -> pi.GetValue(null, evalAll args)
+    | PropertyGet(Some(x),pi,args) -> pi.GetValue(eval x, evalAll args)
+    | Call(None,mi,args) -> mi.Invoke(null, evalAll args)
+    | Call(Some(x),mi,args) -> mi.Invoke(eval x, evalAll args)
+    | arg -> raise <| NotSupportedException(arg.ToString())
+and evalAll args = [|for arg in args -> eval arg|]
+
 
 let flip f b a = f a b
 

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -218,7 +218,7 @@ module Binding =
 
   module SubModel =
 
-    let private mapMinorTypes
+    let internal mapMinorTypes
         (outMapBindingModel: 'bindingModel -> 'bindingModel0)
         (outMapBindingMsg: 'bindingMsg -> 'bindingMsg0)
         (outMapBindingViewModel: 'bindingViewModel -> 'bindingViewModel0)

--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -47,6 +47,7 @@
     <Compile Include="ViewModel.fs" />
     <Compile Include="Binding.fs" />
     <Compile Include="ViewModelModule.fs" />
+    <Compile Include="ViewModelBase.fs" />
     <Compile Include="WpfProgram.fs" />
   </ItemGroup>
 

--- a/src/Elmish.WPF/ViewModel.fs
+++ b/src/Elmish.WPF/ViewModel.fs
@@ -703,7 +703,7 @@ and internal Set(value: obj) =
     | AlterMsgStream b -> this.Recursive(b.Get model, b.Binding)
 
 
-and [<AllowNullLiteral>] internal ViewModel<'model, 'msg>
+and [<AllowNullLiteral>] ViewModel<'model, 'msg>
       ( args: ViewModelArgs<'model, 'msg>,
         bindings: Binding<'model, 'msg> list)
       as this =

--- a/src/Elmish.WPF/ViewModelArgs.fs
+++ b/src/Elmish.WPF/ViewModelArgs.fs
@@ -4,13 +4,13 @@ open Microsoft.Extensions.Logging
 open Microsoft.Extensions.Logging.Abstractions
 
 
-type internal LoggingViewModelArgs =
+type LoggingViewModelArgs =
   { performanceLogThresholdMs: int
     log: ILogger
     logPerformance: ILogger
     nameChain: string }
 
-module internal LoggingViewModelArgs =
+module LoggingViewModelArgs =
 
   let getNameChainFor nameChain name =
     sprintf "%s.%s" nameChain name
@@ -27,12 +27,12 @@ module internal LoggingViewModelArgs =
       nameChain = "" }
 
 
-type internal ViewModelArgs<'model, 'msg> =
+type ViewModelArgs<'model, 'msg> =
   { initialModel: 'model
     dispatch: 'msg -> unit
     loggingArgs: LoggingViewModelArgs }
 
-module internal ViewModelArgs =
+module ViewModelArgs =
   let create initialModel dispatch nameChain loggingArgs =
     { initialModel = initialModel
       dispatch = dispatch

--- a/src/Elmish.WPF/ViewModelBase.fs
+++ b/src/Elmish.WPF/ViewModelBase.fs
@@ -60,9 +60,9 @@ type [<AllowNullLiteral>] ViewModelBase<'model,'msg>
       let binding = Initialize(loggingArgs, name, fun _ -> None).Recursive(initialModel, dispatch, (fun () -> currentModel), wrappedBindingData)
       do binding |> Option.map (fun binding -> bindings.Add(name, binding)) |> ignore
 
-  let initializeCmdBindingIfNew name exec canExec =
+  let initializeCmdBindingIfNew name exec canExec autoRequery =
     if bindings.ContainsKey name |> not then
-      let bindingData = { Exec = exec; CanExec = canExec; AutoRequery = true }
+      let bindingData = { Exec = exec; CanExec = canExec; AutoRequery = autoRequery }
       let wrappedBindingData = bindingData |> CmdData |> BaseBindingData
       let binding = Initialize(loggingArgs, name, fun _ -> None).Recursive(initialModel, dispatch, (fun () -> currentModel), wrappedBindingData)
       do binding |> Option.map (fun binding -> bindings.Add(name, binding)) |> ignore
@@ -136,8 +136,8 @@ type [<AllowNullLiteral>] ViewModelBase<'model,'msg>
     memberName |> Option.iter (fun name -> initializeSetBindingIfNew name setter)
     currentModel |> setter |> dispatch
 
-  member _.cmd(exec: obj -> 'model -> 'msg voption, canExec: obj -> 'model -> bool, [<CallerMemberName>] ?memberName: string) =
-    memberName |> ValueOption.ofOption |> ValueOption.bind (fun name -> initializeCmdBindingIfNew name exec canExec) |> ValueOption.defaultValue null
+  member _.cmd(exec: obj -> 'model -> 'msg voption, canExec: obj -> 'model -> bool, autoRequery: bool, [<CallerMemberName>] ?memberName: string) =
+    memberName |> ValueOption.ofOption |> ValueOption.bind (fun name -> initializeCmdBindingIfNew name exec canExec autoRequery) |> ValueOption.defaultValue null
 
   member _.subModel(getModel: 'model -> 'bindingModel voption, toMsg, createViewModel, updateViewModel, [<CallerMemberName>] ?memberName: string) =
     memberName |> ValueOption.ofOption |> ValueOption.bind (fun name -> initializeSubModelBindingIfNew name getModel toMsg createViewModel updateViewModel) |> ValueOption.defaultValue null

--- a/src/Elmish.WPF/ViewModelBase.fs
+++ b/src/Elmish.WPF/ViewModelBase.fs
@@ -212,7 +212,7 @@ module BindingBase =
     ///   Creates a binding to a sub-model/component. You typically bind this
     ///   to the <c>DataContext</c> of a <c>UserControl</c> or similar.
     /// </summary>
-    /// <param name="bindings">Returns the bindings for the sub-model.</param>
+    /// <param name="create">Returns the static view model for the sub-model.</param>
     let vopt (create: ViewModelArgs<'model, 'msg> -> #ViewModelBase<'model,'msg>)
         : string -> Binding<'model voption, 'msg> =
       { GetModel = id
@@ -228,7 +228,7 @@ module BindingBase =
     ///   Creates a binding to a sub-model/component. You typically bind this
     ///   to the <c>DataContext</c> of a <c>UserControl</c> or similar.
     /// </summary>
-    /// <param name="bindings">Returns the bindings for the sub-model.</param>
+    /// <param name="create">Returns the static view model for the sub-model.</param>
     let opt (create: ViewModelArgs<'model, 'msg> -> #ViewModelBase<'model,'msg>)
         : string -> Binding<'model option, 'msg> =
       vopt create
@@ -238,7 +238,7 @@ module BindingBase =
     ///   Creates a binding to a sub-model/component. You typically bind this
     ///   to the <c>DataContext</c> of a <c>UserControl</c> or similar.
     /// </summary>
-    /// <param name="bindings">Returns the bindings for the sub-model.</param>
+    /// <param name="create">Returns the static view model for the sub-model.</param>
     let required (create: ViewModelArgs<'model, 'msg> -> #ViewModelBase<'model,'msg>)
         : string -> Binding<'model, 'msg> =
       vopt create
@@ -250,7 +250,7 @@ module BindingBase =
     ///   Creates a binding to a sub-model/component. You typically bind this
     ///   to the <c>DataContext</c> of a <c>UserControl</c> or similar.
     /// </summary>
-    /// <param name="bindings">Returns the bindings for the sub-model.</param>
+    /// <param name="create">Returns the static view model for the sub-model.</param>
     let required (create: ViewModelArgs<'model, 'msg> -> #ViewModelBase<'model,'msg>)
         : string -> Binding<'model seq, int * 'msg> =
       BindingData.SubModelSeqUnkeyed.create
@@ -263,7 +263,8 @@ module BindingBase =
     ///   Creates a binding to a sub-model/component. You typically bind this
     ///   to the <c>DataContext</c> of a <c>UserControl</c> or similar.
     /// </summary>
-    /// <param name="bindings">Returns the bindings for the sub-model.</param>
+    /// <param name="create">Returns the static view model for the sub-model.</param>
+    /// <param name="getId">Returns the identifier for the model.</param>
     let required (create: ViewModelArgs<'model, 'msg> -> #ViewModelBase<'model,'msg>) (getId: 'model -> 'id)
         : string -> Binding<'model seq, 'id * 'msg> =
       BindingData.SubModelSeqKeyed.create

--- a/src/Elmish.WPF/ViewModelBase.fs
+++ b/src/Elmish.WPF/ViewModelBase.fs
@@ -1,0 +1,130 @@
+﻿namespace Elmish.WPF
+
+open System
+open System.Collections.Generic
+open System.ComponentModel
+open System.Runtime.CompilerServices
+open System.Windows.Input
+open Microsoft.Extensions.Logging
+
+
+type [<AllowNullLiteral>] ViewModelBase<'model,'msg>
+      ( args: ViewModelArgs<'model, 'msg>,
+        getSender: unit -> obj) =
+
+  let { initialModel = initialModel
+        dispatch = dispatch
+        loggingArgs = loggingArgs
+      } = args
+
+  let { log = log
+        nameChain = nameChain
+      } = loggingArgs
+
+  let mutable currentModel = initialModel
+
+  let propertyChanged = Event<PropertyChangedEventHandler, PropertyChangedEventArgs>()
+  let errorsChanged = DelegateEvent<EventHandler<DataErrorsChangedEventArgs>>()
+
+  let bindings = Dictionary<String, VmBinding<'model, 'msg>>()
+  let validationErrors = Dictionary<String, String list ref>()
+
+  let raisePropertyChanged name =
+    log.LogTrace("[{BindingNameChain}] PropertyChanged {BindingName}", nameChain, name)
+    propertyChanged.Trigger(getSender (), PropertyChangedEventArgs name)
+  let raiseCanExecuteChanged (cmd: Command) =
+    cmd.RaiseCanExecuteChanged ()
+  let raiseErrorsChanged name =
+    log.LogTrace("[{BindingNameChain}] ErrorsChanged {BindingName}", nameChain, name)
+    errorsChanged.Trigger([| getSender (); box <| DataErrorsChangedEventArgs name |])
+
+  let initializeGetBindingIfNew name getter =
+    if bindings.ContainsKey name |> not then
+      let binding = BaseVmBinding (OneWay { OneWayData = { Get = getter >> box } })
+      bindings.Add(name, binding)
+      
+  let initializeSetBindingIfNew name (setter: 'model -> 'msg) =
+    if bindings.ContainsKey name |> not then
+      let binding = BaseVmBinding (OneWayToSource { Set = (fun _ -> unbox >> setter >> dispatch) })
+      bindings.Add(name, binding)
+
+  let initializeCmdBindingIfNew name exec canExec =
+    if bindings.ContainsKey name |> not then
+      let vmBinding = Command((fun p -> currentModel |> exec p |> ValueOption.iter dispatch), (fun p -> currentModel |> canExec p))
+      bindings.Add(name, BaseVmBinding (Cmd vmBinding))
+      vmBinding :> ICommand |> Some
+    else
+      match bindings.Item name with
+      | BaseVmBinding (Cmd vmBinding) -> vmBinding :> ICommand |> Some
+      | foundBinding -> log.LogError("Wrong binding type found for {name}, should be BaseVmBinding, found {foundBinding}", name, foundBinding); None
+
+  let initializeSubModelBindingIfNew
+    name (getModel: 'model -> 'bindingModel voption)
+    (toMsg: 'model -> 'bindingMsg -> 'msg)
+    (createViewModel: ViewModelArgs<'bindingModel, 'bindingMsg> -> #ViewModelBase<'bindingModel, 'bindingMsg>) =
+    if bindings.ContainsKey name |> not then
+      let binding =
+        getModel initialModel
+        |> ValueOption.map (fun m -> createViewModel(ViewModelArgs.create m (toMsg currentModel >> dispatch) name loggingArgs))
+        |> (fun vm -> { SubModelData = { GetModel = getModel; ToMsg = toMsg; CreateViewModel = createViewModel; UpdateViewModel = (fun (vm,m) -> vm.UpdateModel(m)) }; Vm = ref vm })
+      let toMsg2 = fun m bMsg -> binding.SubModelData.ToMsg m (unbox bMsg)
+      let getModel2 = binding.SubModelData.GetModel >> ValueOption.map box
+      let createViewModel2 = (fun args -> ViewModelArgs.map unbox box args |> binding.SubModelData.CreateViewModel |> box)
+      let updateViewModel2 = fun (vm,m) -> binding.SubModelData.UpdateViewModel(unbox vm, unbox m)
+      let initialVm2 = getModel2 currentModel |> ValueOption.map (fun m -> createViewModel2 (ViewModelArgs.create m (toMsg2 currentModel >> dispatch) name loggingArgs))
+      let vmBinding = { SubModelData = { GetModel = getModel2; ToMsg = toMsg2; CreateViewModel = createViewModel2; UpdateViewModel = updateViewModel2 }; Vm = ref initialVm2 }
+      do bindings.Add(name, BaseVmBinding (SubModel vmBinding))
+    
+    match bindings.Item name with
+    | BaseVmBinding (SubModel vmBinding) -> vmBinding.Vm.Value |> ValueOption.map (fun vm -> vm :?> 'viewModel)
+    | foundBinding -> log.LogError("Wrong binding type found for {name}, should be BaseVmBinding, found {foundBinding}", name, foundBinding); ValueNone
+
+  member _.getValue(getter: 'model -> 'a, [<CallerMemberName>] ?memberName: string) =
+    Option.iter (fun name -> initializeGetBindingIfNew name getter) memberName
+    getter currentModel
+
+  member _.setValue(setter: 'model -> 'msg, [<CallerMemberName>] ?memberName: string) =
+    Option.iter (fun name -> initializeSetBindingIfNew name setter) memberName
+    currentModel |> setter |> dispatch
+
+  member _.cmd(exec: obj -> 'model -> 'msg voption, canExec: obj -> 'model -> bool, [<CallerMemberName>] ?memberName: string) =
+    Option.bind (fun name -> initializeCmdBindingIfNew name exec canExec) memberName |> Option.defaultValue null
+
+  member _.subModel(getModel: 'model -> 'bindingModel voption, toMsg, createViewModel, [<CallerMemberName>] ?memberName: string) =
+    memberName |> ValueOption.ofOption |> ValueOption.bind (fun name -> initializeSubModelBindingIfNew name getModel toMsg createViewModel) |> ValueOption.defaultValue null
+
+  member internal _.CurrentModel : 'model = currentModel
+
+  member internal _.UpdateModel (newModel: 'model) : unit =
+    let eventsToRaise =
+      bindings
+      |> Seq.collect (fun (Kvp (name, binding)) -> Update(loggingArgs, name).Recursive(currentModel, newModel, dispatch, binding))
+      |> Seq.toList
+    currentModel <- newModel
+    eventsToRaise
+    |> List.iter (function
+      | ErrorsChanged name -> raiseErrorsChanged name
+      | PropertyChanged name -> raisePropertyChanged name
+      | CanExecuteChanged cmd -> cmd |> raiseCanExecuteChanged)
+
+  interface INotifyPropertyChanged with
+    [<CLIEvent>]
+    member _.PropertyChanged = propertyChanged.Publish
+
+  interface INotifyDataErrorInfo with
+    [<CLIEvent>]
+    member _.ErrorsChanged = errorsChanged.Publish
+    member _.HasErrors =
+      // WPF calls this too often, so don't log https://github.com/elmish/Elmish.WPF/issues/354
+      validationErrors
+      |> Seq.map (fun (Kvp(_, errors)) -> errors.Value)
+      |> Seq.filter (not << List.isEmpty)
+      |> (not << Seq.isEmpty)
+    member _.GetErrors name =
+      let name = name |> Option.ofObj |> Option.defaultValue "<null>" // entity-level errors are being requested when given null or ""  https://docs.microsoft.com/en-us/dotnet/api/system.componentmodel.inotifydataerrorinfo.geterrors#:~:text=null%20or%20Empty%2C%20to%20retrieve%20entity-level%20errors
+      log.LogTrace("[{BindingNameChain}] GetErrors {BindingName}", nameChain, name)
+      validationErrors
+      |> IReadOnlyDictionary.tryFind name
+      |> Option.map (fun errors -> errors.Value)
+      |> Option.defaultValue []
+      |> (fun x -> upcast x)

--- a/src/Elmish.WPF/ViewModelBase.fs
+++ b/src/Elmish.WPF/ViewModelBase.fs
@@ -270,47 +270,47 @@ type [<AllowNullLiteral>] ViewModelBase<'model,'msg>
     if not didSet then
       log.LogError("Failed to set binding {name}", name)
 
-  member _.getValue(getter: 'model -> 'a, [<CallerMemberName>] ?memberName: string) =
+  member _.getValue(getter, [<CallerMemberName>] ?memberName) =
     memberName
     |> ValueOption.ofOption
     |> ValueOption.bind (fun name -> initializeGetBindingIfNew name getter)
     |> ValueOption.defaultValue Unchecked.defaultof<'a>
 
-  member _.setValue(setter: 'model -> 'msg, [<CallerMemberName>] ?memberName: string) =
+  member _.setValue(setter, [<CallerMemberName>] ?memberName) =
     memberName
     |> Option.iter (fun name -> initializeSetBindingIfNew name setter)
 
-  member _.cmd(exec: obj -> 'model -> 'msg voption, canExec: obj -> 'model -> bool, autoRequery: bool, [<CallerMemberName>] ?memberName: string) =
+  member _.cmd(exec, canExec, autoRequery, [<CallerMemberName>] ?memberName) =
     memberName
     |> Option.bind (fun name -> initializeCmdBindingIfNew name exec canExec autoRequery)
     |> Option.defaultValue null
 
-  member _.subModel(getModel, toMsg, createViewModel, updateViewModel, [<CallerMemberName>] ?memberName: string) =
+  member _.subModel(getModel, toMsg, createViewModel, updateViewModel, [<CallerMemberName>] ?memberName) =
     memberName
     |> Option.bind (fun name -> initializeSubModelBindingIfNew name getModel toMsg createViewModel updateViewModel)
     |> Option.defaultValue null
 
-  member _.subModelSeqUnkeyed(getModels: 'model -> 'bindingModel seq, toMsg, createViewModel, updateViewModel, [<CallerMemberName>] ?memberName: string) =
+  member _.subModelSeqUnkeyed(getModels, toMsg, createViewModel, updateViewModel, [<CallerMemberName>] ?memberName) =
     memberName
     |> Option.bind (fun name -> initializeSubModelSeqUnkeyedBindingIfNew name getModels toMsg createViewModel updateViewModel)
     |> Option.defaultValue null
 
-  member _.subModelSeqKeyed(getModels: 'model -> 'bindingModel seq, toMsg, getKey, createViewModel, updateViewModel, getUnderlyingModel, [<CallerMemberName>] ?memberName: string) =
+  member _.subModelSeqKeyed(getModels, toMsg, getKey, createViewModel, updateViewModel, getUnderlyingModel, [<CallerMemberName>] ?memberName) =
     memberName
     |> Option.bind (fun name -> initializeSubModelSeqKeyedBindingIfNew name getModels toMsg getKey createViewModel updateViewModel getUnderlyingModel)
     |> Option.defaultValue null
 
-  member _.subModelWin(getState, toMsg, getWindow, isModal, onCloseRequested, createViewModel, updateViewModel, [<CallerMemberName>] ?memberName: string) =
+  member _.subModelWin(getState, toMsg, getWindow, isModal, onCloseRequested, createViewModel, updateViewModel, [<CallerMemberName>] ?memberName) =
     memberName
     |> Option.bind (fun name -> initializeSubModelWinBindingIfNew name getState toMsg getWindow isModal onCloseRequested createViewModel updateViewModel)
     |> Option.defaultValue null
 
-  member _.getSubModelSelectedItem(seqBinding, getter, [<CallerMemberName>] ?memberName: string) =
+  member _.getSubModelSelectedItem(seqBinding, getter, [<CallerMemberName>] ?memberName) =
     memberName
     |> Option.bind (fun name -> initializeGetSubModelSelectedItemBindingIfNew name getter seqBinding)
     |> Option.defaultValue null
   
-  member _.setSubModelSelectedItem(seqBinding, setter, value, [<CallerMemberName>] ?memberName: string) =
+  member _.setSubModelSelectedItem(seqBinding, setter, value, [<CallerMemberName>] ?memberName) =
     memberName
     |> Option.iter (fun name -> initializeSetSubModelSelectedItemBindingIfNew name setter seqBinding value)
 
@@ -324,8 +324,8 @@ type [<AllowNullLiteral>] ViewModelBase<'model,'msg>
     currentModel <- newModel
     eventsToRaise
     |> List.iter (function
-      | ErrorsChanged name -> raiseErrorsChanged name
-      | PropertyChanged name -> raisePropertyChanged name
+      | ErrorsChanged name -> name |> raiseErrorsChanged
+      | PropertyChanged name -> name |> raisePropertyChanged
       | CanExecuteChanged cmd -> cmd |> raiseCanExecuteChanged)
 
   interface INotifyPropertyChanged with
@@ -361,28 +361,28 @@ module private BindingHelpers =
   
 type ViewModelBase<'model, 'msg> with
 
-  member this.subModel (getModel, toMsg, createViewModel, [<CallerMemberName>] ?memberName: string) =
+  member this.subModel (getModel, toMsg, createViewModel, [<CallerMemberName>] ?memberName) =
     this.subModel (getModel, toMsg, createViewModel, BaseHelpers.updateViewModel, ?memberName = memberName)
 
-  member this.subModelBindings (getModel, toMsg, bindings, [<CallerMemberName>] ?memberName: string) =
+  member this.subModelBindings (getModel, toMsg, bindings, [<CallerMemberName>] ?memberName) =
     this.subModel (getModel, toMsg, BindingHelpers.createViewModel bindings, BindingHelpers.updateViewModel, ?memberName = memberName)
 
-  member this.subModelSeqUnkeyed (getModels, toMsg, createViewModel, [<CallerMemberName>] ?memberName: string) =
+  member this.subModelSeqUnkeyed (getModels, toMsg, createViewModel, [<CallerMemberName>] ?memberName) =
     this.subModelSeqUnkeyed (getModels, toMsg, createViewModel, BaseHelpers.updateViewModel, ?memberName = memberName)
 
-  member this.subModelSeqUnkeyedBindings (getModels, toMsg, bindings, [<CallerMemberName>] ?memberName: string) =
+  member this.subModelSeqUnkeyedBindings (getModels, toMsg, bindings, [<CallerMemberName>] ?memberName) =
     this.subModelSeqUnkeyed (getModels, toMsg, BindingHelpers.createViewModel bindings, BindingHelpers.updateViewModel, ?memberName = memberName)
 
-  member this.subModelSeqKeyed (getModels, getKey, toMsg, createViewModel, [<CallerMemberName>] ?memberName: string) =
+  member this.subModelSeqKeyed (getModels, getKey, toMsg, createViewModel, [<CallerMemberName>] ?memberName) =
     this.subModelSeqKeyed (getModels, getKey, toMsg, createViewModel, BaseHelpers.updateViewModel, BaseHelpers.getUnderlyingModel, ?memberName = memberName)
 
-  member this.subModelSeqKeyedBindings (getModels, getKey, toMsg, bindings, [<CallerMemberName>] ?memberName: string) =
+  member this.subModelSeqKeyedBindings (getModels, getKey, toMsg, bindings, [<CallerMemberName>] ?memberName) =
     this.subModelSeqKeyed (getModels, getKey, toMsg, BindingHelpers.createViewModel bindings, BindingHelpers.updateViewModel, BindingHelpers.getUnderlyingModel, ?memberName = memberName)
 
-  member this.subModelWin (getState, toMsg, getWindow, isModal, onCloseRequested, createViewModel, [<CallerMemberName>] ?memberName: string) =
+  member this.subModelWin (getState, toMsg, getWindow, isModal, onCloseRequested, createViewModel, [<CallerMemberName>] ?memberName) =
     this.subModelWin (getState, toMsg, getWindow, isModal, onCloseRequested, createViewModel, BaseHelpers.updateViewModel, ?memberName = memberName)
     
-  member this.subModelWinBindings (getState, toMsg, getWindow, isModal, onCloseRequested, bindings, [<CallerMemberName>] ?memberName: string) =
+  member this.subModelWinBindings (getState, toMsg, getWindow, isModal, onCloseRequested, bindings, [<CallerMemberName>] ?memberName) =
     this.subModelWin (getState, toMsg, getWindow, isModal, onCloseRequested, BindingHelpers.createViewModel bindings, BindingHelpers.updateViewModel, ?memberName = memberName)
 
 module BindingBase =

--- a/src/Elmish.WPF/ViewModelBase.fs
+++ b/src/Elmish.WPF/ViewModelBase.fs
@@ -98,8 +98,8 @@ type [<AllowNullLiteral>] ViewModelBase<'model,'msg>
       
     let binding = Get(nameChain).Recursive(currentModel, getBindings.Item name)
     match binding with
-    | Ok o -> o |> unbox<ICommand> |> ValueSome
-    | Error error -> log.LogError("Wrong binding type found for {name}, should be BaseVmBinding, found {foundBinding}", name, error); ValueNone
+    | Ok o -> o |> unbox<ICommand> |> Some
+    | Error error -> log.LogError("Wrong binding type found for {name}, should be BaseVmBinding, found {foundBinding}", name, error); None
 
   let initializeSubModelBindingIfNew
     name
@@ -122,8 +122,8 @@ type [<AllowNullLiteral>] ViewModelBase<'model,'msg>
       
     let binding = Get(nameChain).Recursive(currentModel, getBindings.Item name)
     match binding with
-    | Ok o -> o |> unbox<'bindingViewModel> |> ValueSome
-    | Error error -> log.LogError("Wrong binding type found for {name}, should be BaseVmBinding, found {foundBinding}", name, error); ValueNone
+    | Ok o -> o |> unbox<'bindingViewModel> |> Some
+    | Error error -> log.LogError("Wrong binding type found for {name}, should be BaseVmBinding, found {foundBinding}", name, error); None
 
   let initializeSubModelSeqUnkeyedBindingIfNew
     name
@@ -147,8 +147,8 @@ type [<AllowNullLiteral>] ViewModelBase<'model,'msg>
 
     let binding = Get(nameChain).Recursive(currentModel, getBindings.Item name)
     match binding with
-    | Ok o -> o |> unbox<ObservableCollection<'bindingViewModel>> |> ValueSome
-    | Error error -> log.LogError("Wrong binding type found for {name}, should be BaseVmBinding, found {foundBinding}", name, error); ValueNone
+    | Ok o -> o |> unbox<ObservableCollection<'bindingViewModel>> |> Some
+    | Error error -> log.LogError("Wrong binding type found for {name}, should be BaseVmBinding, found {foundBinding}", name, error); None
 
   let initializeSubModelSeqKeyedBindingIfNew
     name
@@ -176,8 +176,8 @@ type [<AllowNullLiteral>] ViewModelBase<'model,'msg>
 
     let binding = Get(nameChain).Recursive(currentModel, getBindings.Item name)
     match binding with
-    | Ok o -> o |> unbox<ObservableCollection<'bindingViewModel>> |> ValueSome
-    | Error error -> log.LogError("Wrong binding type found for {name}, should be BaseVmBinding, found {foundBinding}", name, error); ValueNone
+    | Ok o -> o |> unbox<ObservableCollection<'bindingViewModel>> |> Some
+    | Error error -> log.LogError("Wrong binding type found for {name}, should be BaseVmBinding, found {foundBinding}", name, error); None
     
   let initializeSubModelWinBindingIfNew
     name
@@ -206,8 +206,8 @@ type [<AllowNullLiteral>] ViewModelBase<'model,'msg>
       
     let binding = Get(nameChain).Recursive(currentModel, getBindings.Item name)
     match binding with
-    | Ok o -> o |> unbox<'bindingViewModel> |> ValueSome
-    | Error error -> log.LogError("Wrong binding type found for {name}, should be BaseVmBinding, found {foundBinding}", name, error); ValueNone
+    | Ok o -> o |> unbox<'bindingViewModel> |> Some
+    | Error error -> log.LogError("Wrong binding type found for {name}, should be BaseVmBinding, found {foundBinding}", name, error); None
     
   let initializeGetSubModelSelectedItemBindingIfNew
     name
@@ -237,8 +237,8 @@ type [<AllowNullLiteral>] ViewModelBase<'model,'msg>
 
     let binding = Get(nameChain).Recursive(currentModel, getBindings.Item name)
     match binding with
-    | Ok o -> o |> unbox<'bindingViewModel> |> ValueSome
-    | Error error -> log.LogError("Wrong binding type found for {name}, should be BaseVmBinding, found {foundBinding}", name, error); ValueNone
+    | Ok o -> o |> unbox<'bindingViewModel> |> Some
+    | Error error -> log.LogError("Wrong binding type found for {name}, should be BaseVmBinding, found {foundBinding}", name, error); None
     
   let initializeSetSubModelSelectedItemBindingIfNew
     name
@@ -282,39 +282,33 @@ type [<AllowNullLiteral>] ViewModelBase<'model,'msg>
 
   member _.cmd(exec: obj -> 'model -> 'msg voption, canExec: obj -> 'model -> bool, autoRequery: bool, [<CallerMemberName>] ?memberName: string) =
     memberName
-    |> ValueOption.ofOption
-    |> ValueOption.bind (fun name -> initializeCmdBindingIfNew name exec canExec autoRequery)
-    |> ValueOption.defaultValue null
+    |> Option.bind (fun name -> initializeCmdBindingIfNew name exec canExec autoRequery)
+    |> Option.defaultValue null
 
   member _.subModel(getModel, toMsg, createViewModel, updateViewModel, [<CallerMemberName>] ?memberName: string) =
     memberName
-    |> ValueOption.ofOption
-    |> ValueOption.bind (fun name -> initializeSubModelBindingIfNew name getModel toMsg createViewModel updateViewModel)
-    |> ValueOption.defaultValue null
+    |> Option.bind (fun name -> initializeSubModelBindingIfNew name getModel toMsg createViewModel updateViewModel)
+    |> Option.defaultValue null
 
   member _.subModelSeqUnkeyed(getModels: 'model -> 'bindingModel seq, toMsg, createViewModel, updateViewModel, [<CallerMemberName>] ?memberName: string) =
     memberName
-    |> ValueOption.ofOption
-    |> ValueOption.bind (fun name -> initializeSubModelSeqUnkeyedBindingIfNew name getModels toMsg createViewModel updateViewModel)
-    |> ValueOption.defaultValue null
+    |> Option.bind (fun name -> initializeSubModelSeqUnkeyedBindingIfNew name getModels toMsg createViewModel updateViewModel)
+    |> Option.defaultValue null
 
   member _.subModelSeqKeyed(getModels: 'model -> 'bindingModel seq, toMsg, getKey, createViewModel, updateViewModel, getUnderlyingModel, [<CallerMemberName>] ?memberName: string) =
     memberName
-    |> ValueOption.ofOption
-    |> ValueOption.bind (fun name -> initializeSubModelSeqKeyedBindingIfNew name getModels toMsg getKey createViewModel updateViewModel getUnderlyingModel)
-    |> ValueOption.defaultValue null
+    |> Option.bind (fun name -> initializeSubModelSeqKeyedBindingIfNew name getModels toMsg getKey createViewModel updateViewModel getUnderlyingModel)
+    |> Option.defaultValue null
 
   member _.subModelWin(getState, toMsg, getWindow, isModal, onCloseRequested, createViewModel, updateViewModel, [<CallerMemberName>] ?memberName: string) =
     memberName
-    |> ValueOption.ofOption
-    |> ValueOption.bind (fun name -> initializeSubModelWinBindingIfNew name getState toMsg getWindow isModal onCloseRequested createViewModel updateViewModel)
-    |> ValueOption.defaultValue null
+    |> Option.bind (fun name -> initializeSubModelWinBindingIfNew name getState toMsg getWindow isModal onCloseRequested createViewModel updateViewModel)
+    |> Option.defaultValue null
 
   member _.getSubModelSelectedItem(seqBinding, getter, [<CallerMemberName>] ?memberName: string) =
     memberName
-    |> ValueOption.ofOption
-    |> ValueOption.bind (fun name -> initializeGetSubModelSelectedItemBindingIfNew name getter seqBinding)
-    |> ValueOption.defaultValue null
+    |> Option.bind (fun name -> initializeGetSubModelSelectedItemBindingIfNew name getter seqBinding)
+    |> Option.defaultValue null
   
   member _.setSubModelSelectedItem(seqBinding, setter, value, [<CallerMemberName>] ?memberName: string) =
     memberName

--- a/src/Elmish.WPF/ViewModelBase.fs
+++ b/src/Elmish.WPF/ViewModelBase.fs
@@ -350,30 +350,40 @@ type [<AllowNullLiteral>] ViewModelBase<'model,'msg>
       |> Option.defaultValue []
       |> (fun x -> upcast x)
 
+module private BaseHelpers =
+  let updateViewModel = fun ((vm: #ViewModelBase<'bindingModel, 'bindingMsg>),m) -> vm.UpdateModel(m)
+  let getUnderlyingModel = fun (vm: #ViewModelBase<'bindingModel, 'bindingMsg>) -> vm.CurrentModel
+
+module private BindingHelpers =
+  let createViewModel bindings = fun args -> ViewModel<'bindingModel, 'bindingMsg>(args, bindings)
+  let updateViewModel = fun ((vm: ViewModel<'bindingModel, 'bindingMsg>),m) -> vm.UpdateModel(m)
+  let getUnderlyingModel = fun (vm: ViewModel<'bindingModel, 'bindingMsg>) -> vm.CurrentModel
+  
 type ViewModelBase<'model, 'msg> with
-  member this.subModel (getModel: 'model -> 'bindingModel voption, toMsg, createViewModel: ViewModelArgs<'bindingModel, 'bindingMsg> -> #ViewModelBase<'bindingModel, 'bindingMsg>, [<CallerMemberName>] ?memberName: string) =
-    this.subModel (getModel, toMsg, createViewModel, (fun (vm,m) -> vm.UpdateModel(m)), ?memberName = memberName)
 
-  member this.subModelBindings (getModel: 'model -> 'bindingModel voption, toMsg, bindings, [<CallerMemberName>] ?memberName: string) =
-    this.subModel (getModel, toMsg, (fun args -> ViewModel<'bindingModel, 'bindingMsg>(args, bindings)), (fun (vm,m) -> vm.UpdateModel(m)), ?memberName = memberName)
+  member this.subModel (getModel, toMsg, createViewModel, [<CallerMemberName>] ?memberName: string) =
+    this.subModel (getModel, toMsg, createViewModel, BaseHelpers.updateViewModel, ?memberName = memberName)
 
-  member this.subModelSeqUnkeyed (getModels: 'model -> 'bindingModel seq, toMsg, createViewModel: ViewModelArgs<'bindingModel, 'bindingMsg> -> #ViewModelBase<'bindingModel, 'bindingMsg>, [<CallerMemberName>] ?memberName: string) =
-    this.subModelSeqUnkeyed (getModels, toMsg, createViewModel, (fun (vm,m) -> vm.UpdateModel(m)), ?memberName = memberName)
+  member this.subModelBindings (getModel, toMsg, bindings, [<CallerMemberName>] ?memberName: string) =
+    this.subModel (getModel, toMsg, BindingHelpers.createViewModel bindings, BindingHelpers.updateViewModel, ?memberName = memberName)
 
-  member this.subModelSeqUnkeyedBindings (getModels: 'model -> 'bindingModel seq, toMsg, bindings, [<CallerMemberName>] ?memberName: string) =
-    this.subModelSeqUnkeyed (getModels, toMsg, (fun args -> ViewModel<'bindingModel, 'bindingMsg>(args, bindings)), (fun (vm,m) -> vm.UpdateModel(m)), ?memberName = memberName)
+  member this.subModelSeqUnkeyed (getModels, toMsg, createViewModel, [<CallerMemberName>] ?memberName: string) =
+    this.subModelSeqUnkeyed (getModels, toMsg, createViewModel, BaseHelpers.updateViewModel, ?memberName = memberName)
 
-  member this.subModelSeqKeyed (getModels: 'model -> 'bindingModel seq, getKey, toMsg, createViewModel: ViewModelArgs<'bindingModel, 'bindingMsg> -> #ViewModelBase<'bindingModel, 'bindingMsg>, [<CallerMemberName>] ?memberName: string) =
-    this.subModelSeqKeyed (getModels, getKey, toMsg, createViewModel, (fun (vm,m) -> vm.UpdateModel(m)), (fun vm -> vm.CurrentModel), ?memberName = memberName)
+  member this.subModelSeqUnkeyedBindings (getModels, toMsg, bindings, [<CallerMemberName>] ?memberName: string) =
+    this.subModelSeqUnkeyed (getModels, toMsg, BindingHelpers.createViewModel bindings, BindingHelpers.updateViewModel, ?memberName = memberName)
 
-  member this.subModelSeqKeyedBindings (getModels: 'model -> 'bindingModel seq, getKey, toMsg, bindings, [<CallerMemberName>] ?memberName: string) =
-    this.subModelSeqKeyed (getModels, getKey, toMsg, (fun args -> ViewModel<'bindingModel, 'bindingMsg>(args, bindings)), (fun (vm,m) -> vm.UpdateModel(m)), (fun vm -> vm.CurrentModel), ?memberName = memberName)
+  member this.subModelSeqKeyed (getModels, getKey, toMsg, createViewModel, [<CallerMemberName>] ?memberName: string) =
+    this.subModelSeqKeyed (getModels, getKey, toMsg, createViewModel, BaseHelpers.updateViewModel, BaseHelpers.getUnderlyingModel, ?memberName = memberName)
 
-  member this.subModelWin (getState, toMsg, getWindow, isModal, onCloseRequested, createViewModel: ViewModelArgs<'bindingModel, 'bindingMsg> -> #ViewModelBase<'bindingModel, 'bindingMsg>, [<CallerMemberName>] ?memberName: string) =
-    this.subModelWin (getState, toMsg, getWindow, isModal, onCloseRequested, createViewModel, (fun (vm,m) -> vm.UpdateModel(m)), ?memberName = memberName)
+  member this.subModelSeqKeyedBindings (getModels, getKey, toMsg, bindings, [<CallerMemberName>] ?memberName: string) =
+    this.subModelSeqKeyed (getModels, getKey, toMsg, BindingHelpers.createViewModel bindings, BindingHelpers.updateViewModel, BindingHelpers.getUnderlyingModel, ?memberName = memberName)
+
+  member this.subModelWin (getState, toMsg, getWindow, isModal, onCloseRequested, createViewModel, [<CallerMemberName>] ?memberName: string) =
+    this.subModelWin (getState, toMsg, getWindow, isModal, onCloseRequested, createViewModel, BaseHelpers.updateViewModel, ?memberName = memberName)
     
   member this.subModelWinBindings (getState, toMsg, getWindow, isModal, onCloseRequested, bindings, [<CallerMemberName>] ?memberName: string) =
-    this.subModelWin (getState, toMsg, getWindow, isModal, onCloseRequested, (fun args -> ViewModel<'bindingModel, 'bindingMsg>(args, bindings)), (fun (vm,m) -> vm.UpdateModel(m)), ?memberName = memberName)
+    this.subModelWin (getState, toMsg, getWindow, isModal, onCloseRequested, BindingHelpers.createViewModel bindings, BindingHelpers.updateViewModel, ?memberName = memberName)
 
 module BindingBase =
   module SubModelBase =

--- a/src/Samples/SubModelStatic.Core/Program.fs
+++ b/src/Samples/SubModelStatic.Core/Program.fs
@@ -1,0 +1,179 @@
+module Elmish.WPF.Samples.SubModel.Program
+
+open System
+open Serilog
+open Serilog.Extensions.Logging
+open Elmish
+open Elmish.WPF
+
+module Counter =
+
+  type Model =
+    { Count: int
+      StepSize: int }
+
+  type Msg =
+    | Increment
+    | Decrement
+    | SetStepSize of int
+    | Reset
+
+  let init =
+    { Count = 0
+      StepSize = 1 }
+
+  let canReset = (<>) init
+
+  let update msg m =
+    match msg with
+    | Increment -> { m with Count = m.Count + m.StepSize }
+    | Decrement -> { m with Count = m.Count - m.StepSize }
+    | SetStepSize x -> { m with StepSize = x }
+    | Reset -> init
+
+  let bindings () : Binding<Model, Msg> list = [
+    "CounterValue" |> Binding.oneWay (fun m -> m.Count)
+    "Increment" |> Binding.cmd Increment
+    "Decrement" |> Binding.cmd Decrement
+    "StepSize" |> Binding.twoWay(
+      (fun m -> float m.StepSize),
+      int >> SetStepSize)
+    "Reset" |> Binding.cmdIf(Reset, canReset)
+  ]
+
+
+module Clock =
+
+  type TimeType =
+    | Utc
+    | Local
+
+  type Model =
+    { Time: DateTimeOffset
+      TimeType: TimeType }
+
+  let init () =
+    { Time = DateTimeOffset.Now
+      TimeType = Local }
+
+  let getTime m =
+    match m.TimeType with
+    | Utc -> m.Time.UtcDateTime
+    | Local -> m.Time.LocalDateTime
+
+  type Msg =
+    | Tick of DateTimeOffset
+    | SetTimeType of TimeType
+
+  let update msg m =
+    match msg with
+    | Tick t -> { m with Time = t }
+    | SetTimeType t -> { m with TimeType = t }
+
+  let bindings () : Binding<Model, Msg> list = [
+    "Time" |> Binding.oneWay getTime
+    "IsLocal" |> Binding.oneWay (fun m -> m.TimeType = Local)
+    "SetLocal" |> Binding.cmd (SetTimeType Local)
+    "IsUtc" |> Binding.oneWay (fun m -> m.TimeType = Utc)
+    "SetUtc" |> Binding.cmd (SetTimeType Utc)
+  ]
+
+
+module CounterWithClock =
+
+  type Model =
+    { Counter: Counter.Model
+      Clock: Clock.Model }
+
+  let init () =
+    { Counter = Counter.init
+      Clock = Clock.init () }
+
+  type Msg =
+    | CounterMsg of Counter.Msg
+    | ClockMsg of Clock.Msg
+
+  let update msg m =
+    match msg with
+    | CounterMsg msg -> { m with Counter = Counter.update msg m.Counter }
+    | ClockMsg msg -> { m with Clock = Clock.update msg m.Clock }
+
+  let bindings () : Binding<Model, Msg> list = [
+    "Counter"
+      |> Binding.SubModel.required Counter.bindings
+      |> Binding.mapModel (fun m -> m.Counter)
+      |> Binding.mapMsg CounterMsg
+    "Clock"
+      |> Binding.SubModel.required Clock.bindings
+      |> Binding.mapModel (fun m -> m.Clock)
+      |> Binding.mapMsg ClockMsg
+  ]
+
+
+module App =
+
+  type Model =
+    { ClockCounter1: CounterWithClock.Model
+      ClockCounter2: CounterWithClock.Model }
+
+  let init () =
+    { ClockCounter1 = CounterWithClock.init ()
+      ClockCounter2 = CounterWithClock.init () }
+
+  type Msg =
+    | ClockCounter1Msg of CounterWithClock.Msg
+    | ClockCounter2Msg of CounterWithClock.Msg
+
+  let update msg m =
+    match msg with
+    | ClockCounter1Msg msg ->
+        { m with ClockCounter1 = CounterWithClock.update msg m.ClockCounter1 }
+    | ClockCounter2Msg msg ->
+        { m with ClockCounter2 = CounterWithClock.update msg m.ClockCounter2 }
+
+  let bindings () : Binding<Model, Msg> list = [
+    "ClockCounter1"
+      |> Binding.SubModel.required CounterWithClock.bindings
+      |> Binding.mapModel (fun m -> m.ClockCounter1)
+      |> Binding.mapMsg ClockCounter1Msg
+
+    "ClockCounter2"
+      |> Binding.SubModel.required CounterWithClock.bindings
+      |> Binding.mapModel (fun m -> m.ClockCounter2)
+      |> Binding.mapMsg ClockCounter2Msg
+  ]
+
+
+let counterDesignVm = ViewModel.designInstance Counter.init (Counter.bindings ())
+let clockDesignVm = ViewModel.designInstance (Clock.init ()) (Clock.bindings ())
+let counterWithClockDesignVm = ViewModel.designInstance (CounterWithClock.init ()) (CounterWithClock.bindings ())
+let mainDesignVm = ViewModel.designInstance (App.init ()) (App.bindings ())
+
+
+let timerTick dispatch =
+  let timer = new System.Timers.Timer(1000.)
+  timer.Elapsed.Add (fun _ ->
+    let clockMsg =
+      DateTimeOffset.Now
+      |> Clock.Tick
+      |> CounterWithClock.ClockMsg
+    dispatch <| App.ClockCounter1Msg clockMsg
+    dispatch <| App.ClockCounter2Msg clockMsg
+  )
+  timer.Start()
+
+
+let main window =
+
+  let logger =
+    LoggerConfiguration()
+      .MinimumLevel.Override("Elmish.WPF.Update", Events.LogEventLevel.Verbose)
+      .MinimumLevel.Override("Elmish.WPF.Bindings", Events.LogEventLevel.Verbose)
+      .MinimumLevel.Override("Elmish.WPF.Performance", Events.LogEventLevel.Verbose)
+      .WriteTo.Console()
+      .CreateLogger()
+
+  WpfProgram.mkSimple App.init App.update App.bindings
+  |> WpfProgram.withSubscription (fun _ -> Cmd.ofSub timerTick)
+  |> WpfProgram.withLogger (new SerilogLoggerFactory(logger))
+  |> WpfProgram.startElmishLoop window

--- a/src/Samples/SubModelStatic.Core/Program.fs
+++ b/src/Samples/SubModelStatic.Core/Program.fs
@@ -40,9 +40,9 @@ type [<AllowNullLiteral>] CounterViewModel (args) as this =
     with get() = this.getValue (fun m -> m.StepSize)
     and set(v) = this.setValue (fun _m -> Counter.Msg.SetStepSize v)
   member _.CounterValue = this.getValue (fun m -> m.Count)
-  member _.Increment = this.cmd((fun _ _ -> Counter.Increment |> ValueSome), (fun _ _ -> true))
-  member _.Decrement = this.cmd((fun _ _ -> Counter.Decrement |> ValueSome), (fun _ _ -> true))
-  member _.Reset = this.cmd((fun _ _ -> Counter.Reset |> ValueSome), (fun _ -> Counter.canReset))
+  member _.Increment = this.cmd((fun _ _ -> Counter.Increment |> ValueSome), (fun _ _ -> true), false)
+  member _.Decrement = this.cmd((fun _ _ -> Counter.Decrement |> ValueSome), (fun _ _ -> true), false)
+  member _.Reset = this.cmd((fun _ _ -> Counter.Reset |> ValueSome), (fun _ -> Counter.canReset), false)
 
 
 module Clock =
@@ -80,9 +80,9 @@ type [<AllowNullLiteral>] ClockViewModel (args) as this =
 
   member _.Time = this.getValue Clock.getTime
   member _.IsLocal = this.getValue (fun m -> m.TimeType = Clock.Local)
-  member _.SetLocal = this.cmd ((fun _ _ -> Clock.SetTimeType Clock.Local |> ValueSome), (fun _ _ -> true))
+  member _.SetLocal = this.cmd ((fun _ _ -> Clock.SetTimeType Clock.Local |> ValueSome), (fun _ _ -> true), false)
   member _.IsUtc = this.getValue (fun m -> m.TimeType = Clock.Utc)
-  member _.SetUtc = this.cmd ((fun _ _ -> Clock.SetTimeType Clock.Utc |> ValueSome), (fun _ _ -> true))
+  member _.SetUtc = this.cmd ((fun _ _ -> Clock.SetTimeType Clock.Utc |> ValueSome), (fun _ _ -> true), false)
 
 module CounterWithClock =
 
@@ -145,8 +145,8 @@ type [<AllowNullLiteral>] AppViewModel (args) as this =
   new() = AppViewModel(App2.init () |> ViewModelArgs.simple)
 
   member _.ClockCounters = this.subModelSeqKeyed ((fun m -> m.ClockCounters), (fun m -> m.Id), (fun _ msg -> App2.ClockCountersMsg msg), CounterWithClockViewModel)
-  member _.AddClockCounter = this.cmd ((fun _ _ -> App2.AddClockCounter |> ValueSome), (fun _ _ -> true))
-  member _.RemoveClockCounter = this.cmd ((fun p _ -> p |> unbox |> App2.RemoveClockCounter |> ValueSome), (fun bi _ -> bi <> null))
+  member _.AddClockCounter = this.cmd ((fun _ _ -> App2.AddClockCounter |> ValueSome), (fun _ _ -> true), true)
+  member _.RemoveClockCounter = this.cmd ((fun p _ -> p |> unbox |> App2.RemoveClockCounter |> ValueSome), (fun bi _ -> bi <> null), true)
 
 module Program =
 

--- a/src/Samples/SubModelStatic.Core/Program.fs
+++ b/src/Samples/SubModelStatic.Core/Program.fs
@@ -1,4 +1,4 @@
-module Elmish.WPF.Samples.SubModel.Program
+namespace Elmish.WPF.Samples.SubModelStatic
 
 open System
 open Serilog
@@ -31,15 +31,18 @@ module Counter =
     | SetStepSize x -> { m with StepSize = x }
     | Reset -> init
 
-  let bindings () : Binding<Model, Msg> list = [
-    "CounterValue" |> Binding.oneWay (fun m -> m.Count)
-    "Increment" |> Binding.cmd Increment
-    "Decrement" |> Binding.cmd Decrement
-    "StepSize" |> Binding.twoWay(
-      (fun m -> float m.StepSize),
-      int >> SetStepSize)
-    "Reset" |> Binding.cmdIf(Reset, canReset)
-  ]
+type [<AllowNullLiteral>] CounterViewModel (args) as this =
+  inherit ViewModelBase<Counter.Model,Counter.Msg>(args, fun () -> box this)
+
+  new() = CounterViewModel(Counter.init |> ViewModelArgs.simple)
+
+  member _.StepSize
+    with get() = this.getValue (fun m -> m.StepSize)
+    and set(v) = this.setValue (fun _m -> Counter.Msg.SetStepSize v)
+  member _.CounterValue = this.getValue (fun m -> m.Count)
+  member _.Increment = this.cmd((fun _ _ -> Counter.Increment |> ValueSome), (fun _ _ -> true))
+  member _.Decrement = this.cmd((fun _ _ -> Counter.Decrement |> ValueSome), (fun _ _ -> true))
+  member _.Reset = this.cmd((fun _ _ -> Counter.Reset |> ValueSome), (fun _ -> Counter.canReset))
 
 
 module Clock =
@@ -70,14 +73,16 @@ module Clock =
     | Tick t -> { m with Time = t }
     | SetTimeType t -> { m with TimeType = t }
 
-  let bindings () : Binding<Model, Msg> list = [
-    "Time" |> Binding.oneWay getTime
-    "IsLocal" |> Binding.oneWay (fun m -> m.TimeType = Local)
-    "SetLocal" |> Binding.cmd (SetTimeType Local)
-    "IsUtc" |> Binding.oneWay (fun m -> m.TimeType = Utc)
-    "SetUtc" |> Binding.cmd (SetTimeType Utc)
-  ]
+type [<AllowNullLiteral>] ClockViewModel (args) as this =
+  inherit ViewModelBase<Clock.Model,Clock.Msg>(args, fun () -> box this)
+  
+  new() = ClockViewModel(Clock.init () |> ViewModelArgs.simple)
 
+  member _.Time = this.getValue Clock.getTime
+  member _.IsLocal = this.getValue (fun m -> m.TimeType = Clock.Local)
+  member _.SetLocal = this.cmd ((fun _ _ -> Clock.SetTimeType Clock.Local |> ValueSome), (fun _ _ -> true))
+  member _.IsUtc = this.getValue (fun m -> m.TimeType = Clock.Utc)
+  member _.SetUtc = this.cmd ((fun _ _ -> Clock.SetTimeType Clock.Utc |> ValueSome), (fun _ _ -> true))
 
 module CounterWithClock =
 
@@ -98,19 +103,15 @@ module CounterWithClock =
     | CounterMsg msg -> { m with Counter = Counter.update msg m.Counter }
     | ClockMsg msg -> { m with Clock = Clock.update msg m.Clock }
 
-  let bindings () : Binding<Model, Msg> list = [
-    "Counter"
-      |> Binding.SubModel.required Counter.bindings
-      |> Binding.mapModel (fun m -> m.Counter)
-      |> Binding.mapMsg CounterMsg
-    "Clock"
-      |> Binding.SubModel.required Clock.bindings
-      |> Binding.mapModel (fun m -> m.Clock)
-      |> Binding.mapMsg ClockMsg
-  ]
+type [<AllowNullLiteral>] CounterWithClockViewModel (args) as this =
+  inherit ViewModelBase<CounterWithClock.Model,CounterWithClock.Msg>(args, fun () -> box this)
+  
+  new() = CounterWithClockViewModel(CounterWithClock.init () |> ViewModelArgs.simple)
 
+  member _.Counter = this.subModel ((fun m -> m.Counter |> ValueSome), (fun _ msg -> CounterWithClock.CounterMsg msg), CounterViewModel)
+  member _.Clock = this.subModel ((fun m -> m.Clock |> ValueSome), (fun _ msg -> CounterWithClock.ClockMsg msg), ClockViewModel)
 
-module App =
+module App2 =
 
   type Model =
     { ClockCounter1: CounterWithClock.Model
@@ -131,49 +132,40 @@ module App =
     | ClockCounter2Msg msg ->
         { m with ClockCounter2 = CounterWithClock.update msg m.ClockCounter2 }
 
-  let bindings () : Binding<Model, Msg> list = [
-    "ClockCounter1"
-      |> Binding.SubModel.required CounterWithClock.bindings
-      |> Binding.mapModel (fun m -> m.ClockCounter1)
-      |> Binding.mapMsg ClockCounter1Msg
+type [<AllowNullLiteral>] AppViewModel (args) as this =
+  inherit ViewModelBase<App2.Model,App2.Msg>(args, fun () -> box this)
+  
+  new() = AppViewModel(App2.init () |> ViewModelArgs.simple)
 
-    "ClockCounter2"
-      |> Binding.SubModel.required CounterWithClock.bindings
-      |> Binding.mapModel (fun m -> m.ClockCounter2)
-      |> Binding.mapMsg ClockCounter2Msg
-  ]
+  member _.ClockCounter1 = this.subModel ((fun m -> m.ClockCounter1 |> ValueSome), (fun _ msg -> App2.ClockCounter1Msg msg), CounterWithClockViewModel)
+  member _.ClockCounter2 = this.subModel ((fun m -> m.ClockCounter2 |> ValueSome), (fun _ msg -> App2.ClockCounter2Msg msg), CounterWithClockViewModel)
 
+module Program =
 
-let counterDesignVm = ViewModel.designInstance Counter.init (Counter.bindings ())
-let clockDesignVm = ViewModel.designInstance (Clock.init ()) (Clock.bindings ())
-let counterWithClockDesignVm = ViewModel.designInstance (CounterWithClock.init ()) (CounterWithClock.bindings ())
-let mainDesignVm = ViewModel.designInstance (App.init ()) (App.bindings ())
-
-
-let timerTick dispatch =
-  let timer = new System.Timers.Timer(1000.)
-  timer.Elapsed.Add (fun _ ->
-    let clockMsg =
-      DateTimeOffset.Now
-      |> Clock.Tick
-      |> CounterWithClock.ClockMsg
-    dispatch <| App.ClockCounter1Msg clockMsg
-    dispatch <| App.ClockCounter2Msg clockMsg
-  )
-  timer.Start()
+  let timerTick dispatch =
+    let timer = new System.Timers.Timer(1000.)
+    timer.Elapsed.Add (fun _ ->
+      let clockMsg =
+        DateTimeOffset.Now
+        |> Clock.Tick
+        |> CounterWithClock.ClockMsg
+      dispatch <| App2.ClockCounter1Msg clockMsg
+      dispatch <| App2.ClockCounter2Msg clockMsg
+    )
+    timer.Start()
 
 
-let main window =
+  let main window =
 
-  let logger =
-    LoggerConfiguration()
-      .MinimumLevel.Override("Elmish.WPF.Update", Events.LogEventLevel.Verbose)
-      .MinimumLevel.Override("Elmish.WPF.Bindings", Events.LogEventLevel.Verbose)
-      .MinimumLevel.Override("Elmish.WPF.Performance", Events.LogEventLevel.Verbose)
-      .WriteTo.Console()
-      .CreateLogger()
+    let logger =
+      LoggerConfiguration()
+        .MinimumLevel.Override("Elmish.WPF.Update", Events.LogEventLevel.Verbose)
+        .MinimumLevel.Override("Elmish.WPF.Bindings", Events.LogEventLevel.Verbose)
+        .MinimumLevel.Override("Elmish.WPF.Performance", Events.LogEventLevel.Verbose)
+        .WriteTo.Console()
+        .CreateLogger()
 
-  WpfProgram.mkSimple App.init App.update App.bindings
-  |> WpfProgram.withSubscription (fun _ -> Cmd.ofSub timerTick)
-  |> WpfProgram.withLogger (new SerilogLoggerFactory(logger))
-  |> WpfProgram.startElmishLoop window
+    WpfProgram.mkSimpleBase App2.init App2.update AppViewModel
+    |> WpfProgram.withSubscription (fun _ -> Cmd.ofSub timerTick)
+    |> WpfProgram.withLogger (new SerilogLoggerFactory(logger))
+    |> WpfProgram.startElmishLoop window

--- a/src/Samples/SubModelStatic.Core/SubModelStatic.Core.fsproj
+++ b/src/Samples/SubModelStatic.Core/SubModelStatic.Core.fsproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net5.0-windows</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Elmish.WPF\Elmish.WPF.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Samples/SubModelStatic/App.xaml
+++ b/src/Samples/SubModelStatic/App.xaml
@@ -1,0 +1,7 @@
+﻿<Application x:Class="Elmish.WPF.Samples.SubModelStatic.App"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        StartupUri="MainWindow.xaml">
+  <Application.Resources>
+  </Application.Resources>
+</Application>

--- a/src/Samples/SubModelStatic/App.xaml.cs
+++ b/src/Samples/SubModelStatic/App.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Windows;
+
+namespace Elmish.WPF.Samples.SubModelStatic
+{
+  public partial class App : Application
+  {
+    public App()
+    {
+      this.Activated += StartElmish;
+    }
+
+    private void StartElmish(object sender, EventArgs e)
+    {
+      this.Activated -= StartElmish;
+      Program.main(MainWindow);
+    }
+
+  }
+}

--- a/src/Samples/SubModelStatic/Clock.xaml
+++ b/src/Samples/SubModelStatic/Clock.xaml
@@ -5,7 +5,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelStatic;assembly=SubModelStatic.Core"
              mc:Ignorable="d"
-             d:DataContext="{x:Static vm:Program.clockDesignVm}">
+             d:DataContext="{d:DesignInstance Type=vm:ClockViewModel, IsDesignTimeCreatable=True}">
   <StackPanel Orientation="Horizontal">
     <TextBlock Text="{Binding Time, StringFormat='Today is {0:MMMM dd, yyyy}. The time is {0:HH:mm:ssK}. It is {0:dddd}.'}" />
     <RadioButton Command="{Binding SetLocal}" IsChecked="{Binding IsLocal, Mode=OneWay}" Content="Local" Margin="10,0,0,0"/>

--- a/src/Samples/SubModelStatic/Clock.xaml
+++ b/src/Samples/SubModelStatic/Clock.xaml
@@ -1,0 +1,14 @@
+﻿<UserControl x:Class="Elmish.WPF.Samples.SubModelStatic.Clock"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelStatic;assembly=SubModelStatic.Core"
+             mc:Ignorable="d"
+             d:DataContext="{x:Static vm:Program.clockDesignVm}">
+  <StackPanel Orientation="Horizontal">
+    <TextBlock Text="{Binding Time, StringFormat='Today is {0:MMMM dd, yyyy}. The time is {0:HH:mm:ssK}. It is {0:dddd}.'}" />
+    <RadioButton Command="{Binding SetLocal}" IsChecked="{Binding IsLocal, Mode=OneWay}" Content="Local" Margin="10,0,0,0"/>
+    <RadioButton Command="{Binding SetUtc}" IsChecked="{Binding IsUtc, Mode=OneWay}" Content="Utc" Margin="10,0,0,0"/>
+  </StackPanel>
+</UserControl>

--- a/src/Samples/SubModelStatic/Clock.xaml.cs
+++ b/src/Samples/SubModelStatic/Clock.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Controls;
+
+namespace Elmish.WPF.Samples.SubModelStatic
+{
+    public partial class Clock : UserControl
+    {
+        public Clock()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Samples/SubModelStatic/Counter.xaml
+++ b/src/Samples/SubModelStatic/Counter.xaml
@@ -1,11 +1,11 @@
-﻿<UserControl x:Class="Elmish.WPF.Samples.SubModel.Counter"
+﻿<UserControl x:Class="Elmish.WPF.Samples.SubModelStatic.Counter"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModel;assembly=SubModel.Core"
+             xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelStatic;assembly=SubModelStatic.Core"
              mc:Ignorable="d"
-             d:DataContext="{x:Static vm:Program.counterDesignVm}">
+             d:DataContext="{d:DesignInstance Type=vm:CounterViewModel, IsDesignTimeCreatable=True}">
   <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top">
     <TextBlock Text="{Binding CounterValue, StringFormat='Counter value: {0}'}" Width="110" Margin="0,5,10,5" />
     <Button Command="{Binding Decrement}" Content="-" Margin="0,5,10,5" Width="30" />

--- a/src/Samples/SubModelStatic/Counter.xaml
+++ b/src/Samples/SubModelStatic/Counter.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl x:Class="Elmish.WPF.Samples.SubModel.Counter"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModel;assembly=SubModel.Core"
+             mc:Ignorable="d"
+             d:DataContext="{x:Static vm:Program.counterDesignVm}">
+  <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top">
+    <TextBlock Text="{Binding CounterValue, StringFormat='Counter value: {0}'}" Width="110" Margin="0,5,10,5" />
+    <Button Command="{Binding Decrement}" Content="-" Margin="0,5,10,5" Width="30" />
+    <Button Command="{Binding Increment}" Content="+" Margin="0,5,10,5" Width="30" />
+    <TextBlock Text="{Binding StepSize, StringFormat='Step size: {0}'}" Width="70" Margin="0,5,10,5" />
+    <Slider Value="{Binding StepSize}" TickFrequency="1" Maximum="10" Minimum="1" IsSnapToTickEnabled="True" Width="100" Margin="0,5,10,5" />
+    <Button Command="{Binding Reset}" Content="Reset" Margin="0,5,10,5" Width="50" />
+  </StackPanel>
+</UserControl>

--- a/src/Samples/SubModelStatic/Counter.xaml.cs
+++ b/src/Samples/SubModelStatic/Counter.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Controls;
+
+namespace Elmish.WPF.Samples.SubModelStatic
+{
+    public partial class Counter : UserControl
+    {
+        public Counter()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Samples/SubModelStatic/CounterWithClock.xaml
+++ b/src/Samples/SubModelStatic/CounterWithClock.xaml
@@ -6,7 +6,7 @@
              xmlns:local="clr-namespace:Elmish.WPF.Samples.SubModelStatic"
              xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelStatic;assembly=SubModelStatic.Core"
              mc:Ignorable="d"
-             d:DataContext="{x:Static vm:Program.counterWithClockDesignVm}">
+             d:DataContext="{d:DesignInstance Type=vm:CounterWithClockViewModel, IsDesignTimeCreatable=True}">
   <StackPanel>
     <local:Counter DataContext="{Binding Counter}" d:DataContext="{Binding DataContext.Counter, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />
     <local:Clock DataContext="{Binding Clock}" d:DataContext="{Binding DataContext.Clock, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />

--- a/src/Samples/SubModelStatic/CounterWithClock.xaml
+++ b/src/Samples/SubModelStatic/CounterWithClock.xaml
@@ -1,0 +1,14 @@
+﻿<UserControl x:Class="Elmish.WPF.Samples.SubModelStatic.CounterWithClock"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:local="clr-namespace:Elmish.WPF.Samples.SubModelStatic"
+             xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelStatic;assembly=SubModelStatic.Core"
+             mc:Ignorable="d"
+             d:DataContext="{x:Static vm:Program.counterWithClockDesignVm}">
+  <StackPanel>
+    <local:Counter DataContext="{Binding Counter}" d:DataContext="{Binding DataContext.Counter, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />
+    <local:Clock DataContext="{Binding Clock}" d:DataContext="{Binding DataContext.Clock, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />
+  </StackPanel>
+</UserControl>

--- a/src/Samples/SubModelStatic/CounterWithClock.xaml.cs
+++ b/src/Samples/SubModelStatic/CounterWithClock.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Controls;
+
+namespace Elmish.WPF.Samples.SubModelStatic
+{
+    public partial class CounterWithClock : UserControl
+    {
+        public CounterWithClock()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Samples/SubModelStatic/MainWindow.xaml
+++ b/src/Samples/SubModelStatic/MainWindow.xaml
@@ -13,8 +13,8 @@
         d:DataContext="{d:DesignInstance Type=vm:AppViewModel, IsDesignTimeCreatable=True}">
   <StackPanel>
     <Button Command="{Binding AddClockCounter}">Add Clock Counter</Button>
-    <Button Command="{Binding RemoveClockCounter}" CommandParameter="{Binding ElementName=ListBox, Path=SelectedItem.Id}">Remove Selected Clock Counter</Button>
-    <ListBox x:Name="ListBox" ItemsSource="{Binding ClockCounters}">
+    <Button Command="{Binding RemoveClockCounter}" CommandParameter="{Binding SelectedClockCounter.Id}">Remove Selected Clock Counter</Button>
+    <ListBox x:Name="ListBox" ItemsSource="{Binding ClockCounters}" SelectedItem="{Binding SelectedClockCounter}">
       <ListBox.ItemTemplate>
         <DataTemplate DataType="{x:Type vm:CounterWithClockViewModel}">
           <StackPanel>

--- a/src/Samples/SubModelStatic/MainWindow.xaml
+++ b/src/Samples/SubModelStatic/MainWindow.xaml
@@ -13,7 +13,7 @@
         d:DataContext="{d:DesignInstance Type=vm:AppViewModel, IsDesignTimeCreatable=True}">
   <StackPanel>
     <Button Command="{Binding AddClockCounter}">Add Clock Counter</Button>
-    <Button Command="{Binding RemoveClockCounter}" CommandParameter="{Binding ElementName=ListBox, Path=SelectedIndex}">Remove Selected Clock Counter</Button>
+    <Button Command="{Binding RemoveClockCounter}" CommandParameter="{Binding ElementName=ListBox, Path=SelectedItem.Id}">Remove Selected Clock Counter</Button>
     <ListBox x:Name="ListBox" ItemsSource="{Binding ClockCounters}">
       <ListBox.ItemTemplate>
         <DataTemplate DataType="{x:Type vm:CounterWithClockViewModel}">

--- a/src/Samples/SubModelStatic/MainWindow.xaml
+++ b/src/Samples/SubModelStatic/MainWindow.xaml
@@ -6,15 +6,26 @@
         xmlns:local="clr-namespace:Elmish.WPF.Samples.SubModelStatic"
         xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelStatic;assembly=SubModelStatic.Core"
         Title="Sub-model"
-        Height="270"
+        Height="470"
         Width="500"
         WindowStartupLocation="CenterScreen"
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance Type=vm:AppViewModel, IsDesignTimeCreatable=True}">
   <StackPanel>
-    <TextBlock Text="Counter with clock 1" FontSize="18" FontWeight="Bold" Margin="0,25,0,0" HorizontalAlignment="Center" />
-    <local:CounterWithClock DataContext="{Binding ClockCounter1}" d:DataContext="{Binding DataContext.ClockCounter1, RelativeSource={RelativeSource AncestorType=StackPanel}}"/>
-    <TextBlock Text="Counter with clock 2" FontSize="18" FontWeight="Bold" Margin="0,25,0,0" HorizontalAlignment="Center" />
-    <local:CounterWithClock DataContext="{Binding ClockCounter2}" d:DataContext="{Binding DataContext.ClockCounter2, RelativeSource={RelativeSource AncestorType=StackPanel}}"/>
+    <Button Command="{Binding AddClockCounter}">Add Clock Counter</Button>
+    <Button Command="{Binding RemoveClockCounter}" CommandParameter="{Binding ElementName=ListBox, Path=SelectedIndex}">Remove Selected Clock Counter</Button>
+    <ListBox x:Name="ListBox" ItemsSource="{Binding ClockCounters}">
+      <ListBox.ItemTemplate>
+        <DataTemplate DataType="{x:Type vm:CounterWithClockViewModel}">
+          <StackPanel>
+            <TextBlock FontSize="18" FontWeight="Bold" Margin="0,25,0,0" HorizontalAlignment="Center">
+              <Run Text="Counter with clock"/>
+              <Run Text="{Binding Id, Mode=OneWay}"/>
+            </TextBlock>
+            <local:CounterWithClock DataContext="{Binding}"/>
+          </StackPanel>
+        </DataTemplate>
+      </ListBox.ItemTemplate>
+    </ListBox>
   </StackPanel>
 </Window>

--- a/src/Samples/SubModelStatic/MainWindow.xaml
+++ b/src/Samples/SubModelStatic/MainWindow.xaml
@@ -10,7 +10,7 @@
         Width="500"
         WindowStartupLocation="CenterScreen"
         mc:Ignorable="d"
-        d:DataContext="{x:Static vm:Program.mainDesignVm}">
+        d:DataContext="{d:DesignInstance Type=vm:AppViewModel, IsDesignTimeCreatable=True}">
   <StackPanel>
     <TextBlock Text="Counter with clock 1" FontSize="18" FontWeight="Bold" Margin="0,25,0,0" HorizontalAlignment="Center" />
     <local:CounterWithClock DataContext="{Binding ClockCounter1}" d:DataContext="{Binding DataContext.ClockCounter1, RelativeSource={RelativeSource AncestorType=StackPanel}}"/>

--- a/src/Samples/SubModelStatic/MainWindow.xaml
+++ b/src/Samples/SubModelStatic/MainWindow.xaml
@@ -1,0 +1,20 @@
+﻿<Window x:Class="Elmish.WPF.Samples.SubModelStatic.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Elmish.WPF.Samples.SubModelStatic"
+        xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelStatic;assembly=SubModelStatic.Core"
+        Title="Sub-model"
+        Height="270"
+        Width="500"
+        WindowStartupLocation="CenterScreen"
+        mc:Ignorable="d"
+        d:DataContext="{x:Static vm:Program.mainDesignVm}">
+  <StackPanel>
+    <TextBlock Text="Counter with clock 1" FontSize="18" FontWeight="Bold" Margin="0,25,0,0" HorizontalAlignment="Center" />
+    <local:CounterWithClock DataContext="{Binding ClockCounter1}" d:DataContext="{Binding DataContext.ClockCounter1, RelativeSource={RelativeSource AncestorType=StackPanel}}"/>
+    <TextBlock Text="Counter with clock 2" FontSize="18" FontWeight="Bold" Margin="0,25,0,0" HorizontalAlignment="Center" />
+    <local:CounterWithClock DataContext="{Binding ClockCounter2}" d:DataContext="{Binding DataContext.ClockCounter2, RelativeSource={RelativeSource AncestorType=StackPanel}}"/>
+  </StackPanel>
+</Window>

--- a/src/Samples/SubModelStatic/MainWindow.xaml.cs
+++ b/src/Samples/SubModelStatic/MainWindow.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows;
+
+namespace Elmish.WPF.Samples.SubModelStatic
+{
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Samples/SubModelStatic/SubModelStatic.csproj
+++ b/src/Samples/SubModelStatic/SubModelStatic.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0-windows</TargetFramework>
+    <UseWpf>true</UseWpf>
+    <OutputType>Exe</OutputType>
+    <DisableWinExeOutputInference>true</DisableWinExeOutputInference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SubModelStatic.Core\SubModelStatic.Core.fsproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
# Add support for static view models
Adds a binding base class that can be derived and used to implement view models that work in the Elmish.WPF loop. Getters and Setters can be used directly for primitives, while Collections and SubModels must use helpers with factories to get the update function to pass through.
## ViewModelBase
Add ViewModelBase with the following helpers
- [x] `getValue`
- [x] `setValue`
- [x] `cmd`
- [x] `subModel`
- [x] `subModelSeqUnkeyed`
- [x] `subModelSeqKeyed`
- [x] `subModelWin`
- [x] `subModelSelectedItem`
- [ ] `validation`
- [ ] `alterMsgStream`
- [ ] `lazy`
## BindingBase / ViewModelBase Bindings
Add BindingBase to allow string bindings to include static view models and vice versa
* BindingBase
  * `SubModelBase.required`/`vopt`/`opt`
  * `SubModelSeqUnkeyedBase.required`
  * `SubModelSeqKeyedBase.required`
* ViewModelBase Bindings
  * `subModelBindings`
  * `subModelSeqUnkeyedBindings`
  * `subModelSeqKeyedBindings`
## WpfProgram
Add top-level WpfProgram functions that accept static view models that derive from ViewModelBase
* `WpfProgram.mkSimpleBase`
* `WpfProgram.mkProgramBase`
## SubModelStatic
Add a SubModelStatic example project that extends the SubModel example project
* Uses all static view models
* Extends SubModel to use a list of models to illustrate seq keyed