### PR TITLE
Add ofNull and toNull to ValueOption

### DIFF
--- a/src/Elmish.WPF/InternalUtils.fs
+++ b/src/Elmish.WPF/InternalUtils.fs
@@ -68,6 +68,23 @@ module ValueOption =
     | Ok x -> ValueSome x
     | Error _ -> ValueNone
 
+  [<RequireQualifiedAccess>]
+  type ToNullError =
+    | ValueCannotBeNull
+
+  let ofNull<'a> (x: 'a) =
+    match box x with
+    | null -> ValueNone
+    | _ -> ValueSome x
+
+  let toNull<'a> = function
+    | ValueSome x -> Ok x
+    | ValueNone ->
+      if box Unchecked.defaultof<'a> = null then
+        null |> unbox<'a> |> Ok
+      else
+        ToNullError.ValueCannotBeNull |> Error
+
 
 [<RequireQualifiedAccess>]
 module ByRefPair =


### PR DESCRIPTION
Add some helpers that allow for converting between `ValueOption` and nullable values *without requiring* that `'a` be statically restrained as a nullable type. `toNull` will never generate `ValueNone` if the value is not nullable, and `ofNull` will throw an exception if you feed it a `ValueNone` when `'a` is a non-nullable value.

I'm doing it unchecked currently, but I don't know of any way to match/discriminate on a type between nullable and non-nullable. I'm pretty sure you *always* end up with the type parameter being constrained all the way up, or not able to call constrained functions (hence why the implementation has to use boxing).