### PR TITLE
Update packages and frameworks

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -18,10 +18,10 @@ jobs:
       with:
         dotnet-version: 3.1.x
 
-    - name: Install .NET SDK 5.0.103
+    - name: Install .NET SDK 6.0.x
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.103
+        dotnet-version: 6.0.x
 
     - name: Restore
       run: dotnet restore src/Elmish.WPF.sln

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -13,15 +13,12 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Install .NET SDK 3.1.x
+    - name: Install .NET SDKs
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.x
-
-    - name: Install .NET SDK 6.0.x
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
+        dotnet-version: |
+          3.1.x
+          6.0.x
 
     - name: Restore
       run: dotnet restore src/Elmish.WPF.sln

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,10 +20,10 @@ jobs:
       with:
         dotnet-version: 3.1.x
 
-    - name: Install .NET SDK 5.0.103
+    - name: Install .NET SDK 6.0.x
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.103
+        dotnet-version: 6.0.x
 
     - name: Restore
       run: dotnet restore src/Elmish.WPF.sln

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,15 +15,12 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Install .NET SDK 3.1.x
+    - name: Install .NET SDKs
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.x
-
-    - name: Install .NET SDK 6.0.x
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
+        dotnet-version: |
+          3.1.x
+          6.0.x
 
     - name: Restore
       run: dotnet restore src/Elmish.WPF.sln

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 * Improved caching effect to not invalidating the cache too early (an issue introduced in version `3.5.3 `via PR 181)
 * Renamed `Binding.SetMsgWithModel` to `Binding.setMsgWithModel` (breaking public API added in `4.0.0-beta-42`)
 * Fixed bug with `mapMsgWithModel` and `setMsgWithModel` where the original model was sometimes given (an issue introduced in `4.0.0-beta-42`)
+* Replaced framework targets `net461` and `net5.0-windows` with `net480` and `net6.0-windows` respectively.
 
 #### 4.0.0-beta-43
 * Added `WpfProgram.withElmishErrorHandler`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,8 @@
 * Renamed `Binding.SetMsgWithModel` to `Binding.setMsgWithModel` (breaking public API added in `4.0.0-beta-42`)
 * Fixed bug with `mapMsgWithModel` and `setMsgWithModel` where the original model was sometimes given (an issue introduced in `4.0.0-beta-42`)
 * Replaced framework targets `net461` and `net5.0-windows` with `net480` and `net6.0-windows` respectively.
+* Updated minimum `FSharp.Core` version to `6.0.5`.
+* Updated minimum `Microsoft.Extensions.Logging.Abstractions` version to `6.0.1`.
 
 #### 4.0.0-beta-43
 * Added `WpfProgram.withElmishErrorHandler`

--- a/src/Elmish.WPF.Tests/Elmish.WPF.Tests.fsproj
+++ b/src/Elmish.WPF.Tests/Elmish.WPF.Tests.fsproj
@@ -22,13 +22,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Interop.Dynamic" Version="5.0.0.250" />
-    <PackageReference Include="Hedgehog" Version="0.10.0" />
-    <PackageReference Include="Hedgehog.Experimental" Version="0.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="Unquote" Version="5.0.0" />
+    <PackageReference Include="FSharp.Interop.Dynamic" Version="5.0.1.268" />
+    <PackageReference Include="Hedgehog" Version="0.12.1" />
+    <PackageReference Include="Hedgehog.Experimental" Version="0.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Unquote" Version="6.1.0" />
     <PackageReference Include="xunit.core" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Elmish.WPF.Tests/Elmish.WPF.Tests.fsproj
+++ b/src/Elmish.WPF.Tests/Elmish.WPF.Tests.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows;netcoreapp3.1;net480</TargetFrameworks>
     <UseWpf>true</UseWpf>
     <!--Turn on warnings for unused values (arguments and let bindings) -->
     <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>

--- a/src/Elmish.WPF.Tests/MergeTests.fs
+++ b/src/Elmish.WPF.Tests/MergeTests.fs
@@ -120,8 +120,8 @@ let ``starting with random items, when merging after a move, should contain the 
     let! list = GenX.auto<Guid list>
     let! movedItem = Gen.guid
     let! additionalItem = Gen.guid
-    let! i1 = (0, list.Length + 1) ||> Range.constant |> Gen.int
-    let! i2 = (0, list.Length + 1) ||> Range.constant |> Gen.int |> GenX.notEqualTo i1
+    let! i1 = (0, list.Length + 1) ||> Range.constant |> Gen.int32
+    let! i2 = (0, list.Length + 1) ||> Range.constant |> Gen.int32 |> GenX.notEqualTo i1
 
     let list = additionalItem :: list
     let list1 = list |> List.insert i1 movedItem
@@ -143,7 +143,7 @@ let ``starting with random items, when merging after a replacement, should conta
     let! list1Head = Gen.guid
     let! list1Tail = GenX.auto<Guid list>
     let! list2Replacement = Gen.guid
-    let! replcementIndex = (0, list1Tail.Length) ||> Range.constant |> Gen.int
+    let! replcementIndex = (0, list1Tail.Length) ||> Range.constant |> Gen.int32
 
     let list1 = list1Head :: list1Tail
     let observableCollection = ObservableCollection<_> list1
@@ -165,7 +165,7 @@ let ``starting with random items, when merging after a replacement, should conta
 let ``starting with random items, when merging after swapping two adjacent items, should contain the merged items and never call create and call update exactly once for each item`` () =
   Property.check <| property {
     let! list1 = Gen.guid |> Gen.list (Range.constant 2 50)
-    let! firstSwapIndex = (0, list1.Length - 2) ||> Range.constant |> Gen.int
+    let! firstSwapIndex = (0, list1.Length - 2) ||> Range.constant |> Gen.int32
 
     let observableCollection = ObservableCollection<_> list1
     let array2 =
@@ -186,8 +186,8 @@ let ``starting with random items, when merging after swapping two adjacent items
 let ``starting with random items, when merging after swapping two items, should contain the merged items and never call create and call update exactly once for each item`` () =
   Property.check <| property {
     let! list1 = Gen.guid |> Gen.list (Range.constant 2 50)
-    let! i = (0, list1.Length - 1) ||> Range.constant |> Gen.int
-    let! j = (0, list1.Length - 1) ||> Range.constant |> Gen.int |> GenX.notEqualTo i
+    let! i = (0, list1.Length - 1) ||> Range.constant |> Gen.int32
+    let! j = (0, list1.Length - 1) ||> Range.constant |> Gen.int32 |> GenX.notEqualTo i
 
     let observableCollection = ObservableCollection<_> list1
     let array2 =

--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows;netcoreapp3.1;net480</TargetFrameworks>
     <UseWpf>true</UseWpf>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -52,11 +52,11 @@
 
   <ItemGroup>
     <PackageReference Include="Elmish" Version="[3.1.0, 3.99]" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.6, 99]" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[6.0.1, 99]" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="[4.6.2, 99]" />
+    <PackageReference Update="FSharp.Core" Version="[6.0.5, 99]" />
   </ItemGroup>
 
 </Project>

--- a/src/Samples/Capabilities.Core/Capabilities.Core.fsproj
+++ b/src/Samples/Capabilities.Core/Capabilities.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/Capabilities.Core/Capabilities.Core.fsproj
+++ b/src/Samples/Capabilities.Core/Capabilities.Core.fsproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/Capabilities/Capabilities.csproj
+++ b/src/Samples/Capabilities/Capabilities.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/Capabilities/Capabilities.csproj
+++ b/src/Samples/Capabilities/Capabilities.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/EventBindingsAndBehaviors.Core/EventBindingsAndBehaviors.Core.fsproj
+++ b/src/Samples/EventBindingsAndBehaviors.Core/EventBindingsAndBehaviors.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/EventBindingsAndBehaviors.Core/EventBindingsAndBehaviors.Core.fsproj
+++ b/src/Samples/EventBindingsAndBehaviors.Core/EventBindingsAndBehaviors.Core.fsproj
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/EventBindingsAndBehaviors/EventBindingsAndBehaviors.csproj
+++ b/src/Samples/EventBindingsAndBehaviors/EventBindingsAndBehaviors.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/EventBindingsAndBehaviors/EventBindingsAndBehaviors.csproj
+++ b/src/Samples/EventBindingsAndBehaviors/EventBindingsAndBehaviors.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/FileDialogs.Core/FileDialogs.Core.fsproj
+++ b/src/Samples/FileDialogs.Core/FileDialogs.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/FileDialogs.Core/FileDialogs.Core.fsproj
+++ b/src/Samples/FileDialogs.Core/FileDialogs.Core.fsproj
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/FileDialogs/FileDialogs.csproj
+++ b/src/Samples/FileDialogs/FileDialogs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/FileDialogsCmdMsg.Core/FileDialogsCmdMsg.Core.fsproj
+++ b/src/Samples/FileDialogsCmdMsg.Core/FileDialogsCmdMsg.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/FileDialogsCmdMsg.Core/FileDialogsCmdMsg.Core.fsproj
+++ b/src/Samples/FileDialogsCmdMsg.Core/FileDialogsCmdMsg.Core.fsproj
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/FileDialogsCmdMsg/FileDialogsCmdMsg.csproj
+++ b/src/Samples/FileDialogsCmdMsg/FileDialogsCmdMsg.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/Multiselect.Core/Multiselect.Core.fsproj
+++ b/src/Samples/Multiselect.Core/Multiselect.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/Multiselect.Core/Multiselect.Core.fsproj
+++ b/src/Samples/Multiselect.Core/Multiselect.Core.fsproj
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/Multiselect/Multiselect.csproj
+++ b/src/Samples/Multiselect/Multiselect.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/NewWindow.Core/NewWindow.Core.fsproj
+++ b/src/Samples/NewWindow.Core/NewWindow.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/NewWindow.Core/NewWindow.Core.fsproj
+++ b/src/Samples/NewWindow.Core/NewWindow.Core.fsproj
@@ -17,9 +17,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/NewWindow/NewWindow.csproj
+++ b/src/Samples/NewWindow/NewWindow.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/NewWindow/NewWindow.csproj
+++ b/src/Samples/NewWindow/NewWindow.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/OneWaySeq.Core/OneWaySeq.Core.fsproj
+++ b/src/Samples/OneWaySeq.Core/OneWaySeq.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/OneWaySeq.Core/OneWaySeq.Core.fsproj
+++ b/src/Samples/OneWaySeq.Core/OneWaySeq.Core.fsproj
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/OneWaySeq/OneWaySeq.csproj
+++ b/src/Samples/OneWaySeq/OneWaySeq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/SingleCounter.Core/SingleCounter.Core.fsproj
+++ b/src/Samples/SingleCounter.Core/SingleCounter.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/SingleCounter.Core/SingleCounter.Core.fsproj
+++ b/src/Samples/SingleCounter.Core/SingleCounter.Core.fsproj
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/SingleCounter/SingleCounter.csproj
+++ b/src/Samples/SingleCounter/SingleCounter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/Sticky.Core/Sticky.Core.fsproj
+++ b/src/Samples/Sticky.Core/Sticky.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/Sticky.Core/Sticky.Core.fsproj
+++ b/src/Samples/Sticky.Core/Sticky.Core.fsproj
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/Sticky/Sticky.csproj
+++ b/src/Samples/Sticky/Sticky.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/SubModel.Core/SubModel.Core.fsproj
+++ b/src/Samples/SubModel.Core/SubModel.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/SubModel.Core/SubModel.Core.fsproj
+++ b/src/Samples/SubModel.Core/SubModel.Core.fsproj
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/SubModel/SubModel.csproj
+++ b/src/Samples/SubModel/SubModel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/SubModelOpt.Core/SubModelOpt.Core.fsproj
+++ b/src/Samples/SubModelOpt.Core/SubModelOpt.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/SubModelOpt.Core/SubModelOpt.Core.fsproj
+++ b/src/Samples/SubModelOpt.Core/SubModelOpt.Core.fsproj
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/SubModelOpt/SubModelOpt.csproj
+++ b/src/Samples/SubModelOpt/SubModelOpt.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/SubModelSelectedItem.Core/SubModelSelectedItem.Core.fsproj
+++ b/src/Samples/SubModelSelectedItem.Core/SubModelSelectedItem.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/SubModelSelectedItem.Core/SubModelSelectedItem.Core.fsproj
+++ b/src/Samples/SubModelSelectedItem.Core/SubModelSelectedItem.Core.fsproj
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/SubModelSelectedItem/SubModelSelectedItem.csproj
+++ b/src/Samples/SubModelSelectedItem/SubModelSelectedItem.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/SubModelSeq.Core/SubModelSeq.Core.fsproj
+++ b/src/Samples/SubModelSeq.Core/SubModelSeq.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/SubModelSeq.Core/SubModelSeq.Core.fsproj
+++ b/src/Samples/SubModelSeq.Core/SubModelSeq.Core.fsproj
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/SubModelSeq/SubModelSeq.csproj
+++ b/src/Samples/SubModelSeq/SubModelSeq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/UiBoundCmdParam.Core/UiBoundCmdParam.Core.fsproj
+++ b/src/Samples/UiBoundCmdParam.Core/UiBoundCmdParam.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/UiBoundCmdParam.Core/UiBoundCmdParam.Core.fsproj
+++ b/src/Samples/UiBoundCmdParam.Core/UiBoundCmdParam.Core.fsproj
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/UiBoundCmdParam/UiBoundCmdParam.csproj
+++ b/src/Samples/UiBoundCmdParam/UiBoundCmdParam.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/Validation.Core/Validation.Core.fsproj
+++ b/src/Samples/Validation.Core/Validation.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/Validation.Core/Validation.Core.fsproj
+++ b/src/Samples/Validation.Core/Validation.Core.fsproj
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/Validation/Validation.csproj
+++ b/src/Samples/Validation/Validation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>


### PR DESCRIPTION
Update to .NET 6.0 (LTS) and .NET Framework 4.8 as per Microsoft recommendations. .NET Framework 4.6.1 is out of support and .NET 5.0 is not LTS.

Also updated all packages to latest and consolidated versions.