### PR TITLE
Make view model args partly public

### DIFF
--- a/src/Elmish.WPF/ViewModelArgs.fs
+++ b/src/Elmish.WPF/ViewModelArgs.fs
@@ -27,13 +27,11 @@ module internal LoggingViewModelArgs =
       nameChain = "" }
 
 
-type internal ViewModelArgs<'model, 'msg> =
-  { initialModel: 'model
-    dispatch: 'msg -> unit
-    loggingArgs: LoggingViewModelArgs }
+type ViewModelArgs<'model, 'msg> =
+  internal { initialModel: 'model; dispatch: 'msg -> unit; loggingArgs: LoggingViewModelArgs }
 
-module internal ViewModelArgs =
-  let create initialModel dispatch nameChain loggingArgs =
+module ViewModelArgs =
+  let internal create initialModel dispatch nameChain loggingArgs =
     { initialModel = initialModel
       dispatch = dispatch
       loggingArgs = LoggingViewModelArgs.map nameChain loggingArgs }
@@ -42,8 +40,10 @@ module internal ViewModelArgs =
     { initialModel = v.initialModel |> mapModel
       dispatch = mapMsg >> v.dispatch
       loggingArgs = v.loggingArgs }
-  
-  let simple initialModel =
+
+  let createWithoutLogging initialModel dispatch =
     { initialModel = initialModel
-      dispatch = ignore
+      dispatch = dispatch
       loggingArgs = LoggingViewModelArgs.none }
+  
+  let simple initialModel = createWithoutLogging initialModel ignore


### PR DESCRIPTION
Adding a `createWithoutLogging` function that can be used outside the project for view model args (`simple` will be used for design time view models) - could be useful for debugging purposes.

TODO: rename to `create` after renaming the internal one to `createWithLogging` but only after #489 and #475 are merged in (they conflict with that)