### PR TITLE
Move boxing out of BindingData

### DIFF
--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -90,7 +90,8 @@ module Binding =
 
     /// Elemental instance of a one-way binding.
     let id<'a, 'msg> : string -> Binding<'a, 'msg> =
-      BindingData.OneWay.id<'a, 'msg>
+      BindingData.OneWay.id<'msg>
+      |> BindingData.mapModel box
       |> createBinding
 
     /// Creates a one-way binding to an optional value. The binding
@@ -112,7 +113,8 @@ module Binding =
 
     /// Elemental instance of a one-way-to-source binding.
     let id<'model, 'a> : string -> Binding<'model, 'a> =
-      BindingData.OneWayToSource.id<'model, 'a>
+      BindingData.OneWayToSource.id<'model>
+      |> BindingData.mapMsg unbox
       |> createBinding
 
     /// Creates a one-way-to-source binding to an optional value. The binding
@@ -134,7 +136,9 @@ module Binding =
 
     /// Elemental instance of a two-way binding.
     let id<'a> : string -> Binding<'a, 'a> =
-      BindingData.TwoWay.id<'a> 
+      BindingData.TwoWay.id
+      |> BindingData.mapModel box
+      |> BindingData.mapMsg unbox
       |> createBinding
 
     /// Creates a one-way-to-source binding to an optional value. The binding
@@ -211,7 +215,8 @@ module Binding =
   module OneWaySeq =
 
     let internal create get itemEquals getId =
-      BindingData.OneWaySeq.create get itemEquals getId
+      BindingData.OneWaySeq.create itemEquals getId
+      |> BindingData.mapModel get
       |> createBinding
 
 

--- a/src/Elmish.WPF/BindingData.fs
+++ b/src/Elmish.WPF/BindingData.fs
@@ -362,9 +362,9 @@ module internal BindingData =
 
 
   module OneWay =
-  
-    let id<'a, 'msg> : BindingData<'a, 'msg> =
-      { Get = box }
+
+    let id<'msg> : BindingData<obj, 'msg> =
+      { Get = id }
       |> OneWayData
       |> BaseBindingData
 
@@ -380,9 +380,9 @@ module internal BindingData =
 
 
   module OneWayToSource =
-  
-    let id<'model, 'a> : BindingData<'model, 'a> =
-      { OneWayToSourceData.Set = fun obj _ -> obj |> unbox }
+
+    let id<'model> : BindingData<'model, obj> =
+      { OneWayToSourceData.Set = Func2.id1 }
       |> OneWayToSourceData
       |> BaseBindingData
 
@@ -412,8 +412,8 @@ module internal BindingData =
 
     let boxMinorTypes d = d |> mapMinorTypes box box unbox
 
-    let create get itemEquals getId =
-      { Get = get >> (fun x -> upcast x)
+    let create itemEquals getId =
+      { Get = (fun x -> upcast x)
         CreateCollection = ObservableCollection >> CollectionTarget.create
         ItemEquals = itemEquals
         GetId = getId }
@@ -441,10 +441,10 @@ module internal BindingData =
 
 
   module TwoWay =
-  
-    let id<'a> : BindingData<'a, 'a> =
-      { TwoWayData.Get = box
-        Set = fun obj _ -> obj |> unbox }
+
+    let id : BindingData<obj, obj> =
+      { TwoWayData.Get = id
+        Set = Func2.id1 }
       |> TwoWayData
       |> BaseBindingData
 
@@ -500,7 +500,7 @@ module internal BindingData =
 
     let boxMinorTypes d = d |> mapMinorTypes box unbox
 
-    let create subModelSeqBindingName : BindingData<'id voption, 'id voption> =
+    let create subModelSeqBindingName =
       { Get = id
         Set = Func2.id1
         SubModelSeqBindingName = subModelSeqBindingName }
@@ -545,7 +545,7 @@ module internal BindingData =
       { GetModel = id
         CreateViewModel = createViewModel
         UpdateViewModel = updateViewModel
-        ToMsg = fun _ -> id }
+        ToMsg = Func2.id2 }
       |> boxMinorTypes
       |> SubModelData
       |> BaseBindingData
@@ -647,11 +647,11 @@ module internal BindingData =
     let boxMinorTypes d = d |> mapMinorTypes box box box unbox unbox unbox
 
     let create createViewModel updateViewModel =
-      { GetModels = id
+      { GetModels = (fun x -> upcast x)
         CreateViewModel = createViewModel
         CreateCollection = ObservableCollection >> CollectionTarget.create
         UpdateViewModel = updateViewModel
-        ToMsg = fun _ -> id }
+        ToMsg = Func2.id2 }
       |> boxMinorTypes
       |> SubModelSeqUnkeyedData
       |> BaseBindingData
@@ -699,11 +699,11 @@ module internal BindingData =
       let boxMinorTypes d = d |> mapMinorTypes box box box box unbox unbox unbox unbox
 
       let create createViewModel updateViewModel bmToId vmToId =
-        { GetSubModels = id
+        { GetSubModels = (fun x -> upcast x)
           CreateViewModel = createViewModel
           CreateCollection = ObservableCollection >> CollectionTarget.create
           UpdateViewModel = updateViewModel
-          ToMsg = fun _ -> id
+          ToMsg = Func2.id2
           BmToId = bmToId
           VmToId = vmToId }
         |> boxMinorTypes


### PR DESCRIPTION
First commit extracted out of #470, it seems to stand alone. Basically I extract boxing out of `BindingData.fs` and move it into `Binding.fs` for a more composable structure.