### PR TITLE
Optimize lazy effect by reducing calls to get

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 #### 4.0.0-beta-44
 * Fixed sticky effect that was broken in `4.0.0-beta-42`
+* Improved performance of Lazy effect by reducing calls to later model mappings
 
 #### 4.0.0-beta-43
 * Added `WpfProgram.withElmishErrorHandler`

--- a/src/Elmish.WPF.Tests/BindingTests.fs
+++ b/src/Elmish.WPF.Tests/BindingTests.fs
@@ -16,7 +16,11 @@ module internal Helpers =
     | BaseBindingData d -> d
     | CachingData d -> getBaseBindingData d
     | ValidationData d -> getBaseBindingData d.BindingData
-    | LazyData d -> getBaseBindingData d.BindingData
+    | LazyData d ->
+        d.BindingData
+        |> BindingData.mapModel d.Get
+        |> BindingData.mapMsgWithModel d.Set
+        |> getBaseBindingData
     | AlterMsgStreamData _ -> raise (System.NotSupportedException()) // hack: reasonable because this is test code and the tests don't currently use this case
 
   let getOneWayData f =

--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -369,6 +369,7 @@ module OneWayLazy =
   }
 
 
+
 module OneWaySeqLazy =
 
 
@@ -1407,6 +1408,63 @@ module SubModelSelectedItem =
 
 
 
+module LazyEffect =
+
+  [<Fact>]
+  let ``model mapping not called on initialize`` () =
+    let name = ""
+    let model = 0
+    let mapping = InvokeTester id
+    let binding =
+      name
+      |> Binding.TwoWay.id<int>
+      |> Binding.addLazy (=)
+      |> Binding.addLazy (=)
+      |> Binding.mapModel mapping.Fn
+
+    TestVm(model, binding) |> ignore
+
+    test <@ 0 = mapping.Count @>
+
+
+  [<Fact>]
+  let ``model mapping called exactly twice on update when new model is equal`` () =
+    let name = ""
+    let model = 0
+    let mapping = InvokeTester id
+    let binding =
+      name
+      |> Binding.TwoWay.id<int>
+      |> Binding.addLazy (=)
+      |> Binding.addLazy (=)
+      |> Binding.mapModel mapping.Fn
+    let vm = TestVm(model, binding)
+
+    vm.UpdateModel model
+
+    test <@ 2 = mapping.Count @>
+
+
+  [<Fact>]
+  let ``model mapping called exactly twice on update when new model is unequal`` () =
+    let name = ""
+    let initialModel = 0
+    let newModel = 1
+    let mapping = InvokeTester id
+    let binding =
+      name
+      |> Binding.TwoWay.id<int>
+      |> Binding.addLazy (=)
+      |> Binding.addLazy (=)
+      |> Binding.mapModel mapping.Fn
+    let vm = TestVm(initialModel, binding)
+
+    vm.UpdateModel newModel
+
+    test <@ 2 = mapping.Count @>
+
+
+
 module AlterMsgStream =
 
   [<Fact>]
@@ -1417,7 +1475,7 @@ module AlterMsgStream =
     let set _ _ = ()
     let alteration = InvokeTester id
     let binding =
-      twoWay get set ""
+      twoWay get set name
       |> Binding.alterMsgStream alteration.Fn
     let vm = TestVm(model, binding)
 

--- a/src/Elmish.WPF.Tests/ViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/ViewModelTests.fs
@@ -1411,7 +1411,7 @@ module SubModelSelectedItem =
 module LazyEffect =
 
   [<Fact>]
-  let ``model mapping not called on initialize`` () =
+  let ``model mapping called exactly once on initialize`` () =
     let name = ""
     let model = 0
     let mapping = InvokeTester id
@@ -1424,7 +1424,7 @@ module LazyEffect =
 
     TestVm(model, binding) |> ignore
 
-    test <@ 0 = mapping.Count @>
+    test <@ 1 = mapping.Count @>
 
 
   [<Fact>]
@@ -1439,6 +1439,7 @@ module LazyEffect =
       |> Binding.addLazy (=)
       |> Binding.mapModel mapping.Fn
     let vm = TestVm(model, binding)
+    mapping.Reset ()
 
     vm.UpdateModel model
 
@@ -1458,6 +1459,7 @@ module LazyEffect =
       |> Binding.addLazy (=)
       |> Binding.mapModel mapping.Fn
     let vm = TestVm(initialModel, binding)
+    mapping.Reset ()
 
     vm.UpdateModel newModel
 

--- a/src/Elmish.WPF/BindingVmHelpers.fs
+++ b/src/Elmish.WPF/BindingVmHelpers.fs
@@ -413,7 +413,7 @@ type internal Initialize
           let! b = this.Recursive(initialModel, dispatch, getCurrentModel, d.BindingData)
           return b.AddValidation (getCurrentModel ()) d.Validate
       | LazyData d ->
-          let d = d |> BindingData.Lazy.measureFunctions measure
+          let d = d |> BindingData.Lazy.measureFunctions measure2
           let! b = this.Recursive(initialModel, dispatch, getCurrentModel, d.BindingData)
           return b.AddLazy d.Equals
       | AlterMsgStreamData d ->


### PR DESCRIPTION
Each recursive binding case should either do model/msg mapping on its own functions or its inner binding but not both.

Somewhat annoyingly, this increases duplicate code (which is why I didn't write it this way in the first place).  I wonder if there is a good way to dedup this.

This is also a good reminder that I should write more (view model) tests.