### PR TITLE
Add static helper for creating static view models from bindings

### DIFF
--- a/src/Elmish.WPF.Tests/BindingVmHelpersTests.fs
+++ b/src/Elmish.WPF.Tests/BindingVmHelpersTests.fs
@@ -112,7 +112,6 @@ module Update =
 
       let binding =
         BindingData.TwoWay.id
-        |> BindingData.boxT
 
       let dispatch msg =
         failwith $"Should not dispatch, got {msg}"
@@ -122,7 +121,7 @@ module Update =
           .Recursive(m1, dispatch, (fun () -> model.Value), binding)
         |> Option.defaultWith (fun () -> failwith $"Could not create VmBinding after passing in BindingData: {binding}")
 
-      let updateResult = Update(LoggingViewModelArgs.none, "Nothing").Recursive(ValueSome m1, (fun () -> model.Value), m2, vmBinding)
+      let updateResult = Update(LoggingViewModelArgs.none, "Nothing").Recursive(ValueSome m1, (fun () -> model.Value), m2, vmBinding |> MapOutputType.recursivecase box unbox)
 
       test <@ updateResult |> List.length = 1 @>
     }

--- a/src/Elmish.WPF.Tests/BindingVmHelpersTests.fs
+++ b/src/Elmish.WPF.Tests/BindingVmHelpersTests.fs
@@ -121,7 +121,7 @@ module Update =
           .Recursive(m1, dispatch, (fun () -> model.Value), binding)
         |> Option.defaultWith (fun () -> failwith $"Could not create VmBinding after passing in BindingData: {binding}")
 
-      let updateResult = Update(LoggingViewModelArgs.none, "Nothing").Recursive(ValueSome m1, (fun () -> model.Value), m2, vmBinding |> MapOutputType.recursivecase box unbox)
+      let updateResult = Update(LoggingViewModelArgs.none, "Nothing").Recursive(ValueSome m1, (fun () -> model.Value), m2, vmBinding |> MapOutputType.boxVm)
 
       test <@ updateResult |> List.length = 1 @>
     }

--- a/src/Elmish.WPF.Tests/BindingVmHelpersTests.fs
+++ b/src/Elmish.WPF.Tests/BindingVmHelpersTests.fs
@@ -112,8 +112,7 @@ module Update =
 
       let binding =
         BindingData.TwoWay.id
-        |> BindingData.mapModel box
-        |> BindingData.mapMsg unbox
+        |> BindingData.boxT
 
       let dispatch msg =
         failwith $"Should not dispatch, got {msg}"

--- a/src/Elmish.WPF.Tests/BindingVmHelpersTests.fs
+++ b/src/Elmish.WPF.Tests/BindingVmHelpersTests.fs
@@ -1,0 +1,137 @@
+﻿module BindingVmHelpersTests.M
+
+open System
+
+open Xunit
+open Hedgehog
+open Swensen.Unquote
+
+open Elmish.WPF
+open Elmish.WPF.BindingVmHelpers
+
+
+
+module Initialize =
+
+  let checker<'t when 't : equality> (g: Gen<'t>) =
+    Property.check <| property {
+      let! m1 = g
+
+      let binding = BindingData.OneWay.id
+
+      let vmBinding =
+        Initialize(LoggingViewModelArgs.none, "Nothing", (fun _ -> failwith "Should not call get selected item"))
+          .Recursive(m1, ignore, (fun () -> m1), binding)
+
+      let result =
+        match vmBinding with
+        | Some (BaseVmBinding (OneWay b)) -> b
+        | b -> failwith $"Expected a OneWay binding, instead found {b}"
+      
+      test <@ result.OneWayData.Get m1 = m1 @>
+    }
+
+  [<Fact>]
+  let ``should initialize successfully with various types`` () =
+    GenX.auto<float> |> checker
+    GenX.auto<int32> |> checker
+    GenX.auto<Guid> |> checker
+    GenX.auto<string> |> GenX.withNull |> checker
+    GenX.auto<obj> |> GenX.withNull |> checker
+
+module Get =
+
+  let checker<'t when 't : equality> (g: Gen<'t>) =
+    Property.check <| property {
+      let! m1 = g
+
+      let binding = BindingData.OneWay.id
+      
+      let vmBinding =
+        Initialize(LoggingViewModelArgs.none, "Nothing", (fun _ -> failwith "Should not call get selected item"))
+          .Recursive(m1, ignore, (fun () -> m1), binding)
+
+      let getResult = vmBinding |> Option.map (fun b -> Get("Nothing").Recursive(m1, b))
+
+      let get =
+        match getResult with
+        | Some (Ok x) -> x
+        | x -> failwith $"Expected a success, instead got {x}"
+
+      test <@ get = m1 @>
+    }
+
+  [<Fact>]
+  let ``should get successfully with various types`` () =
+    GenX.auto<float> |> checker
+    GenX.auto<int32> |> checker
+    GenX.auto<Guid> |> checker
+    GenX.auto<string> |> GenX.withNull |> checker
+    GenX.auto<obj> |> GenX.withNull |> checker
+
+module Set =
+
+  let checker<'t when 't : equality> (g: Gen<'t>) =
+    Property.check <| property {
+      let! m1 = g
+      let! m2 = g |> GenX.notEqualTo m1
+
+      let model = ref m1
+
+      let binding = BindingData.TwoWay.id
+
+      let dispatch msg =
+        model.Value <- msg
+      
+      let vmBinding =
+        Initialize(LoggingViewModelArgs.none, "Nothing", (fun _ -> failwith "Should not call get selected item"))
+          .Recursive(m1, dispatch, (fun () -> model.Value), binding)
+        |> Option.defaultWith (fun () -> failwith $"Could not create VmBinding after passing in BindingData: {binding}")
+
+      test <@ Set(m2).Recursive(model.Value, vmBinding) @>
+      test <@ model.Value = m2 @>
+      test <@ model.Value <> m1 @>
+    }
+
+  [<Fact>]
+  let ``should set successfully with various types`` () =
+    GenX.auto<float> |> checker
+    GenX.auto<int32> |> checker
+    GenX.auto<Guid> |> checker
+    GenX.auto<string> |> GenX.withNull |> checker
+    GenX.auto<obj> |> GenX.withNull |> checker
+
+module Update =
+
+  let checker<'t when 't : equality> (g: Gen<'t>) =
+    Property.check <| property {
+      let! m1 = g
+      let! m2 = g |> GenX.notEqualTo m1
+
+      let model = ref m1
+
+      let binding =
+        BindingData.TwoWay.id
+        |> BindingData.mapModel box
+        |> BindingData.mapMsg unbox
+
+      let dispatch msg =
+        failwith $"Should not dispatch, got {msg}"
+
+      let vmBinding =
+        Initialize(LoggingViewModelArgs.none, "Nothing", (fun _ -> failwith "Should not call get selected item"))
+          .Recursive(m1, dispatch, (fun () -> model.Value), binding)
+        |> Option.defaultWith (fun () -> failwith $"Could not create VmBinding after passing in BindingData: {binding}")
+
+      let updateResult = Update(LoggingViewModelArgs.none, "Nothing").Recursive(ValueSome m1, (fun () -> model.Value), m2, dispatch, vmBinding)
+
+      test <@ updateResult |> List.length = 1 @>
+    }
+
+  [<Fact>]
+  let ``should update successfully with various types`` () =
+    GenX.auto<float> |> checker
+    GenX.auto<int32> |> checker
+    GenX.auto<Guid> |> checker
+    GenX.auto<string> |> GenX.withNull |> checker
+    GenX.auto<obj> |> GenX.withNull |> checker

--- a/src/Elmish.WPF.Tests/BindingVmHelpersTests.fs
+++ b/src/Elmish.WPF.Tests/BindingVmHelpersTests.fs
@@ -122,7 +122,7 @@ module Update =
           .Recursive(m1, dispatch, (fun () -> model.Value), binding)
         |> Option.defaultWith (fun () -> failwith $"Could not create VmBinding after passing in BindingData: {binding}")
 
-      let updateResult = Update(LoggingViewModelArgs.none, "Nothing").Recursive(ValueSome m1, (fun () -> model.Value), m2, dispatch, vmBinding)
+      let updateResult = Update(LoggingViewModelArgs.none, "Nothing").Recursive(ValueSome m1, (fun () -> model.Value), m2, vmBinding)
 
       test <@ updateResult |> List.length = 1 @>
     }

--- a/src/Elmish.WPF.Tests/DynamicViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/DynamicViewModelTests.fs
@@ -1448,7 +1448,7 @@ module SubModelSelectedItem =
                 member _.BeginScope _ = { new IDisposable with member _.Dispose() = () }
                 member _.IsEnabled _ = true
                 member _.Log (_, _, state, ex, formatter) = error <- formatter.Invoke(state, ex) |> Some } }
-    let viewModelArgs = ViewModelArgs.create 0.0 ignore "main" loggingArgs
+    let viewModelArgs = ViewModelArgs.createWithLogging 0.0 ignore "main" loggingArgs
     let vm = DynamicViewModel(viewModelArgs, bindings)
 
     raises<Microsoft.CSharp.RuntimeBinder.RuntimeBinderException> <@ vm.Get selectedItemName @>

--- a/src/Elmish.WPF.Tests/DynamicViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/DynamicViewModelTests.fs
@@ -127,7 +127,7 @@ module Helpers =
        AutoRequery = autoRequery }
      |> CmdData
      |> BaseBindingData
-     |> createBinding) name
+     |> Binding.createBinding) name
 
 
   let internal subModel

--- a/src/Elmish.WPF.Tests/Elmish.WPF.Tests.fsproj
+++ b/src/Elmish.WPF.Tests/Elmish.WPF.Tests.fsproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <Compile Include="AutoOpen.fs" />
     <Compile Include="MergeTests.fs" />
+    <Compile Include="BindingVmHelpersTests.fs" />
     <Compile Include="DynamicViewModelTests.fs" />
     <Compile Include="BindingTests.fs" />
     <Compile Include="UtilsTests.fs" />

--- a/src/Elmish.WPF.sln
+++ b/src/Elmish.WPF.sln
@@ -76,6 +76,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Multiselect", "Samples\Mult
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Multiselect.Core", "Samples\Multiselect.Core\Multiselect.Core.fsproj", "{DFF15AD9-337E-4301-9A05-5CFA147C457E}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SubModelStatic", "Samples\SubModelStatic\SubModelStatic.csproj", "{3F50DF04-DE1F-4368-9584-E318FE41AC2C}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "SubModelStatic.Core", "Samples\SubModelStatic.Core\SubModelStatic.Core.fsproj", "{F0064852-8E7F-437B-A414-72EB0FA46711}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -210,6 +214,14 @@ Global
 		{DFF15AD9-337E-4301-9A05-5CFA147C457E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DFF15AD9-337E-4301-9A05-5CFA147C457E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DFF15AD9-337E-4301-9A05-5CFA147C457E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F50DF04-DE1F-4368-9584-E318FE41AC2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F50DF04-DE1F-4368-9584-E318FE41AC2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F50DF04-DE1F-4368-9584-E318FE41AC2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F50DF04-DE1F-4368-9584-E318FE41AC2C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0064852-8E7F-437B-A414-72EB0FA46711}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0064852-8E7F-437B-A414-72EB0FA46711}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0064852-8E7F-437B-A414-72EB0FA46711}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0064852-8E7F-437B-A414-72EB0FA46711}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -245,6 +257,8 @@ Global
 		{BDA46408-691C-47FA-8670-92A5D04663EB} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
 		{57EB1D0A-9182-4A7F-818B-8FDCA58D7321} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
 		{DFF15AD9-337E-4301-9A05-5CFA147C457E} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
+		{3F50DF04-DE1F-4368-9584-E318FE41AC2C} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
+		{F0064852-8E7F-437B-A414-72EB0FA46711} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3125D461-08F4-4071-AAE5-1038EF84A360}

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -90,7 +90,7 @@ module Binding =
 
     /// Elemental instance of a one-way binding.
     let id<'a, 'msg> : string -> Binding<'a, 'msg> =
-      BindingData.OneWay.id<'msg>
+      BindingData.OneWay.id
       |> BindingData.mapModel box
       |> createBinding
 
@@ -113,7 +113,7 @@ module Binding =
 
     /// Elemental instance of a one-way-to-source binding.
     let id<'model, 'a> : string -> Binding<'model, 'a> =
-      BindingData.OneWayToSource.id<'model>
+      BindingData.OneWayToSource.id
       |> BindingData.mapMsg unbox
       |> createBinding
 

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -6,11 +6,12 @@ open Elmish
 
 
 module Binding =
+  let internal createBinding data name = { Data = data |> BindingData.boxT; Name = name }
   open BindingData
 
   let internal mapData f binding =
-    { Name = binding.Name
-      Data = binding.Data |> f }
+    { Data = binding.Data |> f
+      Name = binding.Name }
 
   /// Maps the model of a binding via a contravariant mapping.
   let mapModel (f: 'a -> 'b) (binding: Binding<'b, 'msg>) = f |> mapModel |> mapData <| binding

--- a/src/Elmish.WPF/BindingT.fs
+++ b/src/Elmish.WPF/BindingT.fs
@@ -111,8 +111,13 @@ module BindingT =
   module SubModel =
     open BindingData.SubModel
 
-    let opt createVm : StaticBindingT<'bindingModel voption, 'msg, 'viewModel :> ISubModel<'bindingModel, 'msg>> =
-      create createVm (fun ((vm: #ISubModel<'bindingModel,'msg>),m) -> vm.StaticHelper.UpdateModel(m))
+    let opt<'bindingModel, 'msg, 'viewModel when 'viewModel :> ISubModel<'bindingModel, 'msg>> createVm : StaticBindingT<'bindingModel voption, 'msg, 'viewModel> =
+      create createVm (fun ((vm: 'viewModel),m) -> vm.StaticHelper.UpdateModel(m))
+      |> createStatic
+
+    let id<'bindingModel, 'msg, 'viewModel when 'viewModel :> ISubModel<'bindingModel, 'msg>> createVm : StaticBindingT<'bindingModel, 'msg, 'viewModel> =
+      create createVm (fun ((vm: 'viewModel),m) -> vm.StaticHelper.UpdateModel(m))
+      |> BindingData.mapModel ValueSome
       |> createStatic
 
 
@@ -126,7 +131,7 @@ type ExampleViewModel(args) as this =
   let staticHelper = StaticHelper.create args (fun () -> this)
 
   member _.Model
-    with get() = BindingT.Get.id |> staticHelper.GetValue()
-    and set(v) = BindingT.Get.id >> BindingT.mapMsg int32<string> |> staticHelper.SetValue(v)
-  member _.Command = BindingT.Cmd.createWithParam (fun _ _ -> ValueNone) (fun _ _ -> true) false |> staticHelper.GetValue()
-  member _.SubModel = BindingT.SubModel.opt InnerExampleViewModel >> BindingT.mapModel ValueSome >> BindingT.mapMsg int32 |> staticHelper.GetValue()
+    with get() = BindingT.Get.id |> staticHelper.Get()
+    and set(v) = BindingT.Get.id >> BindingT.mapMsg int32<string> |> staticHelper.Set(v)
+  member _.Command = BindingT.Cmd.createWithParam (fun _ _ -> ValueNone) (fun _ _ -> true) false |> staticHelper.Get()
+  member _.SubModel = BindingT.SubModel.opt InnerExampleViewModel >> BindingT.mapModel ValueSome >> BindingT.mapMsg int32 |> staticHelper.Get()

--- a/src/Elmish.WPF/BindingT.fs
+++ b/src/Elmish.WPF/BindingT.fs
@@ -126,7 +126,7 @@ type ExampleViewModel(args) as this =
   let staticHelper = StaticHelper.create args (fun () -> this)
 
   member _.Model
-    with get() = BindingT.OneWay.id |> staticHelper.GetValue
+    with get() = BindingT.OneWay.id |> staticHelper.GetValue()
     and set(v) = BindingT.OneWay.id >> BindingT.mapMsg int32<string> |> staticHelper.SetValue(v)
-  member _.Command = BindingT.Cmd.createWithParam (fun _ _ -> ValueNone) (fun _ _ -> true) false |> staticHelper.GetValue
-  member _.SubModel = BindingT.SubModel.opt InnerExampleViewModel >> BindingT.mapModel ValueSome >> BindingT.mapMsg int32 |> staticHelper.GetValue
+  member _.Command = BindingT.Cmd.createWithParam (fun _ _ -> ValueNone) (fun _ _ -> true) false |> staticHelper.GetValue()
+  member _.SubModel = BindingT.SubModel.opt InnerExampleViewModel >> BindingT.mapModel ValueSome >> BindingT.mapMsg int32 |> staticHelper.GetValue()

--- a/src/Elmish.WPF/BindingT.fs
+++ b/src/Elmish.WPF/BindingT.fs
@@ -1,5 +1,9 @@
 ﻿namespace Elmish.WPF
 
+open System.Windows
+
+open Elmish
+
 
 module BindingT =
   let internal createStatic data name = { DataT = data; Name = name }
@@ -115,10 +119,10 @@ module BindingT =
       create createVm (fun ((vm: 'viewModel),m) -> vm.StaticHelper.UpdateModel(m))
       |> createStatic
 
-    let id<'bindingModel, 'msg, 'viewModel when 'viewModel :> ISubModel<'bindingModel, 'msg>> createVm : StaticBindingT<'bindingModel, 'msg, 'viewModel> =
+    let req<'bindingModel, 'msg, 'viewModel when 'viewModel :> ISubModel<'bindingModel, 'msg>> createVm : StaticBindingT<'bindingModel, 'msg, 'viewModel> =
       create createVm (fun ((vm: 'viewModel),m) -> vm.StaticHelper.UpdateModel(m))
-      |> BindingData.mapModel ValueSome
       |> createStatic
+      >> mapModel ValueSome
 
 
 [<AllowNullLiteral>]

--- a/src/Elmish.WPF/BindingT.fs
+++ b/src/Elmish.WPF/BindingT.fs
@@ -1,0 +1,128 @@
+﻿namespace Elmish.WPF
+
+
+module BindingT =
+  let internal createStatic data name = { DataT = data; Name = name }
+  open BindingData
+
+  let internal mapData f binding =
+    { DataT = binding.DataT |> f
+      Name = binding.Name }
+
+  /// Map the model of a binding via a contravariant mapping.
+  let mapModel (f: 'a -> 'b) (binding: BindingT<'b, 'msg, 'vm>) = f |> mapModel |> mapData <| binding
+
+  /// Map the message of a binding with access to the model via a covariant mapping.
+  let mapMsgWithModel (f: 'a -> 'model -> 'b) (binding: BindingT<'model, 'a, 'vm>) = f |> mapMsgWithModel |> mapData <| binding
+
+  /// Map the message of a binding via a covariant mapping.
+  let mapMsg (f: 'a -> 'b) (binding: BindingT<'model, 'a, 'vm>) = f |> mapMsg |> mapData <| binding
+
+  /// Set the message of a binding with access to the model.
+  let SetMsgWithModel (f: 'model -> 'b) (binding: BindingT<'model, 'a, 'vm>) = f |> setMsgWithModel |> mapData <| binding
+
+  /// Set the message of a binding.
+  let setMsg (msg: 'b) (binding: BindingT<'model, 'a, 'vm>) = msg |> setMsg |> mapData <| binding
+
+
+  /// Restrict the binding to models that satisfy the predicate after some model satisfies the predicate.
+  let addSticky (predicate: 'model -> bool) (binding: BindingT<'model, 'msg, 'vm>) = predicate |> addSticky |> mapData <| binding
+
+  /// <summary>
+  ///   Adds caching to the given binding.  The cache holds a single value and
+  ///   is invalidated after the given binding raises the
+  ///   <c>PropertyChanged</c> event.
+  /// </summary>
+  /// <param name="binding">The binding to which caching is added.</param>
+  let addCaching (binding: BindingT<'model, 'msg, 'vm>) : BindingT<'model, 'msg, 'vm> =
+    binding
+    |> mapData addCaching
+
+  /// <summary>
+  ///   Adds validation to the given binding using <c>INotifyDataErrorInfo</c>.
+  /// </summary>
+  /// <param name="validate">Returns the errors associated with the given model.</param>
+  /// <param name="binding">The binding to which validation is added.</param>
+  let addValidation (validate: 'model -> string list) (binding: BindingT<'model, 'msg, 'vm>) : BindingT<'model, 'msg, 'vm> =
+    binding
+    |> (addValidation validate |> mapData)
+
+  /// <summary>
+  ///   Adds laziness to the updating of the given binding. If the models are considered equal,
+  ///   then updating of the given binding is skipped.
+  /// </summary>
+  /// <param name="equals">Updating skipped when this function returns <c>true</c>.</param>
+  /// <param name="binding">The binding to which the laziness is added.</param>
+  let addLazy (equals: 'model -> 'model -> bool) (binding: BindingT<'model, 'msg, 'vm>) : BindingT<'model, 'msg, 'vm> =
+    binding
+    |> (addLazy equals |> mapData)
+
+  /// <summary>
+  ///   Accepts a function that can alter the message stream.
+  ///   Ideally suited for use with Reactive Extensions.
+  ///   <code>
+  ///     open FSharp.Control.Reactive
+  ///     let delay dispatch =
+  ///       let subject = Subject.broadcast
+  ///       let observable = subject :&gt; System.IObservable&lt;_&gt;
+  ///       observable
+  ///       |&gt; Observable.delay (System.TimeSpan.FromSeconds 1.0)
+  ///       |&gt; Observable.subscribe dispatch
+  ///       |&gt; ignore
+  ///       subject.OnNext
+  ///
+  ///     // ...
+  ///
+  ///     binding |&gt; Binding.alterMsgStream delay
+  ///   </code>
+  /// </summary>
+  /// <param name="alteration">The function that will alter the message stream.</param>
+  /// <param name="binding">The binding to which the message stream is altered.</param>
+  let alterMsgStream (alteration: ('b -> unit) -> 'a -> unit) (binding: BindingT<'model, 'a, 'vm>) : BindingT<'model, 'b, 'vm> =
+    binding
+    |> (alterMsgStream alteration |> mapData)
+
+  module OneWay =
+    open BindingData.OneWay
+
+    let opt =
+      create id
+      |> createStatic
+
+
+  module OneWayToSource =
+    open BindingData.OneWayToSource
+    
+    let id =
+      create (fun obj _ -> obj)
+      |> createStatic
+
+  module Cmd =
+    open BindingData.Cmd
+
+    let createWithParam exec canExec autoRequery =
+      createWithParam exec canExec autoRequery
+      |> createStatic
+
+  module SubModel =
+    open BindingData.SubModel
+
+    let opt createVm : StaticBindingT<'bindingModel voption, 'msg, 'viewModel :> ISubModel<'bindingModel, 'msg>> =
+      create id createVm (fun ((vm: #ISubModel<'bindingModel,'msg>),m) -> vm.StaticHelper.UpdateModel(m)) (fun _ m -> m)
+      |> createStatic
+
+
+[<AllowNullLiteral>]
+type InnerExampleViewModel(args) as this =
+  interface ISubModel<string, int64> with
+    member _.StaticHelper = StaticHelper.create args (fun () -> this)
+    
+[<AllowNullLiteral>]
+type ExampleViewModel(args) as this =
+  let staticHelper = StaticHelper.create args (fun () -> this)
+
+  member _.Model
+    with get() = BindingT.OneWay.opt |> staticHelper.GetValue
+    and set(v) = BindingT.OneWayToSource.id >> BindingT.mapMsg int32<string> |> staticHelper.SetValue(v)
+  member _.Command = BindingT.Cmd.createWithParam (fun _ _ -> ValueNone) (fun _ _ -> true) false |> staticHelper.GetValue
+  member _.SubModel = BindingT.SubModel.opt InnerExampleViewModel >> BindingT.mapModel ValueSome >> BindingT.mapMsg int32 |> staticHelper.GetValue

--- a/src/Elmish.WPF/BindingT.fs
+++ b/src/Elmish.WPF/BindingT.fs
@@ -82,7 +82,7 @@ module BindingT =
     binding
     |> (alterMsgStream alteration |> mapData)
 
-  module OneWay =
+  module Get =
     open BindingData.OneWay
 
     let id<'a, 'msg> =
@@ -94,7 +94,7 @@ module BindingT =
       >> mapModel get
 
 
-  module OneWayToSource =
+  module Set =
     open BindingData.OneWayToSource
     
     let id<'model, 'a> =
@@ -126,7 +126,7 @@ type ExampleViewModel(args) as this =
   let staticHelper = StaticHelper.create args (fun () -> this)
 
   member _.Model
-    with get() = BindingT.OneWay.id |> staticHelper.GetValue()
-    and set(v) = BindingT.OneWay.id >> BindingT.mapMsg int32<string> |> staticHelper.SetValue(v)
+    with get() = BindingT.Get.id |> staticHelper.GetValue()
+    and set(v) = BindingT.Get.id >> BindingT.mapMsg int32<string> |> staticHelper.SetValue(v)
   member _.Command = BindingT.Cmd.createWithParam (fun _ _ -> ValueNone) (fun _ _ -> true) false |> staticHelper.GetValue()
   member _.SubModel = BindingT.SubModel.opt InnerExampleViewModel >> BindingT.mapModel ValueSome >> BindingT.mapMsg int32 |> staticHelper.GetValue()

--- a/src/Elmish.WPF/BindingT.fs
+++ b/src/Elmish.WPF/BindingT.fs
@@ -85,16 +85,20 @@ module BindingT =
   module OneWay =
     open BindingData.OneWay
 
-    let opt =
-      create id
+    let id<'a, 'msg> =
+      id<'a, 'msg>
       |> createStatic
+
+    let get get =
+      id
+      >> mapModel get
 
 
   module OneWayToSource =
     open BindingData.OneWayToSource
     
-    let id =
-      create (fun obj _ -> obj)
+    let id<'model, 'a> =
+      id<'model, 'a>
       |> createStatic
 
   module Cmd =
@@ -108,7 +112,7 @@ module BindingT =
     open BindingData.SubModel
 
     let opt createVm : StaticBindingT<'bindingModel voption, 'msg, 'viewModel :> ISubModel<'bindingModel, 'msg>> =
-      create id createVm (fun ((vm: #ISubModel<'bindingModel,'msg>),m) -> vm.StaticHelper.UpdateModel(m)) (fun _ m -> m)
+      create createVm (fun ((vm: #ISubModel<'bindingModel,'msg>),m) -> vm.StaticHelper.UpdateModel(m))
       |> createStatic
 
 
@@ -122,7 +126,7 @@ type ExampleViewModel(args) as this =
   let staticHelper = StaticHelper.create args (fun () -> this)
 
   member _.Model
-    with get() = BindingT.OneWay.opt |> staticHelper.GetValue
-    and set(v) = BindingT.OneWayToSource.id >> BindingT.mapMsg int32<string> |> staticHelper.SetValue(v)
+    with get() = BindingT.OneWay.id |> staticHelper.GetValue
+    and set(v) = BindingT.OneWay.id >> BindingT.mapMsg int32<string> |> staticHelper.SetValue(v)
   member _.Command = BindingT.Cmd.createWithParam (fun _ _ -> ValueNone) (fun _ _ -> true) false |> staticHelper.GetValue
   member _.SubModel = BindingT.SubModel.opt InnerExampleViewModel >> BindingT.mapModel ValueSome >> BindingT.mapMsg int32 |> staticHelper.GetValue

--- a/src/Elmish.WPF/BindingT.fs
+++ b/src/Elmish.WPF/BindingT.fs
@@ -19,7 +19,7 @@ module BindingT =
   let mapMsg (f: 'a -> 'b) (binding: BindingT<'model, 'a, 'vm>) = f |> mapMsg |> mapData <| binding
 
   /// Set the message of a binding with access to the model.
-  let SetMsgWithModel (f: 'model -> 'b) (binding: BindingT<'model, 'a, 'vm>) = f |> setMsgWithModel |> mapData <| binding
+  let setMsgWithModel (f: 'model -> 'b) (binding: BindingT<'model, 'a, 'vm>) = f |> setMsgWithModel |> mapData <| binding
 
   /// Set the message of a binding.
   let setMsg (msg: 'b) (binding: BindingT<'model, 'a, 'vm>) = msg |> setMsg |> mapData <| binding

--- a/src/Elmish.WPF/BindingVmHelpers.fs
+++ b/src/Elmish.WPF/BindingVmHelpers.fs
@@ -409,7 +409,7 @@ type Initialize<'t>
           let toMsg = fun msg -> d.ToMsg (getCurrentModel ()) msg
           let chain = LoggingViewModelArgs.getNameChainFor nameChain name
           d.GetModel initialModel
-          |> ValueOption.map (fun m -> ViewModelArgs.create m (toMsg >> dispatch) chain loggingArgs)
+          |> ValueOption.map (fun m -> ViewModelArgs.createWithLogging m (toMsg >> dispatch) chain loggingArgs)
           |> ValueOption.map d.CreateViewModel
           |> (fun vm -> let mutable vm = vm in { SubModelData = d; Dispatch = dispatch; GetVm = (fun () -> vm); SetVm = fun nvm -> vm <- nvm })
           |> SubModel
@@ -428,7 +428,7 @@ type Initialize<'t>
                 SetVmWinState = fun vmState -> vmWinState <- vmState }
           | WindowState.Hidden m ->
               let chain = LoggingViewModelArgs.getNameChainFor nameChain name
-              let args = ViewModelArgs.create m (toMsg >> dispatch) chain loggingArgs
+              let args = ViewModelArgs.createWithLogging m (toMsg >> dispatch) chain loggingArgs
               let vm = d.CreateViewModel args
               let winRef = WeakReference<_>(null)
               let preventClose = ref true
@@ -443,7 +443,7 @@ type Initialize<'t>
                 SetVmWinState = fun vm -> vmWinState <- vm }
           | WindowState.Visible m ->
               let chain = LoggingViewModelArgs.getNameChainFor nameChain name
-              let args = ViewModelArgs.create m (toMsg >> dispatch) chain loggingArgs
+              let args = ViewModelArgs.createWithLogging m (toMsg >> dispatch) chain loggingArgs
               let vm = d.CreateViewModel args
               let winRef = WeakReference<_>(null)
               let preventClose = ref true
@@ -466,7 +466,7 @@ type Initialize<'t>
             |> Seq.indexed
             |> Seq.map (fun (idx, m) ->
                  let chain = LoggingViewModelArgs.getNameChainForItem nameChain name (idx |> string)
-                 let args = ViewModelArgs.create m (fun msg -> toMsg (idx, msg) |> dispatch) chain loggingArgs
+                 let args = ViewModelArgs.createWithLogging m (fun msg -> toMsg (idx, msg) |> dispatch) chain loggingArgs
                  d.CreateViewModel args)
             |> d.CreateCollection
           { SubModelSeqUnkeyedData = d
@@ -482,7 +482,7 @@ type Initialize<'t>
             |> Seq.map (fun m ->
                  let mId = d.BmToId m
                  let chain = LoggingViewModelArgs.getNameChainForItem nameChain name (mId |> string)
-                 let args = ViewModelArgs.create m (fun msg -> toMsg (mId, msg) |> dispatch) chain loggingArgs
+                 let args = ViewModelArgs.createWithLogging m (fun msg -> toMsg (mId, msg) |> dispatch) chain loggingArgs
                  d.CreateViewModel args)
             |> d.CreateCollection
           { SubModelSeqKeyedData = d
@@ -574,7 +574,7 @@ type Update
         | ValueNone, ValueSome m ->
             let toMsg = fun msg -> d.ToMsg (getCurrentModel ()) msg
             let chain = LoggingViewModelArgs.getNameChainFor nameChain name
-            let args = ViewModelArgs.create m (toMsg >> b.Dispatch) chain loggingArgs
+            let args = ViewModelArgs.createWithLogging m (toMsg >> b.Dispatch) chain loggingArgs
             b.SetVm (ValueSome <| d.CreateViewModel(args))
             [ PropertyChanged name ]
         | ValueSome vm, ValueSome m ->
@@ -623,7 +623,7 @@ type Update
           let newVm model =
             let toMsg = fun msg -> d.ToMsg (getCurrentModel ()) msg
             let chain = LoggingViewModelArgs.getNameChainFor nameChain name
-            let args = ViewModelArgs.create model (toMsg >> b.Dispatch) chain loggingArgs
+            let args = ViewModelArgs.createWithLogging model (toMsg >> b.Dispatch) chain loggingArgs
             d.CreateViewModel args
 
           match b.GetVmWinState(), d.GetState newModel with
@@ -664,7 +664,7 @@ type Update
           let d = b.SubModelSeqUnkeyedData
           let create m idx =
             let chain = LoggingViewModelArgs.getNameChainForItem nameChain name (idx |> string)
-            let args = ViewModelArgs.create m (fun msg -> d.ToMsg (getCurrentModel ()) (idx, msg) |> b.Dispatch) chain loggingArgs
+            let args = ViewModelArgs.createWithLogging m (fun msg -> d.ToMsg (getCurrentModel ()) (idx, msg) |> b.Dispatch) chain loggingArgs
             d.CreateViewModel args
           let update vm m = d.UpdateViewModel (vm, m)
           Merge.unkeyed create update b.Vms (d.GetModels newModel)
@@ -673,7 +673,7 @@ type Update
           let d = b.SubModelSeqKeyedData
           let create m id =
             let chain = LoggingViewModelArgs.getNameChainForItem nameChain name (id |> string)
-            let args = ViewModelArgs.create m (fun msg -> d.ToMsg (getCurrentModel ()) (id, msg) |> b.Dispatch) chain loggingArgs
+            let args = ViewModelArgs.createWithLogging m (fun msg -> d.ToMsg (getCurrentModel ()) (id, msg) |> b.Dispatch) chain loggingArgs
             d.CreateViewModel args
           let update vm m = d.UpdateViewModel (vm, m)
           let newSubModels = newModel |> d.GetSubModels |> Seq.toArray

--- a/src/Elmish.WPF/BindingVmHelpers.fs
+++ b/src/Elmish.WPF/BindingVmHelpers.fs
@@ -95,9 +95,9 @@ type OneWayToSourceBinding<'model, 'a> = {
   Set: 'a -> 'model -> unit
 }
 
-type OneWaySeqBinding<'model, 'a, 'id when 'id : equality> = {
-  OneWaySeqData: OneWaySeqData<'model, 'a, 'id>
-  Values: CollectionTarget<'a>
+type OneWaySeqBinding<'model, 'a, 'aCollection, 'id when 'id : equality> = {
+  OneWaySeqData: OneWaySeqData<'model, 'a, 'aCollection, 'id>
+  Values: CollectionTarget<'a, 'aCollection>
 }
 
 type TwoWayBinding<'model, 'a> = {
@@ -117,14 +117,14 @@ type SubModelWinBinding<'model, 'msg, 'bindingModel, 'bindingMsg, 'vm> = {
   VmWinState: WindowState<'vm> ref
 }
 
-type SubModelSeqUnkeyedBinding<'model, 'msg, 'bindingModel, 'bindingMsg, 'vm> = {
-  SubModelSeqUnkeyedData: SubModelSeqUnkeyedData<'model, 'msg, 'bindingModel, 'bindingMsg, 'vm>
-  Vms: CollectionTarget<'vm>
+type SubModelSeqUnkeyedBinding<'model, 'msg, 'bindingModel, 'bindingMsg, 'vm, 'vmCollection> = {
+  SubModelSeqUnkeyedData: SubModelSeqUnkeyedData<'model, 'msg, 'bindingModel, 'bindingMsg, 'vm, 'vmCollection>
+  Vms: CollectionTarget<'vm, 'vmCollection>
 }
 
-type SubModelSeqKeyedBinding<'model, 'msg, 'bindingModel, 'bindingMsg, 'vm, 'id when 'id : equality> =
-  { SubModelSeqKeyedData: SubModelSeqKeyedData<'model, 'msg, 'bindingModel, 'bindingMsg, 'vm, 'id>
-    Vms: CollectionTarget<'vm> }
+type SubModelSeqKeyedBinding<'model, 'msg, 'bindingModel, 'bindingMsg, 'vm, 'vmCollection, 'id when 'id : equality> =
+  { SubModelSeqKeyedData: SubModelSeqKeyedData<'model, 'msg, 'bindingModel, 'bindingMsg, 'vm, 'vmCollection, 'id>
+    Vms: CollectionTarget<'vm, 'vmCollection> }
 
   member b.FromId(id: 'id) =
     b.Vms.Enumerate ()
@@ -151,13 +151,13 @@ type SubModelSelectedItemBinding<'model, 'msg, 'bindingModel, 'bindingMsg, 'vm, 
 type BaseVmBinding<'model, 'msg, 't> =
   | OneWay of OneWayBinding<'model, 't>
   | OneWayToSource of OneWayToSourceBinding<'model, 't>
-  | OneWaySeq of OneWaySeqBinding<'model, obj, obj>
+  | OneWaySeq of OneWaySeqBinding<'model, obj, 't, obj>
   | TwoWay of TwoWayBinding<'model, 't>
   | Cmd of cmd: Command
   | SubModel of SubModelBinding<'model, 'msg, obj, obj, 't>
   | SubModelWin of SubModelWinBinding<'model, 'msg, obj, obj, 't>
-  | SubModelSeqUnkeyed of SubModelSeqUnkeyedBinding<'model, 'msg, obj, obj, obj>
-  | SubModelSeqKeyed of SubModelSeqKeyedBinding<'model, 'msg, obj, obj, obj, obj>
+  | SubModelSeqUnkeyed of SubModelSeqUnkeyedBinding<'model, 'msg, obj, obj, obj, 't>
+  | SubModelSeqKeyed of SubModelSeqKeyedBinding<'model, 'msg, obj, obj, obj, 't, obj>
   | SubModelSelectedItem of SubModelSelectedItemBinding<'model, 'msg, obj, obj, 't, obj>
 
 
@@ -621,7 +621,7 @@ type Get<'t>(nameChain: string) =
     | OneWay { OneWayData = d } -> d.Get model |> Ok
     | TwoWay b -> b.Get model |> Ok
     | OneWayToSource _ -> GetError.OneWayToSource |> Error
-    | OneWaySeq { Values = vals } -> vals.BoxedCollection() |> unbox |> Ok
+    | OneWaySeq { Values = vals } -> vals.GetCollection() |> Ok
     | Cmd cmd -> cmd |> unbox |> Ok
     | SubModel { Vm = vm } ->
         vm.Value
@@ -633,7 +633,7 @@ type Get<'t>(nameChain: string) =
         |> ValueOption.toNull
         |> Result.mapError GetError.ToNullError
     | SubModelSeqUnkeyed { Vms = vms }
-    | SubModelSeqKeyed { Vms = vms } -> vms.BoxedCollection () |> unbox |> Ok
+    | SubModelSeqKeyed { Vms = vms } -> vms.GetCollection () |> Ok
     | SubModelSelectedItem b ->
         b.TypedGet model
         |> function

--- a/src/Elmish.WPF/BindingVmHelpers.fs
+++ b/src/Elmish.WPF/BindingVmHelpers.fs
@@ -209,6 +209,97 @@ and VmBinding<'model, 'msg, 't> =
         Errors = currentModel |> validate |> ref }
       |> Validatation
 
+module internal MapOutputType =
+  let baseCase (fOut: 'a -> 'b) (fIn: 'b -> 'a) (data: BaseVmBinding<'model, 'msg, 'a>) : BaseVmBinding<'model, 'msg, 'b> =
+    match data with
+    | OneWay b -> OneWay { OneWayData = { Get = b.OneWayData.Get >> fOut } }
+    | OneWayToSource b -> OneWayToSource { Set = fIn >> b.Set }
+    | Cmd b -> Cmd b
+    | TwoWay b -> TwoWay { Get = b.Get >> fOut; Set = fIn >> b.Set }
+    | OneWaySeq b -> OneWaySeq {
+        OneWaySeqData = {
+          Get = b.OneWaySeqData.Get
+          CreateCollection = b.OneWaySeqData.CreateCollection >> CollectionTarget.mapCollection fOut
+          GetId = b.OneWaySeqData.GetId
+          ItemEquals = b.OneWaySeqData.ItemEquals }
+        Values = b.Values |> CollectionTarget.mapCollection fOut }
+    | SubModel b -> SubModel {
+        SubModelData = {
+          GetModel = b.SubModelData.GetModel
+          CreateViewModel = b.SubModelData.CreateViewModel >> fOut
+          UpdateViewModel = (fun (vm,m) -> b.SubModelData.UpdateViewModel (fIn vm, m))
+          ToMsg = b.SubModelData.ToMsg }
+        Dispatch = b.Dispatch
+        GetVm = b.GetVm >> ValueOption.map fOut
+        SetVm = ValueOption.map fIn >> b.SetVm }
+    | SubModelWin b -> SubModelWin {
+        SubModelWinData = {
+          GetState = b.SubModelWinData.GetState
+          CreateViewModel = b.SubModelWinData.CreateViewModel >> fOut
+          UpdateViewModel = (fun (vm,m) -> b.SubModelWinData.UpdateViewModel (fIn vm, m))
+          ToMsg = b.SubModelWinData.ToMsg
+          GetWindow = b.SubModelWinData.GetWindow
+          IsModal = b.SubModelWinData.IsModal
+          OnCloseRequested = b.SubModelWinData.OnCloseRequested }
+        Dispatch = b.Dispatch
+        WinRef = b.WinRef
+        PreventClose = b.PreventClose
+        GetVmWinState = b.GetVmWinState >> WindowState.map fOut
+        SetVmWinState = WindowState.map fIn >> b.SetVmWinState }
+    | SubModelSeqUnkeyed b -> SubModelSeqUnkeyed {
+        SubModelSeqUnkeyedData = {
+          GetModels = b.SubModelSeqUnkeyedData.GetModels
+          CreateViewModel = b.SubModelSeqUnkeyedData.CreateViewModel
+          CreateCollection = b.SubModelSeqUnkeyedData.CreateCollection >> CollectionTarget.mapCollection fOut
+          UpdateViewModel = b.SubModelSeqUnkeyedData.UpdateViewModel
+          ToMsg = b.SubModelSeqUnkeyedData.ToMsg }
+        Dispatch = b.Dispatch
+        Vms = b.Vms |> CollectionTarget.mapCollection fOut }
+    | SubModelSeqKeyed b -> SubModelSeqKeyed {
+        SubModelSeqKeyedData = { 
+          GetSubModels = b.SubModelSeqKeyedData.GetSubModels
+          CreateViewModel = b.SubModelSeqKeyedData.CreateViewModel
+          CreateCollection = b.SubModelSeqKeyedData.CreateCollection >> CollectionTarget.mapCollection fOut
+          UpdateViewModel = b.SubModelSeqKeyedData.UpdateViewModel
+          ToMsg = b.SubModelSeqKeyedData.ToMsg
+          BmToId = b.SubModelSeqKeyedData.BmToId
+          VmToId = b.SubModelSeqKeyedData.VmToId }
+        Dispatch = b.Dispatch
+        Vms = b.Vms |> CollectionTarget.mapCollection fOut }
+    | SubModelSelectedItem b -> SubModelSelectedItem {
+        Get = b.Get
+        Set = b.Set
+        SubModelSeqBindingName = b.SubModelSeqBindingName
+        SelectedItemBinding = {
+          VmToId = fIn >> b.SelectedItemBinding.VmToId
+          FromId = b.SelectedItemBinding.FromId >> Option.map fOut } }
+
+  let rec recursivecase<'model, 'msg, 'a, 'b> (fOut: 'a -> 'b) (fIn: 'b -> 'a) (data: VmBinding<'model, 'msg, 'a>) : VmBinding<'model, 'msg, 'b> =
+    match data with
+    | BaseVmBinding b -> baseCase fOut fIn b |> BaseVmBinding
+    | Cached b -> Cached {
+        Binding = recursivecase fOut fIn b.Binding
+        GetCache = b.GetCache >> Option.map fOut
+        SetCache = Option.map fIn >> b.SetCache
+      }
+    | AlterMsgStream b -> AlterMsgStream {
+        Binding = recursivecase fOut fIn b.Binding
+        Dispatch = b.Dispatch
+        Get = b.Get
+      }
+    | Lazy b -> Lazy {
+        Get = b.Get
+        Dispatch = b.Dispatch
+        Binding = recursivecase fOut fIn b.Binding
+        Equals = b.Equals
+      }
+    | Validatation b -> Validatation {
+        Binding = recursivecase fOut fIn b.Binding
+        Errors = b.Errors
+        Validate = b.Validate
+      }
+
+
 type SubModelSelectedItemLast() =
 
   member _.Base(data: BaseBindingData<'model, 'msg, obj>) : int =

--- a/src/Elmish.WPF/BindingVmHelpers.fs
+++ b/src/Elmish.WPF/BindingVmHelpers.fs
@@ -210,7 +210,7 @@ and VmBinding<'model, 'msg, 't> =
       |> Validatation
 
 module internal MapOutputType =
-  let baseCase (fOut: 'a -> 'b) (fIn: 'b -> 'a) (data: BaseVmBinding<'model, 'msg, 'a>) : BaseVmBinding<'model, 'msg, 'b> =
+  let private baseCase (fOut: 'a -> 'b) (fIn: 'b -> 'a) (data: BaseVmBinding<'model, 'msg, 'a>) : BaseVmBinding<'model, 'msg, 'b> =
     match data with
     | OneWay b -> OneWay { OneWayData = { Get = b.OneWayData.Get >> fOut } }
     | OneWayToSource b -> OneWayToSource { Set = fIn >> b.Set }
@@ -274,7 +274,7 @@ module internal MapOutputType =
           VmToId = fIn >> b.SelectedItemBinding.VmToId
           FromId = b.SelectedItemBinding.FromId >> Option.map fOut } }
 
-  let rec recursivecase<'model, 'msg, 'a, 'b> (fOut: 'a -> 'b) (fIn: 'b -> 'a) (data: VmBinding<'model, 'msg, 'a>) : VmBinding<'model, 'msg, 'b> =
+  let rec private recursivecase<'model, 'msg, 'a, 'b> (fOut: 'a -> 'b) (fIn: 'b -> 'a) (data: VmBinding<'model, 'msg, 'a>) : VmBinding<'model, 'msg, 'b> =
     match data with
     | BaseVmBinding b -> baseCase fOut fIn b |> BaseVmBinding
     | Cached b -> Cached {
@@ -298,6 +298,9 @@ module internal MapOutputType =
         Errors = b.Errors
         Validate = b.Validate
       }
+
+  let boxVm b = recursivecase box unbox b
+  let unboxVm b = recursivecase unbox box b
 
 
 type SubModelSelectedItemLast() =

--- a/src/Elmish.WPF/DynamicViewModel.fs
+++ b/src/Elmish.WPF/DynamicViewModel.fs
@@ -18,10 +18,6 @@ type Binding<'model, 'msg> =
 [<AutoOpen>]
 module internal Helpers =
 
-  let createBinding data name =
-    { Name = name
-      Data = data |> BindingData.boxT }
-
   type SubModelSelectedItemLast with
     member this.CompareBindings() : Binding<'model, 'msg> -> Binding<'model, 'msg> -> int =
       fun a b -> this.Recursive(a.Data) - this.Recursive(b.Data)

--- a/src/Elmish.WPF/DynamicViewModel.fs
+++ b/src/Elmish.WPF/DynamicViewModel.fs
@@ -20,7 +20,7 @@ module internal Helpers =
 
   let createBinding data name =
     { Name = name
-      Data = data }
+      Data = data |> BindingData.boxT }
 
   type SubModelSelectedItemLast with
     member this.CompareBindings() : Binding<'model, 'msg> -> Binding<'model, 'msg> -> int =

--- a/src/Elmish.WPF/DynamicViewModel.fs
+++ b/src/Elmish.WPF/DynamicViewModel.fs
@@ -12,7 +12,7 @@ open BindingVmHelpers
 type Binding<'model, 'msg> =
   internal
     { Name: string
-      Data: BindingData<'model, 'msg> }
+      Data: BindingData<'model, 'msg, obj> }
 
 
 [<AutoOpen>]
@@ -57,7 +57,7 @@ type [<AllowNullLiteral>] internal DynamicViewModel<'model, 'msg>
 
   let (bindings, validationErrors) =
     log.LogTrace("[{BindingNameChain}] Initializing bindings", nameChain)
-    let bindingDict = Dictionary<string, VmBinding<'model, 'msg>>(bindings.Length)
+    let bindingDict = Dictionary<string, VmBinding<'model, 'msg, obj>>(bindings.Length)
     let getFunctionsForSubModelSelectedItem name =
       bindingDict
       |> Dictionary.tryFind name
@@ -119,6 +119,7 @@ type [<AllowNullLiteral>] internal DynamicViewModel<'model, 'msg>
               match e with
               | GetError.OneWayToSource -> log.LogError("[{BindingNameChain}] TryGetMember FAILED: Binding {BindingName} is read-only", nameChain, binder.Name)
               | GetError.SubModelSelectedItem d -> log.LogError("[{BindingNameChain}] TryGetMember FAILED: Failed to find an element of the SubModelSeq binding {SubModelSeqBindingName} with ID {ID} in the getter for the binding {BindingName}", d.NameChain, d.SubModelSeqBindingName, d.Id, binder.Name)
+              | GetError.ToNullError ValueOption.ToNullError.ValueCannotBeNull -> log.LogError("[{BindingNameChain}] TryGetMember FAILED: Binding {BindingName} is null, but type is non-nullable", nameChain, binder.Name)
               false
         with e ->
           log.LogError(e, "[{BindingNameChain}] TryGetMember FAILED: Exception thrown while processing binding {BindingName}", nameChain, binder.Name)

--- a/src/Elmish.WPF/DynamicViewModel.fs
+++ b/src/Elmish.WPF/DynamicViewModel.fs
@@ -94,7 +94,7 @@ type [<AllowNullLiteral>] internal DynamicViewModel<'model, 'msg>
   member internal _.UpdateModel (newModel: 'model) : unit =
     let eventsToRaise =
       bindings
-      |> Seq.collect (fun (Kvp (name, binding)) -> Update(loggingArgs, name).Recursive(ValueNone, (fun () -> currentModel), newModel, dispatch, binding))
+      |> Seq.collect (fun (Kvp (name, binding)) -> Update(loggingArgs, name).Recursive(ValueNone, (fun () -> currentModel), newModel, binding))
       |> Seq.toList
     currentModel <- newModel
     eventsToRaise

--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -44,10 +44,11 @@
     <Compile Include="ViewModelArgs.fs" />
     <Compile Include="BindingData.fs" />
     <Compile Include="BindingVmHelpers.fs" />
-    <Compile Include="StaticViewModel.fs" />
-    <Compile Include="BindingT.fs" />
     <Compile Include="DynamicViewModel.fs" />
     <Compile Include="Binding.fs" />
+    <Compile Include="StaticViewModel.fs" />
+    <Compile Include="BindingT.fs" />
+    <Compile Include="StaticDynamicInterop.fs" />
     <Compile Include="ViewModelModule.fs" />
     <Compile Include="WpfProgram.fs" />
   </ItemGroup>

--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -44,6 +44,7 @@
     <Compile Include="ViewModelArgs.fs" />
     <Compile Include="BindingData.fs" />
     <Compile Include="BindingVmHelpers.fs" />
+    <Compile Include="StaticViewModel.fs" />
     <Compile Include="DynamicViewModel.fs" />
     <Compile Include="Binding.fs" />
     <Compile Include="ViewModelModule.fs" />

--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -45,6 +45,7 @@
     <Compile Include="BindingData.fs" />
     <Compile Include="BindingVmHelpers.fs" />
     <Compile Include="StaticViewModel.fs" />
+    <Compile Include="BindingT.fs" />
     <Compile Include="DynamicViewModel.fs" />
     <Compile Include="Binding.fs" />
     <Compile Include="ViewModelModule.fs" />

--- a/src/Elmish.WPF/InternalUtils.fs
+++ b/src/Elmish.WPF/InternalUtils.fs
@@ -48,6 +48,10 @@ module Result =
     | Ok x -> f x
     | Error _ -> ()
 
+  let errorWith f = function
+    | Ok x -> x
+    | Error e -> f e
+
 
 [<RequireQualifiedAccess>]
 module ValueOption =

--- a/src/Elmish.WPF/Merge.fs
+++ b/src/Elmish.WPF/Merge.fs
@@ -16,7 +16,7 @@ type DuplicateIdException (sourceOrTarget: SourceOrTarget, index1: int, index2: 
   member this.Index2 = index2
   member this.Id = id
 
-type CollectionTarget<'a> =
+type CollectionTarget<'a, 'aCollection> =
   { GetLength: unit -> int
     GetAt: int -> 'a
     Append: 'a -> unit
@@ -26,7 +26,7 @@ type CollectionTarget<'a> =
     Move: int * int -> unit
     Clear: unit -> unit
     Enumerate: unit -> 'a seq
-    BoxedCollection: unit -> obj }
+    GetCollection: unit -> 'aCollection }
 
 module CollectionTarget =
 
@@ -40,9 +40,9 @@ module CollectionTarget =
       Move = oc.Move
       Clear = oc.Clear
       Enumerate = fun () -> upcast oc
-      BoxedCollection = fun () -> oc |> box }
+      GetCollection = fun () -> oc }
 
-  let map (fOut: 'a -> 'b) (fIn: 'b -> 'a) (ct: CollectionTarget<'a>) : CollectionTarget<'b> =
+  let map (fOut: 'a0 -> 'a1) (fIn: 'a1 -> 'a0) (ct: CollectionTarget<'a0, 'aCollection>) : CollectionTarget<'a1, 'aCollection> =
     { GetLength = ct.GetLength
       GetAt = ct.GetAt >> fOut
       Append = fIn >> ct.Append
@@ -52,7 +52,19 @@ module CollectionTarget =
       Move = ct.Move
       Clear = ct.Clear
       Enumerate = ct.Enumerate >> Seq.map fOut
-      BoxedCollection = ct.BoxedCollection }
+      GetCollection = ct.GetCollection }
+
+  let mapCollection (fOut: 'aCollection0 -> 'aCollection1) (ct: CollectionTarget<'a, 'aCollection0>) : CollectionTarget<'a, 'aCollection1> =
+    { GetLength = ct.GetLength
+      GetAt = ct.GetAt
+      Append = ct.Append
+      InsertAt = ct.InsertAt
+      SetAt = ct.SetAt
+      RemoveAt = ct.RemoveAt
+      Move = ct.Move
+      Clear = ct.Clear
+      Enumerate = ct.Enumerate
+      GetCollection = ct.GetCollection >> fOut }
 
 
 
@@ -61,7 +73,7 @@ module Merge =
   let unkeyed
       (create: 's -> int -> 't)
       (update: 't -> 's -> unit)
-      (target: CollectionTarget<'t>)
+      (target: CollectionTarget<'t, 'vmCollection>)
       (source: 's seq) =
     let mutable lastIdx = -1
     for (idx, s) in source |> Seq.indexed do
@@ -81,7 +93,7 @@ module Merge =
       (getTargetId: 't -> 'id)
       (create: 's -> 'id -> 't)
       (update: 't -> 's -> int -> unit)
-      (target: CollectionTarget<'t>)
+      (target: CollectionTarget<'t, 'vmCollection>)
       (source: 's array) =
     (*
      * Based on Elm's HTML.keyed

--- a/src/Elmish.WPF/StaticDynamicInterop.fs
+++ b/src/Elmish.WPF/StaticDynamicInterop.fs
@@ -1,0 +1,23 @@
+﻿namespace Elmish.WPF
+
+open System.Runtime.CompilerServices
+
+module StaticDynamicInterop =
+
+  module Binding =
+    let toBindingT binding = { DataT = binding.Data; Name = binding.Name }
+
+  module BindingT =
+    let toBinding bindingT = { Data = bindingT.DataT |> BindingData.boxT; Name = bindingT.Name }
+
+  type StaticHelper<'model, 'msg> with
+
+    member x.GetBinding ([<CallerMemberName>] ?memberName: string) =
+      fun (binding: string -> Binding<'model, 'msg>) ->
+        binding >> Binding.toBindingT
+        |> x.Get(?memberName = memberName)
+
+    member x.SetBinding (value, [<CallerMemberName>] ?memberName: string) =
+      fun (binding: string -> Binding<'model, 'msg>) ->
+        binding >> Binding.toBindingT
+        |> x.Set(value, ?memberName = memberName)

--- a/src/Elmish.WPF/StaticViewModel.fs
+++ b/src/Elmish.WPF/StaticViewModel.fs
@@ -1,0 +1,144 @@
+﻿module Elmish.WPF.StaticViewModel
+
+open System
+open System.Collections.Generic
+open System.ComponentModel
+open System.Runtime.CompilerServices
+open Microsoft.Extensions.Logging
+
+open Elmish.WPF.BindingVmHelpers
+
+
+
+type internal StaticHelper<'model, 'msg>(args: ViewModelArgs<'model, 'msg>, getSender: unit -> obj) =
+
+  let { initialModel = initialModel
+        dispatch = dispatch
+        loggingArgs = loggingArgs
+      } = args
+
+  let { log = log
+        nameChain = nameChain
+      } = loggingArgs
+
+  let mutable currentModel = initialModel
+
+  let propertyChanged = Event<PropertyChangedEventHandler, PropertyChangedEventArgs>()
+  let errorsChanged = DelegateEvent<EventHandler<DataErrorsChangedEventArgs>>()
+
+  let mutable getBindings = Dictionary<String, VmBinding<'model, 'msg, obj>>()
+  let mutable setBindings = Dictionary<String, VmBinding<'model, 'msg, obj>>()
+  let mutable validationErrors = Dictionary<String, String list ref>()
+
+  let raisePropertyChanged name =
+    log.LogTrace("[{BindingNameChain}] PropertyChanged {BindingName}", nameChain, name)
+    propertyChanged.Trigger(getSender (), PropertyChangedEventArgs name)
+  let raiseCanExecuteChanged (cmd: Command) =
+    cmd.RaiseCanExecuteChanged ()
+  let raiseErrorsChanged name =
+    log.LogTrace("[{BindingNameChain}] ErrorsChanged {BindingName}", nameChain, name)
+    errorsChanged.Trigger([| getSender (); box <| DataErrorsChangedEventArgs name |])
+
+  let getFunctionsForSubModelSelectedItem name : SelectedItemBinding<obj, obj, 'a, obj> option =
+    getBindings
+    |> Dictionary.tryFind name
+    |> function
+      | Some b ->
+        let b = unbox<VmBinding<'model, 'msg, 'a>> b
+        match FuncsFromSubModelSeqKeyed().Recursive(b) with
+        | Some x ->
+          Some x
+        | None ->
+          log.LogError("SubModelSelectedItem binding referenced binding {SubModelSeqBindingName} but it is not a SubModelSeq binding", name)
+          None
+      | None ->
+        log.LogError("SubModelSelectedItem binding referenced binding {SubModelSeqBindingName} but no binding was found with that name", name)
+        None
+
+  member _.GetValue (binding: BindingData<'model, 'msg, 'a>, [<CallerMemberName>] ?memberName: string) =
+    option {
+      let! name = memberName
+
+      let! b =
+        option {
+          if getBindings.ContainsKey name then
+            return getBindings.Item name |> MapOutputType.recursivecase unbox box
+          else
+            //let binding = BindingData.mapVm box unbox binding
+            let! b =
+              Initialize(args.loggingArgs, name, getFunctionsForSubModelSelectedItem)
+                .Recursive(currentModel, dispatch, (fun () -> currentModel), binding)
+            do getBindings.Add (name, b |> MapOutputType.recursivecase box unbox)
+            return b
+          }
+      let c = Get(nameChain).Recursive(currentModel, b)
+      let! d =
+        match c with
+        | Ok x -> Some x
+        | Error _ -> None
+      return d
+    } |> Option.defaultValue null
+
+  member _.SetValue (value, [<CallerMemberName>] ?memberName: string) =
+    fun (binding: BindingData<'model, 'msg, 'a>) ->
+      option {
+        let! name = memberName
+
+        let! b =
+          option {
+            if setBindings.ContainsKey name then
+              return setBindings.Item name |> MapOutputType.recursivecase unbox box
+            else
+              //let binding = BindingData.mapVm box unbox binding
+              let! b =
+                Initialize(args.loggingArgs, name, getFunctionsForSubModelSelectedItem)
+                  .Recursive(currentModel, dispatch, (fun () -> currentModel), binding)
+              do setBindings.Add (name, b |> MapOutputType.recursivecase box unbox)
+              return b
+            }
+        let _c = Set(value).Recursive(currentModel, b)
+        return ()
+      } |> Option.defaultValue ()
+
+  member _.CurrentModel : 'model = currentModel
+
+  member _.UpdateModel (newModel: 'model) : unit =
+    let eventsToRaise =
+      getBindings
+      |> Seq.collect (fun (Kvp (name, binding)) -> Update(loggingArgs, name).Recursive(ValueSome currentModel, (fun () -> currentModel), newModel, binding))
+      |> Seq.toList
+    currentModel <- newModel
+    eventsToRaise
+    |> List.iter (function
+      | ErrorsChanged name -> name |> raiseErrorsChanged
+      | PropertyChanged name -> name |> raisePropertyChanged
+      | CanExecuteChanged cmd -> cmd |> raiseCanExecuteChanged)
+
+  interface INotifyPropertyChanged with
+    [<CLIEvent>]
+    member _.PropertyChanged = propertyChanged.Publish
+
+  interface INotifyDataErrorInfo with
+    [<CLIEvent>]
+    member _.ErrorsChanged = errorsChanged.Publish
+    member _.HasErrors =
+      // WPF calls this too often, so don't log https://github.com/elmish/Elmish.WPF/issues/354
+      validationErrors
+      |> Seq.map (fun (Kvp(_, errors)) -> errors.Value)
+      |> Seq.filter (not << List.isEmpty)
+      |> (not << Seq.isEmpty)
+    member _.GetErrors name =
+      let name = name |> Option.ofObj |> Option.defaultValue "<null>" // entity-level errors are being requested when given null or ""  https://docs.microsoft.com/en-us/dotnet/api/system.componentmodel.inotifydataerrorinfo.geterrors#:~:text=null%20or%20Empty%2C%20to%20retrieve%20entity-level%20errors
+      log.LogTrace("[{BindingNameChain}] GetErrors {BindingName}", nameChain, name)
+      validationErrors
+      |> IReadOnlyDictionary.tryFind name
+      |> Option.map (fun errors -> errors.Value)
+      |> Option.defaultValue []
+      |> (fun x -> upcast x)
+
+type ExampleViewModel() as this =
+  let staticHelper = StaticHelper<String, Int32>(ViewModelArgs.simple "", fun () -> this)
+
+  member _.Model = BindingData.OneWay.create id |> staticHelper.GetValue
+  member _.Command = BindingData.Cmd.createWithParam (fun _ _ -> ValueNone) (fun _ _ -> true) false |> staticHelper.GetValue
+  member _.SubModel = BindingData.SubModel.create (fun x -> x |> ValueSome) (failwith "x") (failwith "y") (fun _x y -> y) |> staticHelper.GetValue

--- a/src/Elmish.WPF/StaticViewModel.fs
+++ b/src/Elmish.WPF/StaticViewModel.fs
@@ -1,4 +1,4 @@
-﻿module Elmish.WPF.StaticViewModel
+﻿namespace Elmish.WPF
 
 open System
 open System.Collections.Generic
@@ -144,135 +144,9 @@ type StaticHelper<'model, 'msg>(args: ViewModelArgs<'model, 'msg>, getSender: un
       |> Option.defaultValue []
       |> (fun x -> upcast x)
 
-[<AllowNullLiteral>]
-type ISubModel<'model, 'msg> =
-  abstract StaticHelper: StaticHelper<'model, 'msg>
-
 module StaticHelper =
   let create args getSender = StaticHelper(args, getSender)
 
-module BindingT =
-  let internal createStatic data name = { DataT = data; Name = name }
-  open BindingData
-
-  let internal mapData f binding =
-    { DataT = binding.DataT |> f
-      Name = binding.Name }
-
-  /// Map the model of a binding via a contravariant mapping.
-  let mapModel (f: 'a -> 'b) (binding: BindingT<'b, 'msg, 'vm>) = f |> mapModel |> mapData <| binding
-
-  /// Map the message of a binding with access to the model via a covariant mapping.
-  let mapMsgWithModel (f: 'a -> 'model -> 'b) (binding: BindingT<'model, 'a, 'vm>) = f |> mapMsgWithModel |> mapData <| binding
-
-  /// Map the message of a binding via a covariant mapping.
-  let mapMsg (f: 'a -> 'b) (binding: BindingT<'model, 'a, 'vm>) = f |> mapMsg |> mapData <| binding
-
-  /// Set the message of a binding with access to the model.
-  let SetMsgWithModel (f: 'model -> 'b) (binding: BindingT<'model, 'a, 'vm>) = f |> setMsgWithModel |> mapData <| binding
-
-  /// Set the message of a binding.
-  let setMsg (msg: 'b) (binding: BindingT<'model, 'a, 'vm>) = msg |> setMsg |> mapData <| binding
-
-
-  /// Restrict the binding to models that satisfy the predicate after some model satisfies the predicate.
-  let addSticky (predicate: 'model -> bool) (binding: BindingT<'model, 'msg, 'vm>) = predicate |> addSticky |> mapData <| binding
-
-  /// <summary>
-  ///   Adds caching to the given binding.  The cache holds a single value and
-  ///   is invalidated after the given binding raises the
-  ///   <c>PropertyChanged</c> event.
-  /// </summary>
-  /// <param name="binding">The binding to which caching is added.</param>
-  let addCaching (binding: BindingT<'model, 'msg, 'vm>) : BindingT<'model, 'msg, 'vm> =
-    binding
-    |> mapData addCaching
-
-  /// <summary>
-  ///   Adds validation to the given binding using <c>INotifyDataErrorInfo</c>.
-  /// </summary>
-  /// <param name="validate">Returns the errors associated with the given model.</param>
-  /// <param name="binding">The binding to which validation is added.</param>
-  let addValidation (validate: 'model -> string list) (binding: BindingT<'model, 'msg, 'vm>) : BindingT<'model, 'msg, 'vm> =
-    binding
-    |> (addValidation validate |> mapData)
-
-  /// <summary>
-  ///   Adds laziness to the updating of the given binding. If the models are considered equal,
-  ///   then updating of the given binding is skipped.
-  /// </summary>
-  /// <param name="equals">Updating skipped when this function returns <c>true</c>.</param>
-  /// <param name="binding">The binding to which the laziness is added.</param>
-  let addLazy (equals: 'model -> 'model -> bool) (binding: BindingT<'model, 'msg, 'vm>) : BindingT<'model, 'msg, 'vm> =
-    binding
-    |> (addLazy equals |> mapData)
-
-  /// <summary>
-  ///   Accepts a function that can alter the message stream.
-  ///   Ideally suited for use with Reactive Extensions.
-  ///   <code>
-  ///     open FSharp.Control.Reactive
-  ///     let delay dispatch =
-  ///       let subject = Subject.broadcast
-  ///       let observable = subject :&gt; System.IObservable&lt;_&gt;
-  ///       observable
-  ///       |&gt; Observable.delay (System.TimeSpan.FromSeconds 1.0)
-  ///       |&gt; Observable.subscribe dispatch
-  ///       |&gt; ignore
-  ///       subject.OnNext
-  ///
-  ///     // ...
-  ///
-  ///     binding |&gt; Binding.alterMsgStream delay
-  ///   </code>
-  /// </summary>
-  /// <param name="alteration">The function that will alter the message stream.</param>
-  /// <param name="binding">The binding to which the message stream is altered.</param>
-  let alterMsgStream (alteration: ('b -> unit) -> 'a -> unit) (binding: BindingT<'model, 'a, 'vm>) : BindingT<'model, 'b, 'vm> =
-    binding
-    |> (alterMsgStream alteration |> mapData)
-
-  module OneWay =
-    open BindingData.OneWay
-
-    let opt =
-      create id
-      |> createStatic
-
-
-  module OneWayToSource =
-    open BindingData.OneWayToSource
-    
-    let id =
-      create (fun obj _ -> obj)
-      |> createStatic
-
-  module Cmd =
-    open BindingData.Cmd
-
-    let createWithParam exec canExec autoRequery =
-      createWithParam exec canExec autoRequery
-      |> createStatic
-
-  module SubModel =
-    open BindingData.SubModel
-
-    let opt createVm : StaticBindingT<'bindingModel voption, 'msg, 'viewModel :> ISubModel<'bindingModel, 'msg>> =
-      create id createVm (fun ((vm: #ISubModel<'bindingModel,'msg>),m) -> vm.StaticHelper.UpdateModel(m)) (fun _ m -> m)
-      |> createStatic
-
-
 [<AllowNullLiteral>]
-type InnerExampleViewModel(args) as this =
-  interface ISubModel<String, Int64> with
-    member _.StaticHelper = StaticHelper.create args (fun () -> this)
-    
-[<AllowNullLiteral>]
-type ExampleViewModel(args) as this =
-  let staticHelper = StaticHelper.create args (fun () -> this)
-
-  member _.Model
-    with get() = BindingT.OneWay.opt |> staticHelper.GetValue
-    and set(v) = BindingT.OneWayToSource.id >> BindingT.mapMsg int32<string> |> staticHelper.SetValue(v)
-  member _.Command = BindingT.Cmd.createWithParam (fun _ _ -> ValueNone) (fun _ _ -> true) false |> staticHelper.GetValue
-  member _.SubModel = BindingT.SubModel.opt InnerExampleViewModel >> BindingT.mapModel ValueSome >> BindingT.mapMsg int32 |> staticHelper.GetValue
+type ISubModel<'model, 'msg> =
+  abstract StaticHelper: StaticHelper<'model, 'msg>

--- a/src/Elmish.WPF/StaticViewModel.fs
+++ b/src/Elmish.WPF/StaticViewModel.fs
@@ -9,8 +9,9 @@ open Microsoft.Extensions.Logging
 open Elmish.WPF.BindingVmHelpers
 
 
+type StaticBinding<'model, 'msg, 'a> = internal { Data: BindingData<'model, 'msg, 'a> }
 
-type internal StaticHelper<'model, 'msg>(args: ViewModelArgs<'model, 'msg>, getSender: unit -> obj) =
+type StaticHelper<'model, 'msg>(args: ViewModelArgs<'model, 'msg>, getSender: unit -> obj) =
 
   let { initialModel = initialModel
         dispatch = dispatch
@@ -55,7 +56,7 @@ type internal StaticHelper<'model, 'msg>(args: ViewModelArgs<'model, 'msg>, getS
         log.LogError("SubModelSelectedItem binding referenced binding {SubModelSeqBindingName} but no binding was found with that name", name)
         None
 
-  member _.GetValue (binding: BindingData<'model, 'msg, 'a>, [<CallerMemberName>] ?memberName: string) =
+  member _.GetValue (binding: StaticBinding<'model, 'msg, 'a>, [<CallerMemberName>] ?memberName: string) =
     option {
       let! name = memberName
 
@@ -67,7 +68,7 @@ type internal StaticHelper<'model, 'msg>(args: ViewModelArgs<'model, 'msg>, getS
             //let binding = BindingData.mapVm box unbox binding
             let! b =
               Initialize(args.loggingArgs, name, getFunctionsForSubModelSelectedItem)
-                .Recursive(currentModel, dispatch, (fun () -> currentModel), binding)
+                .Recursive(currentModel, dispatch, (fun () -> currentModel), binding.Data)
             do getBindings.Add (name, b |> MapOutputType.recursivecase box unbox)
             return b
           }
@@ -80,7 +81,7 @@ type internal StaticHelper<'model, 'msg>(args: ViewModelArgs<'model, 'msg>, getS
     } |> Option.defaultValue null
 
   member _.SetValue (value, [<CallerMemberName>] ?memberName: string) =
-    fun (binding: BindingData<'model, 'msg, 'a>) ->
+    fun (binding: StaticBinding<'model, 'msg, 'a>) ->
       option {
         let! name = memberName
 
@@ -92,7 +93,7 @@ type internal StaticHelper<'model, 'msg>(args: ViewModelArgs<'model, 'msg>, getS
               //let binding = BindingData.mapVm box unbox binding
               let! b =
                 Initialize(args.loggingArgs, name, getFunctionsForSubModelSelectedItem)
-                  .Recursive(currentModel, dispatch, (fun () -> currentModel), binding)
+                  .Recursive(currentModel, dispatch, (fun () -> currentModel), binding.Data)
               do setBindings.Add (name, b |> MapOutputType.recursivecase box unbox)
               return b
             }
@@ -136,9 +137,124 @@ type internal StaticHelper<'model, 'msg>(args: ViewModelArgs<'model, 'msg>, getS
       |> Option.defaultValue []
       |> (fun x -> upcast x)
 
-type ExampleViewModel() as this =
-  let staticHelper = StaticHelper<String, Int32>(ViewModelArgs.simple "", fun () -> this)
+[<AllowNullLiteral>]
+type ISubModel<'model, 'msg> =
+  abstract StaticHelper: StaticHelper<'model, 'msg>
 
-  member _.Model = BindingData.OneWay.create id |> staticHelper.GetValue
-  member _.Command = BindingData.Cmd.createWithParam (fun _ _ -> ValueNone) (fun _ _ -> true) false |> staticHelper.GetValue
-  member _.SubModel = BindingData.SubModel.create (fun x -> x |> ValueSome) (failwith "x") (failwith "y") (fun _x y -> y) |> staticHelper.GetValue
+module StaticHelper =
+  let create args getSender = StaticHelper(args, getSender)
+
+module StaticBinding =
+  let internal createStatic bd = { Data = bd }
+  open BindingData
+
+  let internal mapData f binding =
+    { Data = binding.Data |> f }
+
+  /// Map the model of a binding via a contravariant mapping.
+  let mapModel (f: 'a -> 'b) (binding: StaticBinding<'b, 'msg, 'vm>) = f |> mapModel |> mapData <| binding
+
+  /// Map the message of a binding with access to the model via a covariant mapping.
+  let mapMsgWithModel (f: 'a -> 'model -> 'b) (binding: StaticBinding<'model, 'a, 'vm>) = f |> mapMsgWithModel |> mapData <| binding
+
+  /// Map the message of a binding via a covariant mapping.
+  let mapMsg (f: 'a -> 'b) (binding: StaticBinding<'model, 'a, 'vm>) = f |> mapMsg |> mapData <| binding
+
+  /// Set the message of a binding with access to the model.
+  let SetMsgWithModel (f: 'model -> 'b) (binding: StaticBinding<'model, 'a, 'vm>) = f |> setMsgWithModel |> mapData <| binding
+
+  /// Set the message of a binding.
+  let setMsg (msg: 'b) (binding: StaticBinding<'model, 'a, 'vm>) = msg |> setMsg |> mapData <| binding
+
+
+  /// Restrict the binding to models that satisfy the predicate after some model satisfies the predicate.
+  let addSticky (predicate: 'model -> bool) (binding: StaticBinding<'model, 'msg, 'vm>) = predicate |> addSticky |> mapData <| binding
+
+  /// <summary>
+  ///   Adds caching to the given binding.  The cache holds a single value and
+  ///   is invalidated after the given binding raises the
+  ///   <c>PropertyChanged</c> event.
+  /// </summary>
+  /// <param name="binding">The binding to which caching is added.</param>
+  let addCaching (binding: StaticBinding<'model, 'msg, 'vm>) : StaticBinding<'model, 'msg, 'vm> =
+    binding
+    |> mapData addCaching
+
+  /// <summary>
+  ///   Adds validation to the given binding using <c>INotifyDataErrorInfo</c>.
+  /// </summary>
+  /// <param name="validate">Returns the errors associated with the given model.</param>
+  /// <param name="binding">The binding to which validation is added.</param>
+  let addValidation (validate: 'model -> string list) (binding: StaticBinding<'model, 'msg, 'vm>) : StaticBinding<'model, 'msg, 'vm> =
+    binding
+    |> (addValidation validate |> mapData)
+
+  /// <summary>
+  ///   Adds laziness to the updating of the given binding. If the models are considered equal,
+  ///   then updating of the given binding is skipped.
+  /// </summary>
+  /// <param name="equals">Updating skipped when this function returns <c>true</c>.</param>
+  /// <param name="binding">The binding to which the laziness is added.</param>
+  let addLazy (equals: 'model -> 'model -> bool) (binding: StaticBinding<'model, 'msg, 'vm>) : StaticBinding<'model, 'msg, 'vm> =
+    binding
+    |> (addLazy equals |> mapData)
+
+  /// <summary>
+  ///   Accepts a function that can alter the message stream.
+  ///   Ideally suited for use with Reactive Extensions.
+  ///   <code>
+  ///     open FSharp.Control.Reactive
+  ///     let delay dispatch =
+  ///       let subject = Subject.broadcast
+  ///       let observable = subject :&gt; System.IObservable&lt;_&gt;
+  ///       observable
+  ///       |&gt; Observable.delay (System.TimeSpan.FromSeconds 1.0)
+  ///       |&gt; Observable.subscribe dispatch
+  ///       |&gt; ignore
+  ///       subject.OnNext
+  ///
+  ///     // ...
+  ///
+  ///     binding |&gt; Binding.alterMsgStream delay
+  ///   </code>
+  /// </summary>
+  /// <param name="alteration">The function that will alter the message stream.</param>
+  /// <param name="binding">The binding to which the message stream is altered.</param>
+  let alterMsgStream (alteration: ('b -> unit) -> 'a -> unit) (binding: StaticBinding<'model, 'a, 'vm>) : StaticBinding<'model, 'b, 'vm> =
+    binding
+    |> (alterMsgStream alteration |> mapData)
+
+  module OneWay =
+    open BindingData.OneWay
+
+    let opt () =
+      create id
+      |> createStatic
+
+  module Cmd =
+    open BindingData.Cmd
+
+    let createWithParam exec canExec autoRequery =
+      createWithParam exec canExec autoRequery
+      |> createStatic
+
+  module SubModel =
+    open BindingData.SubModel
+
+    let internal opt createVm : StaticBinding<'bindingModel voption, 'msg, 'viewModel :> ISubModel<'bindingModel, 'msg>> =
+      create id createVm (fun ((vm: #ISubModel<'bindingModel,'msg>),m) -> vm.StaticHelper.UpdateModel(m)) (fun _ m -> m)
+      |> createStatic
+
+
+[<AllowNullLiteral>]
+type InnerExampleViewModel(args) as this =
+  interface ISubModel<String, Int64> with
+    member _.StaticHelper = StaticHelper.create args (fun () -> this)
+    
+[<AllowNullLiteral>]
+type ExampleViewModel(args) as this =
+  let staticHelper = StaticHelper.create args (fun () -> this)
+
+  member _.Model = StaticBinding.OneWay.opt () |> staticHelper.GetValue
+  member _.Command = StaticBinding.Cmd.createWithParam (fun _ _ -> ValueNone) (fun _ _ -> true) false |> staticHelper.GetValue
+  member _.SubModel = StaticBinding.SubModel.opt InnerExampleViewModel |> StaticBinding.mapModel ValueSome |> StaticBinding.mapMsg int32 |> staticHelper.GetValue

--- a/src/Elmish.WPF/StaticViewModel.fs
+++ b/src/Elmish.WPF/StaticViewModel.fs
@@ -82,7 +82,10 @@ type StaticHelper<'model, 'msg>(args: ViewModelArgs<'model, 'msg>, getSender: un
           match Get(nameChain).Recursive(currentModel, vmBinding) with
           | Ok x -> Some x
           | Error _ -> None
-      } |> Option.defaultValue null
+      }
+      |> ValueOption.ofOption
+      |> ValueOption.toNull
+      |> Result.errorWith (failwithf "Got null on non-nullable type %O")
 
   member _.SetValue (value, [<CallerMemberName>] ?memberName: string) =
     fun (binding: StaticBindingT<'model, 'msg, 'a>) ->

--- a/src/Elmish.WPF/StaticViewModel.fs
+++ b/src/Elmish.WPF/StaticViewModel.fs
@@ -231,6 +231,14 @@ module StaticBinding =
       create id
       |> createStatic
 
+
+  module OneWayToSource =
+    open BindingData.OneWayToSource
+    
+    let id () =
+      create (fun obj _ -> obj)
+      |> createStatic
+
   module Cmd =
     open BindingData.Cmd
 
@@ -255,6 +263,8 @@ type InnerExampleViewModel(args) as this =
 type ExampleViewModel(args) as this =
   let staticHelper = StaticHelper.create args (fun () -> this)
 
-  member _.Model = StaticBinding.OneWay.opt () |> staticHelper.GetValue
+  member _.Model
+    with get() = StaticBinding.OneWay.opt () |> staticHelper.GetValue
+    and set(v) = StaticBinding.OneWayToSource.id () |> StaticBinding.mapMsg int32<string> |> staticHelper.SetValue(v)
   member _.Command = StaticBinding.Cmd.createWithParam (fun _ _ -> ValueNone) (fun _ _ -> true) false |> staticHelper.GetValue
   member _.SubModel = StaticBinding.SubModel.opt InnerExampleViewModel |> StaticBinding.mapModel ValueSome |> StaticBinding.mapMsg int32 |> staticHelper.GetValue

--- a/src/Elmish.WPF/StaticViewModel.fs
+++ b/src/Elmish.WPF/StaticViewModel.fs
@@ -61,7 +61,7 @@ type StaticHelper<'model, 'msg>(args: ViewModelArgs<'model, 'msg>, getSender: un
         log.LogError("SubModelSelectedItem binding referenced binding {SubModelSeqBindingName} but no binding was found with that name", name)
         None
 
-  member _.GetValue<'a> ([<CallerMemberName>] ?memberName: string) =
+  member _.Get<'a> ([<CallerMemberName>] ?memberName: string) =
     fun (binding: StaticBindingT<'model, 'msg, 'a>) ->
       option {
         let! name = memberName
@@ -87,7 +87,7 @@ type StaticHelper<'model, 'msg>(args: ViewModelArgs<'model, 'msg>, getSender: un
       |> ValueOption.toNull
       |> Result.errorWith (failwithf "Got null on non-nullable type %O")
 
-  member _.SetValue<'a> (value, [<CallerMemberName>] ?memberName: string) =
+  member _.Set<'a> (value, [<CallerMemberName>] ?memberName: string) =
     fun (binding: StaticBindingT<'model, 'msg, 'a>) ->
       option {
         let! name = memberName
@@ -145,7 +145,7 @@ type StaticHelper<'model, 'msg>(args: ViewModelArgs<'model, 'msg>, getSender: un
       |> (fun x -> upcast x)
 
 module StaticHelper =
-  let create args getSender = StaticHelper(args, getSender)
+  let create<'model, 'msg> args getSender = StaticHelper<'model, 'msg>(args, getSender)
 
 [<AllowNullLiteral>]
 type ISubModel<'model, 'msg> =

--- a/src/Elmish.WPF/StaticViewModel.fs
+++ b/src/Elmish.WPF/StaticViewModel.fs
@@ -235,7 +235,7 @@ module BindingT =
   module OneWay =
     open BindingData.OneWay
 
-    let opt () =
+    let opt =
       create id
       |> createStatic
 
@@ -243,7 +243,7 @@ module BindingT =
   module OneWayToSource =
     open BindingData.OneWayToSource
     
-    let id () =
+    let id =
       create (fun obj _ -> obj)
       |> createStatic
 
@@ -257,7 +257,7 @@ module BindingT =
   module SubModel =
     open BindingData.SubModel
 
-    let internal opt createVm : StaticBindingT<'bindingModel voption, 'msg, 'viewModel :> ISubModel<'bindingModel, 'msg>> =
+    let opt createVm : StaticBindingT<'bindingModel voption, 'msg, 'viewModel :> ISubModel<'bindingModel, 'msg>> =
       create id createVm (fun ((vm: #ISubModel<'bindingModel,'msg>),m) -> vm.StaticHelper.UpdateModel(m)) (fun _ m -> m)
       |> createStatic
 
@@ -272,7 +272,7 @@ type ExampleViewModel(args) as this =
   let staticHelper = StaticHelper.create args (fun () -> this)
 
   member _.Model
-    with get() = BindingT.OneWay.opt () |> staticHelper.GetValue
-    and set(v) = BindingT.OneWayToSource.id () >> BindingT.mapMsg int32<string> |> staticHelper.SetValue(v)
+    with get() = BindingT.OneWay.opt |> staticHelper.GetValue
+    and set(v) = BindingT.OneWayToSource.id >> BindingT.mapMsg int32<string> |> staticHelper.SetValue(v)
   member _.Command = BindingT.Cmd.createWithParam (fun _ _ -> ValueNone) (fun _ _ -> true) false |> staticHelper.GetValue
   member _.SubModel = BindingT.SubModel.opt InnerExampleViewModel >> BindingT.mapModel ValueSome >> BindingT.mapMsg int32 |> staticHelper.GetValue

--- a/src/Elmish.WPF/StaticViewModel.fs
+++ b/src/Elmish.WPF/StaticViewModel.fs
@@ -61,7 +61,7 @@ type StaticHelper<'model, 'msg>(args: ViewModelArgs<'model, 'msg>, getSender: un
         log.LogError("SubModelSelectedItem binding referenced binding {SubModelSeqBindingName} but no binding was found with that name", name)
         None
 
-  member _.GetValue ([<CallerMemberName>] ?memberName: string) =
+  member _.GetValue<'a> ([<CallerMemberName>] ?memberName: string) =
     fun (binding: StaticBindingT<'model, 'msg, 'a>) ->
       option {
         let! name = memberName
@@ -87,7 +87,7 @@ type StaticHelper<'model, 'msg>(args: ViewModelArgs<'model, 'msg>, getSender: un
       |> ValueOption.toNull
       |> Result.errorWith (failwithf "Got null on non-nullable type %O")
 
-  member _.SetValue (value, [<CallerMemberName>] ?memberName: string) =
+  member _.SetValue<'a> (value, [<CallerMemberName>] ?memberName: string) =
     fun (binding: StaticBindingT<'model, 'msg, 'a>) ->
       option {
         let! name = memberName

--- a/src/Elmish.WPF/StaticViewModel.fs
+++ b/src/Elmish.WPF/StaticViewModel.fs
@@ -67,7 +67,7 @@ type StaticHelper<'model, 'msg>(args: ViewModelArgs<'model, 'msg>, getSender: un
         let! name = memberName
         let! vmBinding =
           option {
-            match setBindings.TryGetValue name with
+            match getBindings.TryGetValue name with
             | true, value ->
               return value |> MapOutputType.unboxVm
             | _ ->

--- a/src/Elmish.WPF/ViewModelArgs.fs
+++ b/src/Elmish.WPF/ViewModelArgs.fs
@@ -27,13 +27,11 @@ module internal LoggingViewModelArgs =
       nameChain = "" }
 
 
-type internal ViewModelArgs<'model, 'msg> =
-  { initialModel: 'model
-    dispatch: 'msg -> unit
-    loggingArgs: LoggingViewModelArgs }
+type ViewModelArgs<'model, 'msg> =
+  internal { initialModel: 'model; dispatch: 'msg -> unit; loggingArgs: LoggingViewModelArgs }
 
-module internal ViewModelArgs =
-  let create initialModel dispatch nameChain loggingArgs =
+module ViewModelArgs =
+  let internal createWithLogging initialModel dispatch nameChain loggingArgs =
     { initialModel = initialModel
       dispatch = dispatch
       loggingArgs = LoggingViewModelArgs.map nameChain loggingArgs }
@@ -42,8 +40,10 @@ module internal ViewModelArgs =
     { initialModel = v.initialModel |> mapModel
       dispatch = mapMsg >> v.dispatch
       loggingArgs = v.loggingArgs }
-  
-  let simple initialModel =
+
+  let create initialModel dispatch =
     { initialModel = initialModel
-      dispatch = ignore
+      dispatch = dispatch
       loggingArgs = LoggingViewModelArgs.none }
+  
+  let simple initialModel = create initialModel ignore

--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -6,10 +6,11 @@ open Microsoft.Extensions.Logging.Abstractions
 open Elmish
 
 
-type WpfProgram<'model, 'msg> =
+type WpfProgram<'model, 'msg, 'viewModel> =
   internal {
     ElmishProgram: Program<unit, 'model, 'msg, unit>
-    Bindings: Binding<'model, 'msg> list
+    CreateViewModel: ViewModelArgs<'model,'msg> -> 'viewModel
+    UpdateViewModel: 'viewModel * 'model -> unit
     LoggerFactory: ILoggerFactory
     ErrorHandler: string -> exn -> unit
     /// Only log calls that take at least this many milliseconds. Default 1.
@@ -20,10 +21,27 @@ type WpfProgram<'model, 'msg> =
 [<RequireQualifiedAccess>]
 module WpfProgram =
 
+  let private mapVm mapOut mapIn (p: WpfProgram<'model, 'msg, 'viewModel0>) : WpfProgram<'model, 'msg, 'viewModel1> =
+    { ElmishProgram = p.ElmishProgram
+      CreateViewModel = p.CreateViewModel >> mapOut
+      UpdateViewModel = (fun (vm, m) -> p.UpdateViewModel(mapIn vm, m))
+      LoggerFactory = p.LoggerFactory
+      ErrorHandler = p.ErrorHandler
+      PerformanceLogThreshold = p.PerformanceLogThreshold }
 
-  let private create getBindings program =
+  let private createWithBindings (getBindings: unit -> Binding<'model,'msg> list) program =
     { ElmishProgram = program
-      Bindings = getBindings ()
+      CreateViewModel = fun args -> DynamicViewModel<'model,'msg>(args, getBindings ())
+      UpdateViewModel = fun (vm,m) -> vm.UpdateModel m
+      LoggerFactory = NullLoggerFactory.Instance
+      ErrorHandler = fun _ _ -> ()
+      PerformanceLogThreshold = 1 }
+    |> mapVm box unbox
+
+  let private createWithBase (createViewModel: ViewModelArgs<'model,'msg> -> #ISubModel<'model,'msg>) program =
+    { ElmishProgram = program
+      CreateViewModel = createViewModel
+      UpdateViewModel = fun (vm: #ISubModel<'model,'msg>,m) -> vm.StaticHelper.UpdateModel m
       LoggerFactory = NullLoggerFactory.Instance
       ErrorHandler = fun _ _ -> ()
       PerformanceLogThreshold = 1 }
@@ -35,7 +53,15 @@ module WpfProgram =
       (update: 'msg  -> 'model -> 'model)
       (bindings: unit -> Binding<'model, 'msg> list) =
     Program.mkSimple init update (fun _ _ -> ())
-    |> create bindings
+    |> createWithBindings bindings
+
+  /// Creates a WpfProgram that does not use commands.
+  let mkSimpleBase
+      (init: unit -> 'model)
+      (update: 'msg  -> 'model -> 'model)
+      createViewModel =
+    Program.mkSimple init update (fun _ _ -> ())
+    |> createWithBase createViewModel
 
 
   /// Creates a WpfProgram that uses commands
@@ -44,7 +70,15 @@ module WpfProgram =
       (update: 'msg  -> 'model -> 'model * Cmd<'msg>)
       (bindings: unit -> Binding<'model, 'msg> list) =
     Program.mkProgram init update (fun _ _ -> ())
-    |> create bindings
+    |> createWithBindings bindings
+    
+  /// Creates a WpfProgram that uses commands
+  let mkProgramBase
+      (init: unit -> 'model * Cmd<'msg>)
+      (update: 'msg  -> 'model -> 'model * Cmd<'msg>)
+      createViewModel =
+    Program.mkProgram init update (fun _ _ -> ())
+    |> createWithBase createViewModel
 
 
   /// Starts an Elmish dispatch loop, setting the bindings as the DataContext for the
@@ -52,7 +86,7 @@ module WpfProgram =
   /// you control app/window instantiation, runWindowWithConfig might be a better option.
   let startElmishLoop
       (element: FrameworkElement)
-      (program: WpfProgram<'model, 'msg>) =
+      (program: WpfProgram<'model, 'msg, 'viewModel>) =
     let mutable viewModel = None
 
     let updateLogger = program.LoggerFactory.CreateLogger("Elmish.WPF.Update")
@@ -84,11 +118,11 @@ module WpfProgram =
                   nameChain = "main"
                   log = bindingsLogger
                   logPerformance = performanceLogger } }
-          let vm = DynamicViewModel<'model, 'msg>(args, program.Bindings)
+          let vm = program.CreateViewModel args
           element.DataContext <- vm
           viewModel <- Some vm
       | Some vm ->
-          vm.UpdateModel model
+          program.UpdateViewModel (vm, model)
 
     let cmdDispatch (innerDispatch: Dispatch<'msg>) : Dispatch<'msg> =
       dispatch <- innerDispatch

--- a/src/Samples/SubModel/CounterWithClock.xaml
+++ b/src/Samples/SubModel/CounterWithClock.xaml
@@ -6,7 +6,7 @@
              xmlns:local="clr-namespace:Elmish.WPF.Samples.SubModel"
              xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModel;assembly=SubModel.Core"
              mc:Ignorable="d"
-             d:DataContext="{x:Static vm:Program.counterWithClockDesignVm}">
+             d:DataContext="{d:DesignInstance Type=vm:CounterWithClockViewModel, IsDesignTimeCreatable=True}">
   <StackPanel>
     <local:Counter DataContext="{Binding Counter}" d:DataContext="{Binding DataContext.Counter, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />
     <local:Clock DataContext="{Binding Clock}" d:DataContext="{Binding DataContext.Clock, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />

--- a/src/Samples/SubModelStatic.Core/Program.fs
+++ b/src/Samples/SubModelStatic.Core/Program.fs
@@ -1,4 +1,4 @@
-module Elmish.WPF.Samples.SubModel.Program
+namespace Elmish.WPF.Samples.SubModelStatic
 
 open System
 open Serilog
@@ -31,15 +31,21 @@ module Counter =
     | SetStepSize x -> { m with StepSize = x }
     | Reset -> init
 
-  let bindings () : Binding<Model, Msg> list = [
-    "CounterValue" |> Binding.oneWay (fun m -> m.Count)
-    "Increment" |> Binding.cmd Increment
-    "Decrement" |> Binding.cmd Decrement
-    "StepSize" |> Binding.twoWay(
-      (fun m -> float m.StepSize),
-      int >> SetStepSize)
-    "Reset" |> Binding.cmdIf(Reset, canReset)
-  ]
+type [<AllowNullLiteral>] CounterViewModel (args) as this =
+  let sh = StaticHelper.create args (fun () -> box this)
+
+  new() = CounterViewModel(Counter.init |> ViewModelArgs.simple)
+
+  member _.StepSize
+    with get() = sh.Get () (BindingT.Get.id >> BindingT.mapModel (fun m -> m.StepSize))
+    and set(v) = sh.Set (v) (BindingT.Set.id >> BindingT.mapMsg Counter.Msg.SetStepSize)
+  member _.CounterValue = sh.Get () (BindingT.Get.id >> BindingT.mapModel (fun m -> m.Count))
+  member _.Increment = sh.Get () (BindingT.Cmd.createWithParam (fun _ _ -> Counter.Increment |> ValueSome) (fun _ _ -> true) true)
+  member _.Decrement = sh.Get () (BindingT.Cmd.createWithParam (fun _ _ -> Counter.Decrement |> ValueSome) (fun _ _ -> true) true)
+  member _.Reset = sh.Get () (BindingT.Cmd.createWithParam (fun _ _ -> Counter.Reset |> ValueSome) (fun _ -> Counter.canReset) true)
+
+  interface ISubModel<Counter.Model, Counter.Msg> with
+    member _.StaticHelper = sh
 
 
 module Clock =
@@ -70,20 +76,31 @@ module Clock =
     | Tick t -> { m with Time = t }
     | SetTimeType t -> { m with TimeType = t }
 
-  let bindings () : Binding<Model, Msg> list = [
-    "Time" |> Binding.oneWay getTime
-    "IsLocal" |> Binding.oneWay (fun m -> m.TimeType = Local)
-    "SetLocal" |> Binding.cmd (SetTimeType Local)
-    "IsUtc" |> Binding.oneWay (fun m -> m.TimeType = Utc)
-    "SetUtc" |> Binding.cmd (SetTimeType Utc)
-  ]
+type [<AllowNullLiteral>] ClockViewModel (args) as this =
+  let sh = StaticHelper.create args (fun () -> box this)
+  
+  new() = ClockViewModel(Clock.init () |> ViewModelArgs.simple)
 
+  member _.Time = sh.Get() (BindingT.Get.id >> BindingT.mapModel Clock.getTime)
+  member _.IsLocal = sh.Get() (BindingT.Get.id >> BindingT.mapModel (fun m -> m.TimeType = Clock.Local))
+  member _.SetLocal = sh.Get () (BindingT.Cmd.createWithParam (fun _ _ -> Clock.SetTimeType Clock.Local |> ValueSome) (fun _ _ -> true) true)
+  member _.IsUtc = sh.Get() (BindingT.Get.id >> BindingT.mapModel (fun m -> m.TimeType = Clock.Utc))
+  member _.SetUtc = sh.Get () (BindingT.Cmd.createWithParam (fun _ _ -> Clock.SetTimeType Clock.Utc |> ValueSome) (fun _ _ -> true) true)
+
+  interface ISubModel<Clock.Model, Clock.Msg> with
+    member _.StaticHelper = sh
 
 module CounterWithClock =
 
   type Model =
     { Counter: Counter.Model
       Clock: Clock.Model }
+
+  module ModelM =
+    module Counter =
+      let get m = m.Counter
+    module Clock =
+      let get m = m.Clock
 
   let init () =
     { Counter = Counter.init
@@ -98,23 +115,28 @@ module CounterWithClock =
     | CounterMsg msg -> { m with Counter = Counter.update msg m.Counter }
     | ClockMsg msg -> { m with Clock = Clock.update msg m.Clock }
 
-  let bindings () : Binding<Model, Msg> list = [
-    "Counter"
-      |> Binding.SubModel.required Counter.bindings
-      |> Binding.mapModel (fun m -> m.Counter)
-      |> Binding.mapMsg CounterMsg
-    "Clock"
-      |> Binding.SubModel.required Clock.bindings
-      |> Binding.mapModel (fun m -> m.Clock)
-      |> Binding.mapMsg ClockMsg
-  ]
+type [<AllowNullLiteral>] CounterWithClockViewModel (args) as this =
+  let sh = StaticHelper.create args (fun () -> box this)
+  
+  new() = CounterWithClockViewModel(CounterWithClock.init () |> ViewModelArgs.simple)
 
+  member _.Counter = sh.Get() (BindingT.SubModel.id CounterViewModel >> BindingT.mapModel CounterWithClock.ModelM.Counter.get >> BindingT.mapMsg CounterWithClock.CounterMsg)
+  member _.Clock = sh.Get() (BindingT.SubModel.id ClockViewModel >> BindingT.mapModel CounterWithClock.ModelM.Clock.get >> BindingT.mapMsg CounterWithClock.ClockMsg)
 
-module App =
+  interface ISubModel<CounterWithClock.Model, CounterWithClock.Msg> with
+    member _.StaticHelper = sh
+
+module App2 =
 
   type Model =
     { ClockCounter1: CounterWithClock.Model
       ClockCounter2: CounterWithClock.Model }
+
+  module ModelM =
+    module ClockCounter1 =
+      let get m = m.ClockCounter1
+    module ClockCounter2 =
+      let get m = m.ClockCounter2
 
   let init () =
     { ClockCounter1 = CounterWithClock.init ()
@@ -131,49 +153,40 @@ module App =
     | ClockCounter2Msg msg ->
         { m with ClockCounter2 = CounterWithClock.update msg m.ClockCounter2 }
 
-  let bindings () : Binding<Model, Msg> list = [
-    "ClockCounter1"
-      |> Binding.SubModel.required CounterWithClock.bindings
-      |> Binding.mapModel (fun m -> m.ClockCounter1)
-      |> Binding.mapMsg ClockCounter1Msg
+type [<AllowNullLiteral>] AppViewModel (args) as this =
+  let sh = StaticHelper.create args (fun () -> box this)
+  
+  new() = AppViewModel(App2.init () |> ViewModelArgs.simple)
 
-    "ClockCounter2"
-      |> Binding.SubModel.required CounterWithClock.bindings
-      |> Binding.mapModel (fun m -> m.ClockCounter2)
-      |> Binding.mapMsg ClockCounter2Msg
-  ]
+  member _.ClockCounter1 = sh.Get() (BindingT.SubModel.id CounterWithClockViewModel >> BindingT.mapModel App2.ModelM.ClockCounter1.get >> BindingT.mapMsg App2.ClockCounter1Msg)
+  member _.ClockCounter2 = sh.Get() (BindingT.SubModel.id CounterWithClockViewModel >> BindingT.mapModel App2.ModelM.ClockCounter2.get >> BindingT.mapMsg App2.ClockCounter2Msg)
 
+module Program =
 
-let counterDesignVm = ViewModel.designInstance Counter.init (Counter.bindings ())
-let clockDesignVm = ViewModel.designInstance (Clock.init ()) (Clock.bindings ())
-let counterWithClockDesignVm = ViewModel.designInstance (CounterWithClock.init ()) (CounterWithClock.bindings ())
-let mainDesignVm = ViewModel.designInstance (App.init ()) (App.bindings ())
-
-
-let timerTick dispatch =
-  let timer = new System.Timers.Timer(1000.)
-  timer.Elapsed.Add (fun _ ->
-    let clockMsg =
-      DateTimeOffset.Now
-      |> Clock.Tick
-      |> CounterWithClock.ClockMsg
-    dispatch <| App.ClockCounter1Msg clockMsg
-    dispatch <| App.ClockCounter2Msg clockMsg
-  )
-  timer.Start()
+  let timerTick dispatch =
+    let timer = new System.Timers.Timer(1000.)
+    timer.Elapsed.Add (fun _ ->
+      let clockMsg =
+        DateTimeOffset.Now
+        |> Clock.Tick
+        |> CounterWithClock.ClockMsg
+      dispatch <| App2.ClockCounter1Msg clockMsg
+      dispatch <| App2.ClockCounter2Msg clockMsg
+    )
+    timer.Start()
 
 
-let main window =
+  let main window =
 
-  let logger =
-    LoggerConfiguration()
-      .MinimumLevel.Override("Elmish.WPF.Update", Events.LogEventLevel.Verbose)
-      .MinimumLevel.Override("Elmish.WPF.Bindings", Events.LogEventLevel.Verbose)
-      .MinimumLevel.Override("Elmish.WPF.Performance", Events.LogEventLevel.Verbose)
-      .WriteTo.Console()
-      .CreateLogger()
+    let logger =
+      LoggerConfiguration()
+        .MinimumLevel.Override("Elmish.WPF.Update", Events.LogEventLevel.Verbose)
+        .MinimumLevel.Override("Elmish.WPF.Bindings", Events.LogEventLevel.Verbose)
+        .MinimumLevel.Override("Elmish.WPF.Performance", Events.LogEventLevel.Verbose)
+        .WriteTo.Console()
+        .CreateLogger()
 
-  WpfProgram.mkSimple App.init App.update App.bindings
-  |> WpfProgram.withSubscription (fun _ -> Cmd.ofSub timerTick)
-  |> WpfProgram.withLogger (new SerilogLoggerFactory(logger))
-  |> WpfProgram.startElmishLoop window
+    WpfProgram.mkSimpleBase App2.init App2.update AppViewModel
+    |> WpfProgram.withSubscription (fun _ -> Cmd.ofSub timerTick)
+    |> WpfProgram.withLogger (new SerilogLoggerFactory(logger))
+    |> WpfProgram.startElmishLoop window

--- a/src/Samples/SubModelStatic.Core/Program.fs
+++ b/src/Samples/SubModelStatic.Core/Program.fs
@@ -5,6 +5,7 @@ open Serilog
 open Serilog.Extensions.Logging
 open Elmish
 open Elmish.WPF
+open System.ComponentModel
 
 module Counter =
 
@@ -46,6 +47,10 @@ type [<AllowNullLiteral>] CounterViewModel (args) as this =
 
   interface ISubModel<Counter.Model, Counter.Msg> with
     member _.StaticHelper = sh
+
+  interface INotifyPropertyChanged with
+    [<CLIEvent>]
+    member this.PropertyChanged = (sh :> INotifyPropertyChanged).PropertyChanged
 
 
 module Clock =
@@ -90,6 +95,10 @@ type [<AllowNullLiteral>] ClockViewModel (args) as this =
   interface ISubModel<Clock.Model, Clock.Msg> with
     member _.StaticHelper = sh
 
+  interface INotifyPropertyChanged with
+    [<CLIEvent>]
+    member this.PropertyChanged = (sh :> INotifyPropertyChanged).PropertyChanged
+
 module CounterWithClock =
 
   type Model =
@@ -126,6 +135,10 @@ type [<AllowNullLiteral>] CounterWithClockViewModel (args) as this =
   interface ISubModel<CounterWithClock.Model, CounterWithClock.Msg> with
     member _.StaticHelper = sh
 
+  interface INotifyPropertyChanged with
+    [<CLIEvent>]
+    member this.PropertyChanged = (sh :> INotifyPropertyChanged).PropertyChanged
+
 module App2 =
 
   type Model =
@@ -160,6 +173,13 @@ type [<AllowNullLiteral>] AppViewModel (args) as this =
 
   member _.ClockCounter1 = sh.Get() (BindingT.SubModel.id CounterWithClockViewModel >> BindingT.mapModel App2.ModelM.ClockCounter1.get >> BindingT.mapMsg App2.ClockCounter1Msg)
   member _.ClockCounter2 = sh.Get() (BindingT.SubModel.id CounterWithClockViewModel >> BindingT.mapModel App2.ModelM.ClockCounter2.get >> BindingT.mapMsg App2.ClockCounter2Msg)
+
+  interface ISubModel<App2.Model, App2.Msg> with
+    member _.StaticHelper = sh
+
+  interface INotifyPropertyChanged with
+    [<CLIEvent>]
+    member this.PropertyChanged = (sh :> INotifyPropertyChanged).PropertyChanged
 
 module Program =
 

--- a/src/Samples/SubModelStatic.Core/Program.fs
+++ b/src/Samples/SubModelStatic.Core/Program.fs
@@ -1,0 +1,179 @@
+module Elmish.WPF.Samples.SubModel.Program
+
+open System
+open Serilog
+open Serilog.Extensions.Logging
+open Elmish
+open Elmish.WPF
+
+module Counter =
+
+  type Model =
+    { Count: int
+      StepSize: int }
+
+  type Msg =
+    | Increment
+    | Decrement
+    | SetStepSize of int
+    | Reset
+
+  let init =
+    { Count = 0
+      StepSize = 1 }
+
+  let canReset = (<>) init
+
+  let update msg m =
+    match msg with
+    | Increment -> { m with Count = m.Count + m.StepSize }
+    | Decrement -> { m with Count = m.Count - m.StepSize }
+    | SetStepSize x -> { m with StepSize = x }
+    | Reset -> init
+
+  let bindings () : Binding<Model, Msg> list = [
+    "CounterValue" |> Binding.oneWay (fun m -> m.Count)
+    "Increment" |> Binding.cmd Increment
+    "Decrement" |> Binding.cmd Decrement
+    "StepSize" |> Binding.twoWay(
+      (fun m -> float m.StepSize),
+      int >> SetStepSize)
+    "Reset" |> Binding.cmdIf(Reset, canReset)
+  ]
+
+
+module Clock =
+
+  type TimeType =
+    | Utc
+    | Local
+
+  type Model =
+    { Time: DateTimeOffset
+      TimeType: TimeType }
+
+  let init () =
+    { Time = DateTimeOffset.Now
+      TimeType = Local }
+
+  let getTime m =
+    match m.TimeType with
+    | Utc -> m.Time.UtcDateTime
+    | Local -> m.Time.LocalDateTime
+
+  type Msg =
+    | Tick of DateTimeOffset
+    | SetTimeType of TimeType
+
+  let update msg m =
+    match msg with
+    | Tick t -> { m with Time = t }
+    | SetTimeType t -> { m with TimeType = t }
+
+  let bindings () : Binding<Model, Msg> list = [
+    "Time" |> Binding.oneWay getTime
+    "IsLocal" |> Binding.oneWay (fun m -> m.TimeType = Local)
+    "SetLocal" |> Binding.cmd (SetTimeType Local)
+    "IsUtc" |> Binding.oneWay (fun m -> m.TimeType = Utc)
+    "SetUtc" |> Binding.cmd (SetTimeType Utc)
+  ]
+
+
+module CounterWithClock =
+
+  type Model =
+    { Counter: Counter.Model
+      Clock: Clock.Model }
+
+  let init () =
+    { Counter = Counter.init
+      Clock = Clock.init () }
+
+  type Msg =
+    | CounterMsg of Counter.Msg
+    | ClockMsg of Clock.Msg
+
+  let update msg m =
+    match msg with
+    | CounterMsg msg -> { m with Counter = Counter.update msg m.Counter }
+    | ClockMsg msg -> { m with Clock = Clock.update msg m.Clock }
+
+  let bindings () : Binding<Model, Msg> list = [
+    "Counter"
+      |> Binding.SubModel.required Counter.bindings
+      |> Binding.mapModel (fun m -> m.Counter)
+      |> Binding.mapMsg CounterMsg
+    "Clock"
+      |> Binding.SubModel.required Clock.bindings
+      |> Binding.mapModel (fun m -> m.Clock)
+      |> Binding.mapMsg ClockMsg
+  ]
+
+
+module App =
+
+  type Model =
+    { ClockCounter1: CounterWithClock.Model
+      ClockCounter2: CounterWithClock.Model }
+
+  let init () =
+    { ClockCounter1 = CounterWithClock.init ()
+      ClockCounter2 = CounterWithClock.init () }
+
+  type Msg =
+    | ClockCounter1Msg of CounterWithClock.Msg
+    | ClockCounter2Msg of CounterWithClock.Msg
+
+  let update msg m =
+    match msg with
+    | ClockCounter1Msg msg ->
+        { m with ClockCounter1 = CounterWithClock.update msg m.ClockCounter1 }
+    | ClockCounter2Msg msg ->
+        { m with ClockCounter2 = CounterWithClock.update msg m.ClockCounter2 }
+
+  let bindings () : Binding<Model, Msg> list = [
+    "ClockCounter1"
+      |> Binding.SubModel.required CounterWithClock.bindings
+      |> Binding.mapModel (fun m -> m.ClockCounter1)
+      |> Binding.mapMsg ClockCounter1Msg
+
+    "ClockCounter2"
+      |> Binding.SubModel.required CounterWithClock.bindings
+      |> Binding.mapModel (fun m -> m.ClockCounter2)
+      |> Binding.mapMsg ClockCounter2Msg
+  ]
+
+
+let counterDesignVm = ViewModel.designInstance Counter.init (Counter.bindings ())
+let clockDesignVm = ViewModel.designInstance (Clock.init ()) (Clock.bindings ())
+let counterWithClockDesignVm = ViewModel.designInstance (CounterWithClock.init ()) (CounterWithClock.bindings ())
+let mainDesignVm = ViewModel.designInstance (App.init ()) (App.bindings ())
+
+
+let timerTick dispatch =
+  let timer = new System.Timers.Timer(1000.)
+  timer.Elapsed.Add (fun _ ->
+    let clockMsg =
+      DateTimeOffset.Now
+      |> Clock.Tick
+      |> CounterWithClock.ClockMsg
+    dispatch <| App.ClockCounter1Msg clockMsg
+    dispatch <| App.ClockCounter2Msg clockMsg
+  )
+  timer.Start()
+
+
+let main window =
+
+  let logger =
+    LoggerConfiguration()
+      .MinimumLevel.Override("Elmish.WPF.Update", Events.LogEventLevel.Verbose)
+      .MinimumLevel.Override("Elmish.WPF.Bindings", Events.LogEventLevel.Verbose)
+      .MinimumLevel.Override("Elmish.WPF.Performance", Events.LogEventLevel.Verbose)
+      .WriteTo.Console()
+      .CreateLogger()
+
+  WpfProgram.mkSimple App.init App.update App.bindings
+  |> WpfProgram.withSubscription (fun _ -> Cmd.ofSub timerTick)
+  |> WpfProgram.withLogger (new SerilogLoggerFactory(logger))
+  |> WpfProgram.startElmishLoop window

--- a/src/Samples/SubModelStatic.Core/SubModelStatic.Core.fsproj
+++ b/src/Samples/SubModelStatic.Core/SubModelStatic.Core.fsproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net6.0-windows</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Elmish.WPF\Elmish.WPF.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Samples/SubModelStatic/App.xaml
+++ b/src/Samples/SubModelStatic/App.xaml
@@ -1,0 +1,7 @@
+﻿<Application x:Class="Elmish.WPF.Samples.SubModelStatic.App"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        StartupUri="MainWindow.xaml">
+  <Application.Resources>
+  </Application.Resources>
+</Application>

--- a/src/Samples/SubModelStatic/App.xaml.cs
+++ b/src/Samples/SubModelStatic/App.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Windows;
+
+namespace Elmish.WPF.Samples.SubModelStatic
+{
+  public partial class App : Application
+  {
+    public App()
+    {
+      this.Activated += StartElmish;
+    }
+
+    private void StartElmish(object sender, EventArgs e)
+    {
+      this.Activated -= StartElmish;
+      Program.main(MainWindow);
+    }
+
+  }
+}

--- a/src/Samples/SubModelStatic/Clock.xaml
+++ b/src/Samples/SubModelStatic/Clock.xaml
@@ -5,7 +5,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelStatic;assembly=SubModelStatic.Core"
              mc:Ignorable="d"
-             d:DataContext="{x:Static vm:Program.clockDesignVm}">
+             d:DataContext="{d:DesignInstance Type=vm:ClockViewModel, IsDesignTimeCreatable=True}">
   <StackPanel Orientation="Horizontal">
     <TextBlock Text="{Binding Time, StringFormat='Today is {0:MMMM dd, yyyy}. The time is {0:HH:mm:ssK}. It is {0:dddd}.'}" />
     <RadioButton Command="{Binding SetLocal}" IsChecked="{Binding IsLocal, Mode=OneWay}" Content="Local" Margin="10,0,0,0"/>

--- a/src/Samples/SubModelStatic/Clock.xaml
+++ b/src/Samples/SubModelStatic/Clock.xaml
@@ -1,0 +1,14 @@
+﻿<UserControl x:Class="Elmish.WPF.Samples.SubModelStatic.Clock"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelStatic;assembly=SubModelStatic.Core"
+             mc:Ignorable="d"
+             d:DataContext="{x:Static vm:Program.clockDesignVm}">
+  <StackPanel Orientation="Horizontal">
+    <TextBlock Text="{Binding Time, StringFormat='Today is {0:MMMM dd, yyyy}. The time is {0:HH:mm:ssK}. It is {0:dddd}.'}" />
+    <RadioButton Command="{Binding SetLocal}" IsChecked="{Binding IsLocal, Mode=OneWay}" Content="Local" Margin="10,0,0,0"/>
+    <RadioButton Command="{Binding SetUtc}" IsChecked="{Binding IsUtc, Mode=OneWay}" Content="Utc" Margin="10,0,0,0"/>
+  </StackPanel>
+</UserControl>

--- a/src/Samples/SubModelStatic/Clock.xaml.cs
+++ b/src/Samples/SubModelStatic/Clock.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Controls;
+
+namespace Elmish.WPF.Samples.SubModelStatic
+{
+    public partial class Clock : UserControl
+    {
+        public Clock()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Samples/SubModelStatic/Counter.xaml
+++ b/src/Samples/SubModelStatic/Counter.xaml
@@ -1,11 +1,11 @@
-﻿<UserControl x:Class="Elmish.WPF.Samples.SubModel.Counter"
+﻿<UserControl x:Class="Elmish.WPF.Samples.SubModelStatic.Counter"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModel;assembly=SubModel.Core"
+             xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelStatic;assembly=SubModelStatic.Core"
              mc:Ignorable="d"
-             d:DataContext="{x:Static vm:Program.counterDesignVm}">
+             d:DataContext="{d:DesignInstance Type=vm:CounterViewModel, IsDesignTimeCreatable=True}">
   <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top">
     <TextBlock Text="{Binding CounterValue, StringFormat='Counter value: {0}'}" Width="110" Margin="0,5,10,5" />
     <Button Command="{Binding Decrement}" Content="-" Margin="0,5,10,5" Width="30" />

--- a/src/Samples/SubModelStatic/Counter.xaml
+++ b/src/Samples/SubModelStatic/Counter.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl x:Class="Elmish.WPF.Samples.SubModel.Counter"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModel;assembly=SubModel.Core"
+             mc:Ignorable="d"
+             d:DataContext="{x:Static vm:Program.counterDesignVm}">
+  <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Top">
+    <TextBlock Text="{Binding CounterValue, StringFormat='Counter value: {0}'}" Width="110" Margin="0,5,10,5" />
+    <Button Command="{Binding Decrement}" Content="-" Margin="0,5,10,5" Width="30" />
+    <Button Command="{Binding Increment}" Content="+" Margin="0,5,10,5" Width="30" />
+    <TextBlock Text="{Binding StepSize, StringFormat='Step size: {0}'}" Width="70" Margin="0,5,10,5" />
+    <Slider Value="{Binding StepSize}" TickFrequency="1" Maximum="10" Minimum="1" IsSnapToTickEnabled="True" Width="100" Margin="0,5,10,5" />
+    <Button Command="{Binding Reset}" Content="Reset" Margin="0,5,10,5" Width="50" />
+  </StackPanel>
+</UserControl>

--- a/src/Samples/SubModelStatic/Counter.xaml.cs
+++ b/src/Samples/SubModelStatic/Counter.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Controls;
+
+namespace Elmish.WPF.Samples.SubModelStatic
+{
+    public partial class Counter : UserControl
+    {
+        public Counter()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Samples/SubModelStatic/CounterWithClock.xaml
+++ b/src/Samples/SubModelStatic/CounterWithClock.xaml
@@ -6,7 +6,7 @@
              xmlns:local="clr-namespace:Elmish.WPF.Samples.SubModelStatic"
              xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelStatic;assembly=SubModelStatic.Core"
              mc:Ignorable="d"
-             d:DataContext="{x:Static vm:Program.counterWithClockDesignVm}">
+             d:DataContext="{d:DesignInstance Type=vm:CounterWithClockViewModel, IsDesignTimeCreatable=True}">
   <StackPanel>
     <local:Counter DataContext="{Binding Counter}" d:DataContext="{Binding DataContext.Counter, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />
     <local:Clock DataContext="{Binding Clock}" d:DataContext="{Binding DataContext.Clock, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />

--- a/src/Samples/SubModelStatic/CounterWithClock.xaml
+++ b/src/Samples/SubModelStatic/CounterWithClock.xaml
@@ -8,7 +8,7 @@
              mc:Ignorable="d"
              d:DataContext="{d:DesignInstance Type=vm:CounterWithClockViewModel, IsDesignTimeCreatable=True}">
   <StackPanel>
-    <local:Counter DataContext="{Binding Counter}" d:DataContext="{Binding DataContext.Counter, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />
-    <local:Clock DataContext="{Binding Clock}" d:DataContext="{Binding DataContext.Clock, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />
+    <local:Counter DataContext="{Binding Counter}" HorizontalAlignment="Center" />
+    <local:Clock DataContext="{Binding Clock}" HorizontalAlignment="Center" />
   </StackPanel>
 </UserControl>

--- a/src/Samples/SubModelStatic/CounterWithClock.xaml
+++ b/src/Samples/SubModelStatic/CounterWithClock.xaml
@@ -1,0 +1,14 @@
+﻿<UserControl x:Class="Elmish.WPF.Samples.SubModelStatic.CounterWithClock"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:local="clr-namespace:Elmish.WPF.Samples.SubModelStatic"
+             xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelStatic;assembly=SubModelStatic.Core"
+             mc:Ignorable="d"
+             d:DataContext="{x:Static vm:Program.counterWithClockDesignVm}">
+  <StackPanel>
+    <local:Counter DataContext="{Binding Counter}" d:DataContext="{Binding DataContext.Counter, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />
+    <local:Clock DataContext="{Binding Clock}" d:DataContext="{Binding DataContext.Clock, RelativeSource={RelativeSource AncestorType=UserControl}}" HorizontalAlignment="Center" />
+  </StackPanel>
+</UserControl>

--- a/src/Samples/SubModelStatic/CounterWithClock.xaml.cs
+++ b/src/Samples/SubModelStatic/CounterWithClock.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Controls;
+
+namespace Elmish.WPF.Samples.SubModelStatic
+{
+    public partial class CounterWithClock : UserControl
+    {
+        public CounterWithClock()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Samples/SubModelStatic/MainWindow.xaml
+++ b/src/Samples/SubModelStatic/MainWindow.xaml
@@ -10,7 +10,7 @@
         Width="500"
         WindowStartupLocation="CenterScreen"
         mc:Ignorable="d"
-        d:DataContext="{x:Static vm:Program.mainDesignVm}">
+        d:DataContext="{d:DesignInstance Type=vm:AppViewModel, IsDesignTimeCreatable=True}">
   <StackPanel>
     <TextBlock Text="Counter with clock 1" FontSize="18" FontWeight="Bold" Margin="0,25,0,0" HorizontalAlignment="Center" />
     <local:CounterWithClock DataContext="{Binding ClockCounter1}" d:DataContext="{Binding DataContext.ClockCounter1, RelativeSource={RelativeSource AncestorType=StackPanel}}"/>

--- a/src/Samples/SubModelStatic/MainWindow.xaml
+++ b/src/Samples/SubModelStatic/MainWindow.xaml
@@ -13,8 +13,8 @@
         d:DataContext="{d:DesignInstance Type=vm:AppViewModel, IsDesignTimeCreatable=True}">
   <StackPanel>
     <TextBlock Text="Counter with clock 1" FontSize="18" FontWeight="Bold" Margin="0,25,0,0" HorizontalAlignment="Center" />
-    <local:CounterWithClock DataContext="{Binding ClockCounter1}" d:DataContext="{Binding DataContext.ClockCounter1, RelativeSource={RelativeSource AncestorType=StackPanel}}"/>
+    <local:CounterWithClock DataContext="{Binding ClockCounter1}" />
     <TextBlock Text="Counter with clock 2" FontSize="18" FontWeight="Bold" Margin="0,25,0,0" HorizontalAlignment="Center" />
-    <local:CounterWithClock DataContext="{Binding ClockCounter2}" d:DataContext="{Binding DataContext.ClockCounter2, RelativeSource={RelativeSource AncestorType=StackPanel}}"/>
+    <local:CounterWithClock DataContext="{Binding ClockCounter2}" />
   </StackPanel>
 </Window>

--- a/src/Samples/SubModelStatic/MainWindow.xaml
+++ b/src/Samples/SubModelStatic/MainWindow.xaml
@@ -1,0 +1,20 @@
+﻿<Window x:Class="Elmish.WPF.Samples.SubModelStatic.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Elmish.WPF.Samples.SubModelStatic"
+        xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelStatic;assembly=SubModelStatic.Core"
+        Title="Sub-model"
+        Height="270"
+        Width="500"
+        WindowStartupLocation="CenterScreen"
+        mc:Ignorable="d"
+        d:DataContext="{x:Static vm:Program.mainDesignVm}">
+  <StackPanel>
+    <TextBlock Text="Counter with clock 1" FontSize="18" FontWeight="Bold" Margin="0,25,0,0" HorizontalAlignment="Center" />
+    <local:CounterWithClock DataContext="{Binding ClockCounter1}" d:DataContext="{Binding DataContext.ClockCounter1, RelativeSource={RelativeSource AncestorType=StackPanel}}"/>
+    <TextBlock Text="Counter with clock 2" FontSize="18" FontWeight="Bold" Margin="0,25,0,0" HorizontalAlignment="Center" />
+    <local:CounterWithClock DataContext="{Binding ClockCounter2}" d:DataContext="{Binding DataContext.ClockCounter2, RelativeSource={RelativeSource AncestorType=StackPanel}}"/>
+  </StackPanel>
+</Window>

--- a/src/Samples/SubModelStatic/MainWindow.xaml.cs
+++ b/src/Samples/SubModelStatic/MainWindow.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows;
+
+namespace Elmish.WPF.Samples.SubModelStatic
+{
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Samples/SubModelStatic/SubModelStatic.csproj
+++ b/src/Samples/SubModelStatic/SubModelStatic.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWpf>true</UseWpf>
+    <OutputType>Exe</OutputType>
+    <DisableWinExeOutputInference>true</DisableWinExeOutputInference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SubModelStatic.Core\SubModelStatic.Core.fsproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## WIP

* Adds a `BindingT<'model,'msg,'a>` type that mirrors `Binding<'model,'msg>` except it unboxes the output type (much more useful for static properties, not very useful for assembling into a list).
* Adds a static helper that can convert a `string -> BindingT<'model,'msg,'a>` to a property getter and setter.
  * Also maybe implement property getter and setter helpers for `string -> Binding<'model,'msg>`, which will not be nearly as type-safe since `Binding<'model,'msg>` doesn't carry type information for the property (boxes to `obj`)