### PR TITLE
Add CollectionTarget so that SubModelSeq's can be properly typed

### DIFF
--- a/src/Elmish.WPF.Tests/BindingTests.fs
+++ b/src/Elmish.WPF.Tests/BindingTests.fs
@@ -3053,7 +3053,7 @@ module sorting =
         let! s = GenX.auto<string>
         let data =
           [ SubModelSelectedItemData { Get = fail; Set = fail2; SubModelSeqBindingName = s }
-            SubModelSeqKeyedData { GetSubModels = fail; GetId = fail; CreateViewModel = fail; UpdateViewModel = fail; GetUnderlyingModel = fail; ToMsg = fail }
+            SubModelSeqKeyedData { GetSubModels = fail; GetId = fail; CreateViewModel = fail; CreateCollection = fail; UpdateViewModel = fail; GetUnderlyingModel = fail; ToMsg = fail }
             SubModelSelectedItemData { Get = fail; Set = fail2; SubModelSeqBindingName = s }
           ] |> List.map BaseBindingData
         let sorted = data |> List.sortWith (SubModelSelectedItemLast().CompareBindingDatas())

--- a/src/Elmish.WPF.Tests/MergeTests.fs
+++ b/src/Elmish.WPF.Tests/MergeTests.fs
@@ -14,7 +14,7 @@ open Elmish.WPF
 let getIdAsId = id
 let createAsId a _ = a
 let updateNoOp _ _ _ = ()
-let merge x = x |> Merge.keyed
+let internal merge x = x |> Merge.keyed
 
 
 let private trackCC (observableCollection: ObservableCollection<_>) =
@@ -37,7 +37,7 @@ let ``starting from empty, when items merged, should contain those items and cal
     let createTracker = InvokeTester2 createAsId
     let updateTracker = InvokeTester3 updateNoOp
 
-    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn observableCollection array
+    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn (observableCollection |> CollectionTarget.create) array
 
     testObservableCollectionContainsDataInArray observableCollection array
     test <@ createTracker.Count = array.Length @>
@@ -54,7 +54,7 @@ let ``starting with random items, when merging the same items, should still cont
     let updateTracker = InvokeTester3 updateNoOp
     let ccEvents = trackCC observableCollection
 
-    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn observableCollection array
+    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn (observableCollection |> CollectionTarget.create) array
 
     testObservableCollectionContainsDataInArray observableCollection array
     test <@ createTracker.Count = 0 @>
@@ -71,7 +71,7 @@ let ``starting with random items, when merging random items, should contain the 
 
     let observableCollection = ObservableCollection<_> array1
 
-    merge getIdAsId getIdAsId createAsId updateNoOp observableCollection array2
+    merge getIdAsId getIdAsId createAsId updateNoOp (observableCollection |> CollectionTarget.create) array2
 
     testObservableCollectionContainsDataInArray observableCollection array2
   }
@@ -88,7 +88,7 @@ let ``starting with random items, when merging after an addition, should contain
     let createTracker = InvokeTester2 createAsId
     let updateTracker = InvokeTester3 updateNoOp
 
-    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn observableCollection array2
+    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn (observableCollection |> CollectionTarget.create) array2
 
     testObservableCollectionContainsDataInArray observableCollection array2
     test <@ createTracker.Count = 1 @>
@@ -107,7 +107,7 @@ let ``starting with random items, when merging after a removal, should contain t
     let createTracker = InvokeTester2 createAsId
     let updateTracker = InvokeTester3 updateNoOp
 
-    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn observableCollection array2
+    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn (observableCollection |> CollectionTarget.create) array2
 
     testObservableCollectionContainsDataInArray observableCollection array2
     test <@ createTracker.Count = 0 @>
@@ -130,7 +130,7 @@ let ``starting with random items, when merging after a move, should contain the 
     let createTracker = InvokeTester2 createAsId
     let updateTracker = InvokeTester3 updateNoOp
 
-    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn observableCollection array2
+    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn (observableCollection |> CollectionTarget.create) array2
 
     testObservableCollectionContainsDataInArray observableCollection array2
     test <@ createTracker.Count = 0 @>
@@ -154,7 +154,7 @@ let ``starting with random items, when merging after a replacement, should conta
     let createTracker = InvokeTester2 createAsId
     let updateTracker = InvokeTester3 updateNoOp
 
-    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn observableCollection array2
+    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn (observableCollection |> CollectionTarget.create) array2
 
     testObservableCollectionContainsDataInArray observableCollection array2
     test <@ createTracker.Count = 1 @>
@@ -175,7 +175,7 @@ let ``starting with random items, when merging after swapping two adjacent items
     let createTracker = InvokeTester2 createAsId
     let updateTracker = InvokeTester3 updateNoOp
 
-    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn observableCollection array2
+    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn (observableCollection |> CollectionTarget.create) array2
 
     testObservableCollectionContainsDataInArray observableCollection array2
     test <@ createTracker.Count = 0 @>
@@ -197,7 +197,7 @@ let ``starting with random items, when merging after swapping two items, should 
     let createTracker = InvokeTester2 createAsId
     let updateTracker = InvokeTester3 updateNoOp
 
-    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn observableCollection array2
+    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn (observableCollection |> CollectionTarget.create) array2
 
     testObservableCollectionContainsDataInArray observableCollection array2
     test <@ createTracker.Count = 0 @>
@@ -215,7 +215,7 @@ let ``starting with random items, when merging after shuffling, should contain t
     let createTracker = InvokeTester2 createAsId
     let updateTracker = InvokeTester3 updateNoOp
 
-    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn observableCollection array2
+    merge getIdAsId getIdAsId createTracker.Fn updateTracker.Fn (observableCollection |> CollectionTarget.create) array2
 
     testObservableCollectionContainsDataInArray observableCollection array2
     test <@ createTracker.Count = 0 @>
@@ -247,7 +247,7 @@ let ``starting with two TestClass instances, when merging after removing the las
     let ccEvents = trackCC observableCollection
     let getId (tc: TestClass) = tc.Id
 
-    merge getId getId createAsId updateNoOp observableCollection array2
+    merge getId getId createAsId updateNoOp (observableCollection |> CollectionTarget.create) array2
 
     test <@ ((ccEvents
       |> Seq.filter (fun e -> e.Action = NotifyCollectionChangedAction.Remove)
@@ -275,7 +275,7 @@ let ``starting with two TestClass instances, when merging after updating the las
     let update target _ _ =
       mTarget <- Some target
 
-    merge getId getId createAsId update observableCollection array2
+    merge getId getId createAsId update (observableCollection |> CollectionTarget.create) array2
 
     let actual = mTarget
     test <@ actual.Value.Id = tc2.Id @>

--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -1220,7 +1220,7 @@ module SubModelSeq =
     let actual =
       vm.Get name
       |> unbox<ObservableCollection<ViewModel<Guid,obj>>>
-      |> Seq.map (fun vm -> vm |> (fun vm -> vm.CurrentModel))
+      |> Seq.map (fun vm -> vm.CurrentModel)
       |> Seq.toList
     test <@ expected = actual @>
 
@@ -1301,7 +1301,7 @@ module SubModelSeq =
       let actual =
         vm.Get name
         |> unbox<ObservableCollection<ViewModel<Guid,obj>>>
-        |> Seq.map (fun vm -> vm |> (fun vm -> vm.Get subName) |> unbox<string>)
+        |> Seq.map (fun vm -> vm.Get subName |> unbox<string>)
         |> Seq.toList
 
       let expected = getModels m |> Seq.map subGet |> Seq.toList
@@ -1329,7 +1329,7 @@ module SubModelSeq =
 
       vm.Get name
       |> unbox<ObservableCollection<ViewModel<Guid,string>>>
-      |> Seq.iter (fun vm -> vm |> (fun vm -> vm.Set subName p))
+      |> Seq.iter (fun vm -> vm.Set subName p)
 
       let expected = m |> getModels |> List.map (fun m -> (getId m, subSet p m) |> toMsg)
       test <@ expected = vm.Dispatches @>
@@ -1401,7 +1401,7 @@ module SubModelSelectedItem =
         selectedSubModel |> ValueOption.bind (fun sm ->
           vm.Get subModelSeqName
           |> unbox<ObservableCollection<ViewModel<Guid,int voption>>>
-          |> Seq.tryFind (fun vm -> vm |> (fun vm -> vm.CurrentModel) |> getId = getId sm)
+          |> Seq.tryFind (fun vm -> vm.CurrentModel |> getId = getId sm)
           |> ValueOption.ofOption
         )
         |> ValueOption.toObj

--- a/src/Elmish.WPF/BindingInternal.fs
+++ b/src/Elmish.WPF/BindingInternal.fs
@@ -28,7 +28,7 @@ type internal OneWaySeqLazyData<'model, 'a, 'b, 'id when 'id : equality> =
       let create v _ = v
       let update oldVal newVal oldIdx =
         if not (d.ItemEquals newVal oldVal) then
-          values.ReplaceAt (oldIdx, newVal)
+          values.SetAt (oldIdx, newVal)
       let newVals = intermediate |> d.Map |> Seq.toArray
       Merge.keyed d.GetId d.GetId create update values newVals
 

--- a/src/Elmish.WPF/BindingInternal.fs
+++ b/src/Elmish.WPF/BindingInternal.fs
@@ -17,17 +17,18 @@ type internal OneWayToSourceData<'model, 'msg> =
 type internal OneWaySeqLazyData<'model, 'a, 'b, 'id when 'id : equality> =
   { Get: 'model -> 'a
     Map: 'a -> 'b seq
+    CreateCollection: 'b seq -> CollectionTarget<'b>
     Equals: 'a -> 'a -> bool
     GetId: 'b -> 'id
     ItemEquals: 'b -> 'b -> bool }
 
-  member d.Merge(values: ObservableCollection<'b>, currentModel: 'model, newModel: 'model) =
+  member d.Merge(values: CollectionTarget<'b>, currentModel: 'model, newModel: 'model) =
     let intermediate = d.Get newModel
     if not <| d.Equals intermediate (d.Get currentModel) then
       let create v _ = v
       let update oldVal newVal oldIdx =
         if not (d.ItemEquals newVal oldVal) then
-          values.[oldIdx] <- newVal
+          values.ReplaceAt (oldIdx, newVal)
       let newVals = intermediate |> d.Map |> Seq.toArray
       Merge.keyed d.GetId d.GetId create update values newVals
 
@@ -72,6 +73,7 @@ and internal SubModelWinData<'model, 'msg, 'bindingModel, 'bindingMsg, 'bindingV
 and internal SubModelSeqUnkeyedData<'model, 'msg, 'bindingModel, 'bindingMsg, 'bindingViewModel> =
   { GetModels: 'model -> 'bindingModel seq
     CreateViewModel: ViewModelArgs<'bindingModel,'bindingMsg> -> 'bindingViewModel
+    CreateCollection: 'bindingViewModel seq -> CollectionTarget<'bindingViewModel>
     UpdateViewModel: 'bindingViewModel * 'bindingModel -> unit
     ToMsg: 'model -> int * 'bindingMsg -> 'msg }
 
@@ -79,6 +81,7 @@ and internal SubModelSeqUnkeyedData<'model, 'msg, 'bindingModel, 'bindingMsg, 'b
 and internal SubModelSeqKeyedData<'model, 'msg, 'bindingModel, 'bindingMsg, 'bindingViewModel, 'id when 'id : equality> =
   { GetSubModels: 'model -> 'bindingModel seq
     CreateViewModel: ViewModelArgs<'bindingModel,'bindingMsg> -> 'bindingViewModel
+    CreateCollection: 'bindingViewModel seq -> CollectionTarget<'bindingViewModel>
     UpdateViewModel: 'bindingViewModel * 'bindingModel -> unit
     GetUnderlyingModel: 'bindingViewModel -> 'bindingModel
     ToMsg: 'model -> 'id * 'bindingMsg -> 'msg
@@ -88,7 +91,7 @@ and internal SubModelSeqKeyedData<'model, 'msg, 'bindingModel, 'bindingMsg, 'bin
       (getTargetId: ('bindingModel -> 'id) -> 't -> 'id,
        create: 'bindingModel -> 'id -> 't,
        update: 't -> 'bindingModel -> unit,
-       values: ObservableCollection<'t>,
+       values: CollectionTarget<'t>,
        newSubModels: 'bindingModel []) =
     let update t bm _ = update t bm
     Merge.keyed d.GetId (getTargetId d.GetId) create update values newSubModels
@@ -168,6 +171,7 @@ module internal BindingData =
       | OneWaySeqLazyData d -> OneWaySeqLazyData {
           Get = f >> d.Get
           Map = d.Map
+          CreateCollection = d.CreateCollection
           Equals = d.Equals
           GetId = d.GetId
           ItemEquals = d.ItemEquals
@@ -199,12 +203,14 @@ module internal BindingData =
       | SubModelSeqUnkeyedData d -> SubModelSeqUnkeyedData {
           GetModels = f >> d.GetModels
           CreateViewModel = d.CreateViewModel
+          CreateCollection = d.CreateCollection
           UpdateViewModel = d.UpdateViewModel
           ToMsg = f >> d.ToMsg
         }
       | SubModelSeqKeyedData d -> SubModelSeqKeyedData {
           GetSubModels = f >> d.GetSubModels
           CreateViewModel = d.CreateViewModel
+          CreateCollection = d.CreateCollection
           UpdateViewModel = d.UpdateViewModel
           GetUnderlyingModel = d.GetUnderlyingModel
           ToMsg = f >> d.ToMsg
@@ -268,12 +274,14 @@ module internal BindingData =
       | SubModelSeqUnkeyedData d -> SubModelSeqUnkeyedData {
           GetModels = d.GetModels
           CreateViewModel = d.CreateViewModel
+          CreateCollection = d.CreateCollection
           UpdateViewModel = d.UpdateViewModel
           ToMsg = fun m bMsg -> f (d.ToMsg m bMsg) m
         }
       | SubModelSeqKeyedData d -> SubModelSeqKeyedData {
           GetSubModels = d.GetSubModels
           CreateViewModel = d.CreateViewModel
+          CreateCollection = d.CreateCollection
           UpdateViewModel = d.UpdateViewModel
           GetUnderlyingModel = d.GetUnderlyingModel
           ToMsg = fun m bMsg -> f (d.ToMsg m bMsg) m
@@ -410,6 +418,7 @@ module internal BindingData =
         (d: OneWaySeqLazyData<'model, 'a, 'b, 'id>) = {
       Get = d.Get >> outMapA
       Map = inMapA >> d.Map >> Seq.map outMapB
+      CreateCollection = Seq.map inMapB >> d.CreateCollection >> CollectionTarget.map outMapB inMapB
       Equals = fun a1 a2 -> d.Equals (inMapA a1) (inMapA a2)
       GetId = inMapB >> d.GetId >> outMapId
       ItemEquals = fun b1 b2 -> d.ItemEquals (inMapB b1) (inMapB b2)
@@ -421,6 +430,7 @@ module internal BindingData =
       { Get = get
         Equals = equals
         Map = fun a -> upcast map a
+        CreateCollection = ObservableCollection >> CollectionTarget.create
         ItemEquals = itemEquals
         GetId = getId }
       |> box
@@ -613,6 +623,7 @@ module internal BindingData =
         (d: SubModelSeqUnkeyedData<'model, 'msg, 'bindingModel, 'bindingMsg, 'bindingViewModel>) = {
       GetModels = d.GetModels >> Seq.map outMapBindingModel
       CreateViewModel = fun args -> d.CreateViewModel(args |> ViewModelArgs.map inMapBindingModel outMapBindingMsg) |> outMapBindingViewModel
+      CreateCollection = Seq.map inMapBindingViewModel >> d.CreateCollection >> CollectionTarget.map outMapBindingViewModel inMapBindingViewModel
       UpdateViewModel = fun (vm,m) -> d.UpdateViewModel (inMapBindingViewModel vm,inMapBindingModel m)
       ToMsg = fun m (idx, bMsg) -> d.ToMsg m (idx, (inMapBindingMsg bMsg))
     }
@@ -622,6 +633,7 @@ module internal BindingData =
     let create createViewModel updateViewModel =
       { GetModels = id
         CreateViewModel = createViewModel
+        CreateCollection = ObservableCollection >> CollectionTarget.create
         UpdateViewModel = updateViewModel
         ToMsg = fun _ -> id }
       |> box
@@ -662,6 +674,7 @@ module internal BindingData =
           (d: SubModelSeqKeyedData<'model, 'msg, 'bindingModel, 'bindingMsg, 'bindingViewModel, 'id>) = {
         GetSubModels = d.GetSubModels >> Seq.map outMapBindingModel
         CreateViewModel = fun args -> d.CreateViewModel(args |> ViewModelArgs.map inMapBindingModel outMapBindingMsg) |> outMapBindingViewModel
+        CreateCollection = Seq.map inMapBindingViewModel >> d.CreateCollection >> CollectionTarget.map outMapBindingViewModel inMapBindingViewModel
         UpdateViewModel = fun (vm,m) -> (inMapBindingViewModel vm,inMapBindingModel m) |> d.UpdateViewModel
         GetUnderlyingModel = fun vm -> vm |> inMapBindingViewModel |> d.GetUnderlyingModel |> outMapBindingModel
         ToMsg = fun m (id, bMsg) -> d.ToMsg m ((inMapId id), (inMapBindingMsg bMsg))
@@ -673,6 +686,7 @@ module internal BindingData =
       let create createViewModel updateViewModel getUnderlyingModel getId =
         { GetSubModels = id
           CreateViewModel = createViewModel
+          CreateCollection = ObservableCollection >> CollectionTarget.create
           UpdateViewModel = updateViewModel
           GetUnderlyingModel = getUnderlyingModel
           ToMsg = fun _ -> id

--- a/src/Elmish.WPF/InternalUtils.fs
+++ b/src/Elmish.WPF/InternalUtils.fs
@@ -93,6 +93,8 @@ module Pair =
 
   let mapAll f g (a, c) = (f a, g c)
 
+  let map2 f (a, c) = (a, f c)
+
 
 [<RequireQualifiedAccess>]
 module PairOption =

--- a/src/Elmish.WPF/Merge.fs
+++ b/src/Elmish.WPF/Merge.fs
@@ -50,7 +50,7 @@ module internal CollectionTarget =
       RemoveAt = oc.RemoveAt
       Move = oc.Move
       Clear = oc.Clear
-      Enumerate = fun () -> oc
+      Enumerate = fun () -> upcast oc
       BoxedCollection = fun () -> oc |> box }
 
 module internal Merge =

--- a/src/Elmish.WPF/Merge.fs
+++ b/src/Elmish.WPF/Merge.fs
@@ -28,16 +28,16 @@ type internal CollectionTarget<'a> =
     BoxedCollection: unit -> obj }
 
 module internal CollectionTarget =
-  let map (f: 'a -> 'b) (f': 'b -> 'a) (ct: CollectionTarget<'a>) : CollectionTarget<'b> =
+  let map (fOut: 'a -> 'b) (fIn: 'b -> 'a) (ct: CollectionTarget<'a>) : CollectionTarget<'b> =
     { GetLength = ct.GetLength
-      GetAt = ct.GetAt >> f
-      Append = f' >> ct.Append
-      InsertAt = Pair.mapAll id f' >> ct.InsertAt
-      ReplaceAt = Pair.mapAll id f' >> ct.ReplaceAt
+      GetAt = ct.GetAt >> fOut
+      Append = fIn >> ct.Append
+      InsertAt = Pair.map2 fIn >> ct.InsertAt
+      ReplaceAt = Pair.map2 fIn >> ct.ReplaceAt
       RemoveAt = ct.RemoveAt
       Move = ct.Move
       Clear = ct.Clear
-      Enumerate = ct.Enumerate >> Seq.map f
+      Enumerate = ct.Enumerate >> Seq.map fOut
       BoxedCollection = ct.BoxedCollection }
 
   let create (oc: ObservableCollection<'a>) =

--- a/src/Elmish.WPF/Merge.fs
+++ b/src/Elmish.WPF/Merge.fs
@@ -2,7 +2,6 @@
 
 open System.Collections.Generic
 open System.Collections.ObjectModel
-open System.Collections.Specialized
 
 
 type SourceOrTarget =
@@ -138,7 +137,7 @@ module internal Merge =
         match mNextSource, mNextTarget with
         | Some (nextSource, _, true), Some (nextTarget, _, true) -> // swap adjacent
             target.ReplaceAt (curTargetIdx, nextTarget)
-            target.ReplaceAt ((curTargetIdx + 1), curTarget)
+            target.ReplaceAt (curTargetIdx + 1, curTarget)
 
             update curTarget nextSource (curTargetIdx + 1)
             update nextTarget curSource curTargetIdx

--- a/src/Elmish.WPF/Merge.fs
+++ b/src/Elmish.WPF/Merge.fs
@@ -20,7 +20,7 @@ type internal CollectionTarget<'a> =
     GetAt: int -> 'a
     Append: 'a -> unit
     InsertAt: int * 'a -> unit
-    ReplaceAt: int * 'a -> unit
+    SetAt: int * 'a -> unit
     RemoveAt: int -> unit
     Move: int * int -> unit
     Clear: unit -> unit
@@ -33,7 +33,7 @@ module internal CollectionTarget =
       GetAt = ct.GetAt >> fOut
       Append = fIn >> ct.Append
       InsertAt = Pair.map2 fIn >> ct.InsertAt
-      ReplaceAt = Pair.map2 fIn >> ct.ReplaceAt
+      SetAt = Pair.map2 fIn >> ct.SetAt
       RemoveAt = ct.RemoveAt
       Move = ct.Move
       Clear = ct.Clear
@@ -45,7 +45,7 @@ module internal CollectionTarget =
       GetAt = fun i -> oc.[i]
       Append = oc.Add
       InsertAt = oc.Insert
-      ReplaceAt = fun (i,a) -> oc.[i] <- a
+      SetAt = fun (i,a) -> oc.[i] <- a
       RemoveAt = oc.RemoveAt
       Move = oc.Move
       Clear = oc.Clear
@@ -136,8 +136,8 @@ module internal Merge =
 
         match mNextSource, mNextTarget with
         | Some (nextSource, _, true), Some (nextTarget, _, true) -> // swap adjacent
-            target.ReplaceAt (curTargetIdx, nextTarget)
-            target.ReplaceAt (curTargetIdx + 1, curTarget)
+            target.SetAt (curTargetIdx, nextTarget)
+            target.SetAt (curTargetIdx + 1, curTarget)
 
             update curTarget nextSource (curTargetIdx + 1)
             update nextTarget curSource curTargetIdx
@@ -233,8 +233,8 @@ module internal Merge =
         target.Move(tIdx, sIdx)
     | [ (t1Idx, s1Idx, _, _); (t2Idx, s2Idx, _, _) ], 0, 0 when t1Idx = s2Idx && t2Idx = s1Idx-> // single swap
         let temp = target.GetAt t1Idx
-        target.ReplaceAt (t1Idx, target.GetAt t2Idx)
-        target.ReplaceAt (t2Idx, temp)
+        target.SetAt (t1Idx, target.GetAt t2Idx)
+        target.SetAt (t2Idx, temp)
     | _, rc, _ when rc = targetCount && rc > 0 -> // remove everything (implies moves = [])
         target.Clear ()
         actuallyAdd ()


### PR DESCRIPTION
Add a `CollectionTarget<'a>` so that we can properly box and unbox the collections so that they have the strongest type under the hood.