### PR TITLE
Rename TryGetMember and TrySetMember to avoid confusion with system methods

### DIFF
--- a/src/Elmish.WPF/BindingVmHelpers.fs
+++ b/src/Elmish.WPF/BindingVmHelpers.fs
@@ -139,7 +139,7 @@ type SubModelSelectedItemBinding<'model, 'msg, 'bindingModel, 'bindingMsg, 'vm, 
     SubModelSeqBindingName: string
     SelectedItemBinding: SelectedItemBinding<'bindingModel, 'bindingMsg, 'vm, 'id> }
 
-  member b.TryGetMember (model: 'model) =
+  member b.TypedGet(model: 'model) =
     b.Get model |> ValueOption.map (fun selectedId -> selectedId, b.SelectedItemBinding.FromId selectedId)
 
   member b.TrySetMember(model: 'model, vm: 'vm voption) =
@@ -632,7 +632,7 @@ type Get(nameChain: string) =
     | SubModelSeqUnkeyed { Vms = vms }
     | SubModelSeqKeyed { Vms = vms } -> vms.BoxedCollection () |> Ok
     | SubModelSelectedItem b ->
-        b.TryGetMember model
+        b.TypedGet model
         |> function
           | ValueNone -> ValueNone |> Ok // deselecting successful
           | ValueSome (id, mVm) ->

--- a/src/Elmish.WPF/BindingVmHelpers.fs
+++ b/src/Elmish.WPF/BindingVmHelpers.fs
@@ -142,7 +142,7 @@ type SubModelSelectedItemBinding<'model, 'msg, 'bindingModel, 'bindingMsg, 'vm, 
   member b.TypedGet(model: 'model) =
     b.Get model |> ValueOption.map (fun selectedId -> selectedId, b.SelectedItemBinding.FromId selectedId)
 
-  member b.TrySetMember(model: 'model, vm: 'vm voption) =
+  member b.TypedSet(model: 'model, vm: 'vm voption) =
     let id = vm |> ValueOption.map b.SelectedItemBinding.VmToId
     b.Set id model
 
@@ -675,7 +675,7 @@ type Set(value: obj) =
         b.Set value model
         true
     | SubModelSelectedItem b ->
-        b.TrySetMember(model, ValueOption.ofObj value)
+        b.TypedSet(model, ValueOption.ofObj value)
         true
     | OneWay _
     | OneWaySeq _


### PR DESCRIPTION
`TryGetMember` -> `TryGet`
`TrySetMember` -> `TrySet`

This is in response to confusion while debugging `DynamicViewModel.TryGetMember`.