### PR TITLE
Add output type information to `BindingData`

### DIFF
--- a/src/Elmish.WPF/BindingVmHelpers.fs
+++ b/src/Elmish.WPF/BindingVmHelpers.fs
@@ -204,12 +204,12 @@ and VmBinding<'model, 'msg> =
 
 type SubModelSelectedItemLast() =
 
-  member _.Base(data: BaseBindingData<'model, 'msg>) : int =
+  member _.Base(data: BaseBindingData<'model, 'msg, obj>) : int =
     match data with
     | SubModelSelectedItemData _ -> 1
     | _ -> 0
 
-  member this.Recursive<'model, 'msg>(data: BindingData<'model, 'msg>) : int =
+  member this.Recursive<'model, 'msg>(data: BindingData<'model, 'msg, obj>) : int =
     match data with
     | BaseBindingData d -> this.Base d
     | CachingData d -> this.Recursive d
@@ -217,7 +217,7 @@ type SubModelSelectedItemLast() =
     | LazyData d -> this.Recursive d.BindingData
     | AlterMsgStreamData d -> this.Recursive d.BindingData
 
-  member this.CompareBindingDatas() : BindingData<'model, 'msg> -> BindingData<'model, 'msg> -> int =
+  member this.CompareBindingDatas() : BindingData<'model, 'msg, obj> -> BindingData<'model, 'msg, obj> -> int =
     fun a b -> this.Recursive(a) - this.Recursive(b)
 
 
@@ -273,7 +273,7 @@ type Initialize
       (initialModel: 'model,
        dispatch: 'msg -> unit,
        getCurrentModel: unit -> 'model,
-       binding: BaseBindingData<'model, 'msg>)
+       binding: BaseBindingData<'model, 'msg, obj>)
       : BaseVmBinding<'model, 'msg> option =
     match binding with
       | OneWayData d ->
@@ -396,7 +396,7 @@ type Initialize
       (initialModel: 'model,
        dispatch: 'msg -> unit,
        getCurrentModel: unit -> 'model,
-       binding: BindingData<'model, 'msg>)
+       binding: BindingData<'model, 'msg, obj>)
       : VmBinding<'model, 'msg> option =
     option {
       match binding with

--- a/src/Elmish.WPF/DynamicViewModel.fs
+++ b/src/Elmish.WPF/DynamicViewModel.fs
@@ -12,7 +12,7 @@ open BindingVmHelpers
 type Binding<'model, 'msg> =
   internal
     { Name: string
-      Data: BindingData<'model, 'msg> }
+      Data: BindingData<'model, 'msg, obj> }
 
 
 [<AutoOpen>]


### PR DESCRIPTION
This Pull Request adds another type parameter to `BindingData` which allows it to carry the actual view model property type statically through the builder.

From a conversation with @TysonMN:
> When used in the context of "dot" notation in the XAML project, you will be able to get compile-time help for things like ViewModelProp.SubModel.Prop. If those were constrained to obj, you wouldn't get compile-time checking of those types.
Also XAML will warn you about type issues (number vs string, etc)

Note that the current usage of `Binding<'model,'msg>` constrains the new type parameter to be `obj` for every construction of it (this is the entire public interface in `Binding.fs`). This is intentional, as all of those bindings are by necessity constrained to `obj` in order to work in the various `SubModel` and `SubModelSeq` bindings. The advantage mentioned above will not be realized until after a static helper is created that can turn a binding into a statically-typed getter or setter.