### PR TITLE
Make type of get/set propagate to static view model property

### DIFF
--- a/src/Elmish.WPF.Tests/BindingVmHelpersTests.fs
+++ b/src/Elmish.WPF.Tests/BindingVmHelpersTests.fs
@@ -56,6 +56,24 @@ module Get =
     GenX.auto<obj> |> GenX.withNull |> check
 
 
+  [<Fact>]
+  let ``should return error on bad typing`` () =
+    let binding = Binding.SubModel.opt (fun () -> []) >> Binding.mapModel (fun () -> None) <| ""
+
+    let dispatch msg =
+      failwith $"Should not dispatch, got {msg}"
+
+    let vmBinding =
+      Initialize(LoggingViewModelArgs.none, "Nothing", (fun _ -> failwith "Should not call get selected item"))
+        .Recursive((), dispatch, (fun () -> ()), binding.Data)
+      |> Option.defaultWith (fun () -> failwith $"Could not create VmBinding after passing in BindingData: {binding}")
+
+    let vmBinding2 = vmBinding |> MapOutputType.unboxVm
+
+    let getResult: Result<int, GetError> =  Get("Nothing").Recursive((), vmBinding2)
+
+    test <@ match getResult with | Error (GetError.ToNullError (ValueOption.ToNullError.ValueCannotBeNull _)) -> true | _ -> false @>
+
 module Set =
 
   let check<'a when 'a : equality> (g: Gen<'a>) =

--- a/src/Elmish.WPF.Tests/StaticViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/StaticViewModelTests.fs
@@ -37,7 +37,7 @@ type internal TestVm<'model, 'msg, 'B1>(model, binding: string -> Binding<'model
   member _.UpdateModel(m) = IViewModel.updateModel(this, m)
 
   member x.GetPropertyName = nameof(x.GetProperty)
-  member _.GetProperty = base.Get<'B1>() binding
+  member _.GetProperty = base.Get<'B1>() (binding >> Binding.unboxT)
 
   member private __.Dispatch x =
     dispatchMsgs.Add x

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -19,23 +19,23 @@ module Binding =
   let unboxT (binding: Binding<'b, 'msg>): Binding<'b, 'msg, 't> = BindingData.unboxT |> mapData <| binding
 
   /// Maps the model of a binding via a contravariant mapping.
-  let mapModel (f: 'a -> 'b) (binding: Binding<'b, 'msg>) = f |> mapModel |> mapData <| binding
+  let mapModel (f: 'a -> 'b) (binding: Binding<'b, 'msg, 't>) = f |> mapModel |> mapData <| binding
 
   /// Maps the message of a binding with access to the model via a covariant mapping.
-  let mapMsgWithModel (f: 'a -> 'model -> 'b) (binding: Binding<'model, 'a>) = f |> mapMsgWithModel |> mapData <| binding
+  let mapMsgWithModel (f: 'a -> 'model -> 'b) (binding: Binding<'model, 'a, 't>) = f |> mapMsgWithModel |> mapData <| binding
 
   /// Maps the message of a binding via a covariant mapping.
-  let mapMsg (f: 'a -> 'b) (binding: Binding<'model, 'a>) = f |> mapMsg |> mapData <| binding
+  let mapMsg (f: 'a -> 'b) (binding: Binding<'model, 'a, 't>) = f |> mapMsg |> mapData <| binding
 
   /// Sets the message of a binding with access to the model.
-  let setMsgWithModel (f: 'model -> 'b) (binding: Binding<'model, 'a>) = f |> setMsgWithModel |> mapData <| binding
+  let setMsgWithModel (f: 'model -> 'b) (binding: Binding<'model, 'a, 't>) = f |> setMsgWithModel |> mapData <| binding
 
   /// Sets the message of a binding.
-  let setMsg (msg: 'b) (binding: Binding<'model, 'a>) = msg |> setMsg |> mapData <| binding
+  let setMsg (msg: 'b) (binding: Binding<'model, 'a, 't>) = msg |> setMsg |> mapData <| binding
 
 
   /// Restricts the binding to models that satisfy the predicate after some model satisfies the predicate.
-  let addSticky (predicate: 'model -> bool) (binding: Binding<'model, 'msg>) = predicate |> addSticky |> mapData <| binding
+  let addSticky (predicate: 'model -> bool) (binding: Binding<'model, 'msg, 't>) = predicate |> addSticky |> mapData <| binding
 
   /// <summary>
   ///   Adds caching to the given binding.  The cache holds a single value and
@@ -43,7 +43,7 @@ module Binding =
   ///   <c>PropertyChanged</c> event.
   /// </summary>
   /// <param name="binding">The binding to which caching is added.</param>
-  let addCaching (binding: Binding<'model, 'msg>) : Binding<'model, 'msg> =
+  let addCaching (binding: Binding<'model, 'msg, 't>) : Binding<'model, 'msg, 't> =
     binding
     |> mapData addCaching
 
@@ -52,7 +52,7 @@ module Binding =
   /// </summary>
   /// <param name="validate">Returns the errors associated with the given model.</param>
   /// <param name="binding">The binding to which validation is added.</param>
-  let addValidation (validate: 'model -> string list) (binding: Binding<'model, 'msg>) : Binding<'model, 'msg> =
+  let addValidation (validate: 'model -> string list) (binding: Binding<'model, 'msg, 't>) : Binding<'model, 'msg, 't> =
     binding
     |> mapData (addValidation validate)
 
@@ -62,7 +62,7 @@ module Binding =
   /// </summary>
   /// <param name="equals">Updating skipped when this function returns <c>true</c>.</param>
   /// <param name="binding">The binding to which the laziness is added.</param>
-  let addLazy (equals: 'model -> 'model -> bool) (binding: Binding<'model, 'msg>) : Binding<'model, 'msg> =
+  let addLazy (equals: 'model -> 'model -> bool) (binding: Binding<'model, 'msg, 't>) : Binding<'model, 'msg, 't> =
     binding
     |> mapData (addLazy equals)
 
@@ -87,7 +87,7 @@ module Binding =
   /// </summary>
   /// <param name="alteration">The function that can alter the message stream.</param>
   /// <param name="binding">The binding of the altered message stream.</param>
-  let alterMsgStream (alteration: ('b -> unit) -> 'a -> unit) (binding: Binding<'model, 'a>) : Binding<'model, 'b> =
+  let alterMsgStream (alteration: ('b -> unit) -> 'a -> unit) (binding: Binding<'model, 'a, 't>) : Binding<'model, 'b, 't> =
     binding
     |> mapData (alterMsgStream alteration)
 

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -12,6 +12,12 @@ module Binding =
     { Name = binding.Name
       Data = binding.Data |> f }
 
+  /// Boxes the output parameter
+  let boxT (binding: Binding<'b, 'msg, 't>) = BindingData.boxT |> mapData <| binding
+
+  /// Unboxes the output parameter
+  let unboxT (binding: Binding<'b, 'msg>): Binding<'b, 'msg, 't> = BindingData.unboxT |> mapData <| binding
+
   /// Maps the model of a binding via a contravariant mapping.
   let mapModel (f: 'a -> 'b) (binding: Binding<'b, 'msg>) = f |> mapModel |> mapData <| binding
 

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -91,7 +91,6 @@ module Binding =
     /// Elemental instance of a one-way binding.
     let id<'a, 'msg> : string -> Binding<'a, 'msg> =
       OneWay.id
-      |> BindingData.mapModel box
       |> createBinding
 
     /// Creates a one-way binding to an optional value. The binding
@@ -114,7 +113,6 @@ module Binding =
     /// Elemental instance of a one-way-to-source binding.
     let id<'model, 'a> : string -> Binding<'model, 'a> =
       OneWayToSource.id
-      |> BindingData.mapMsg unbox
       |> createBinding
 
     /// Creates a one-way-to-source binding to an optional value. The binding
@@ -137,8 +135,6 @@ module Binding =
     /// Elemental instance of a two-way binding.
     let id<'a> : string -> Binding<'a, 'a> =
       TwoWay.id
-      |> BindingData.mapModel box
-      |> BindingData.mapMsg unbox
       |> createBinding
 
     /// Creates a one-way-to-source binding to an optional value. The binding

--- a/src/Elmish.WPF/BindingData.fs
+++ b/src/Elmish.WPF/BindingData.fs
@@ -245,6 +245,7 @@ module BindingData =
         }
 
   let boxT b = MapT.recursiveCase box unbox b
+  let unboxT b = MapT.recursiveCase unbox box b
 
   let mapModel f =
     let binaryHelper binary x m = binary x (f m)

--- a/src/Elmish.WPF/BindingData.fs
+++ b/src/Elmish.WPF/BindingData.fs
@@ -3,6 +3,7 @@ module internal Elmish.WPF.BindingData
 
 open System.Collections.ObjectModel
 open System.Windows
+open System.Windows.Input
 
 open Elmish
 
@@ -552,7 +553,7 @@ module BindingData =
 
   module Cmd =
 
-    let createWithParam exec canExec autoRequery : BindingData<'model, 'msg, 't> =
+    let createWithParam exec canExec autoRequery : BindingData<'model, 'msg, ICommand> =
       { Exec = exec
         CanExec = canExec
         AutoRequery = autoRequery }

--- a/src/Elmish.WPF/BindingVmHelpers.fs
+++ b/src/Elmish.WPF/BindingVmHelpers.fs
@@ -264,7 +264,7 @@ module internal MapOutputType =
         Vms = b.Vms |> CollectionTarget.mapCollection fOut
         GetCurrentModel = b.GetCurrentModel }
     | SubModelSeqKeyed b -> SubModelSeqKeyed {
-        SubModelSeqKeyedData = { 
+        SubModelSeqKeyedData = {
           GetSubModels = b.SubModelSeqKeyedData.GetSubModels
           CreateViewModel = b.SubModelSeqKeyedData.CreateViewModel
           CreateCollection = b.SubModelSeqKeyedData.CreateCollection >> CollectionTarget.mapCollection fOut
@@ -283,31 +283,31 @@ module internal MapOutputType =
           VmToId = fIn >> b.SelectedItemBinding.VmToId
           FromId = b.SelectedItemBinding.FromId >> Option.map fOut } }
 
-  let rec private recursivecase<'model, 'msg, 'a, 'b> (fOut: 'a -> 'b) (fIn: 'b -> 'a) (data: VmBinding<'model, 'msg, 'a>) : VmBinding<'model, 'msg, 'b> =
+  let rec private recursiveCase<'model, 'msg, 'a, 'b> (fOut: 'a -> 'b) (fIn: 'b -> 'a) (data: VmBinding<'model, 'msg, 'a>) : VmBinding<'model, 'msg, 'b> =
     match data with
     | BaseVmBinding b -> baseCase fOut fIn b |> BaseVmBinding
     | Cached b -> Cached {
-        Binding = recursivecase fOut fIn b.Binding
+        Binding = recursiveCase fOut fIn b.Binding
         GetCache = b.GetCache >> Option.map fOut
         SetCache = Option.map fIn >> b.SetCache
       }
     | AlterMsgStream b -> AlterMsgStream {
-        Binding = recursivecase fOut fIn b.Binding
+        Binding = recursiveCase fOut fIn b.Binding
         Get = b.Get
       }
     | Lazy b -> Lazy {
         Get = b.Get
-        Binding = recursivecase fOut fIn b.Binding
+        Binding = recursiveCase fOut fIn b.Binding
         Equals = b.Equals
       }
     | Validatation b -> Validatation {
-        Binding = recursivecase fOut fIn b.Binding
+        Binding = recursiveCase fOut fIn b.Binding
         Errors = b.Errors
         Validate = b.Validate
       }
 
-  let boxVm b = recursivecase box unbox b
-  let unboxVm b = recursivecase unbox box b
+  let boxVm b = recursiveCase box unbox b
+  let unboxVm b = recursiveCase unbox box b
 
 type SubModelSelectedItemLast() =
 

--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -18,7 +18,7 @@
     <PackageProjectUrl>https://github.com/elmish/Elmish.WPF</PackageProjectUrl>
     <PackageTags>WPF F# fsharp Elmish Elm</PackageTags>
     <PackageIcon>elmish-wpf-logo-128x128.png</PackageIcon>
-    <Version>4.0.0-beta-45</Version>
+    <Version>4.0.0-beta-46</Version>
     <PackageReleaseNotes>https://github.com/elmish/Elmish.WPF/blob/master/RELEASE_NOTES.md</PackageReleaseNotes>
     <!--Turn on warnings for unused values (arguments and let bindings) -->
     <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>

--- a/src/Elmish.WPF/Merge.fs
+++ b/src/Elmish.WPF/Merge.fs
@@ -42,7 +42,7 @@ module CollectionTarget =
       Enumerate = fun () -> upcast oc
       GetCollection = fun () -> oc }
 
-  let private mapA (fOut: 'a0 -> 'a1) (fIn: 'a1 -> 'a0) (ct: CollectionTarget<'a0, 'aCollection>) : CollectionTarget<'a1, 'aCollection> =
+  let mapA (fOut: 'a0 -> 'a1) (fIn: 'a1 -> 'a0) (ct: CollectionTarget<'a0, 'aCollection>) : CollectionTarget<'a1, 'aCollection> =
     { GetLength = ct.GetLength
       GetAt = ct.GetAt >> fOut
       Append = fIn >> ct.Append
@@ -54,7 +54,7 @@ module CollectionTarget =
       Enumerate = ct.Enumerate >> Seq.map fOut
       GetCollection = ct.GetCollection }
 
-  let private mapCollection (fOut: 'aCollection0 -> 'aCollection1) (ct: CollectionTarget<'a, 'aCollection0>) : CollectionTarget<'a, 'aCollection1> =
+  let mapCollection (fOut: 'aCollection0 -> 'aCollection1) (ct: CollectionTarget<'a, 'aCollection0>) : CollectionTarget<'a, 'aCollection1> =
     { GetLength = ct.GetLength
       GetAt = ct.GetAt
       Append = ct.Append
@@ -65,10 +65,6 @@ module CollectionTarget =
       Clear = ct.Clear
       Enumerate = ct.Enumerate
       GetCollection = ct.GetCollection >> fOut }
-
-  let map outMapA outMapCollection inMapA =
-    mapA outMapA inMapA
-    >> mapCollection outMapCollection
 
 
 

--- a/src/Elmish.WPF/ViewModels.fs
+++ b/src/Elmish.WPF/ViewModels.fs
@@ -9,10 +9,12 @@ open Microsoft.Extensions.Logging
 open BindingVmHelpers
 
 /// Represents all necessary data used to create a binding.
-type Binding<'model, 'msg> =
+type Binding<'model, 'msg, 't> =
   internal
     { Name: string
-      Data: BindingData<'model, 'msg, obj> }
+      Data: BindingData<'model, 'msg, 't> }
+
+type Binding<'model, 'msg> = Binding<'model, 'msg, obj>
 
 
 [<AutoOpen>]
@@ -21,6 +23,10 @@ module internal Helpers =
   let createBinding data name =
     { Name = name
       Data = data |> BindingData.boxT }
+
+  let createBindingT data name =
+    { Name = name
+      Data = data }
 
   type SubModelSelectedItemLast with
     member this.CompareBindings() : Binding<'model, 'msg> -> Binding<'model, 'msg> -> int =

--- a/src/Elmish.WPF/ViewModels.fs
+++ b/src/Elmish.WPF/ViewModels.fs
@@ -20,7 +20,7 @@ module internal Helpers =
 
   let createBinding data name =
     { Name = name
-      Data = data }
+      Data = data |> BindingData.boxT }
 
   type SubModelSelectedItemLast with
     member this.CompareBindings() : Binding<'model, 'msg> -> Binding<'model, 'msg> -> int =

--- a/src/Samples/SubModelStatic.Core/Program.fs
+++ b/src/Samples/SubModelStatic.Core/Program.fs
@@ -37,12 +37,12 @@ type [<AllowNullLiteral>] CounterViewModel (args) =
   new() = CounterViewModel(Counter.init |> ViewModelArgs.simple)
 
   member _.StepSize
-    with get() = base.Get<int> () (Binding.OneWay.id >> Binding.addLazy (=) >> Binding.mapModel (fun m -> m.StepSize))
-    and set v = base.Set<int>(v) (Binding.OneWayToSource.id >> Binding.mapMsg Counter.Msg.SetStepSize)
-  member _.CounterValue = base.Get<int> () (Binding.OneWay.id >> Binding.addLazy (=) >> Binding.mapModel (fun m -> m.Count))
-  member _.Increment = base.Get () (Binding.cmd Counter.Increment)
-  member _.Decrement = base.Get () (Binding.cmd Counter.Decrement)
-  member _.Reset = base.Get () (Binding.cmdIf (Counter.Reset, Counter.canReset))
+    with get() = base.Get() (Binding.OneWayT.id >> Binding.addLazy (=) >> Binding.mapModel (fun m -> m.StepSize))
+    and set(v) = base.Set(v) (Binding.OneWayToSourceT.id >> Binding.mapMsg Counter.Msg.SetStepSize)
+  member _.CounterValue = base.Get() (Binding.OneWayT.id >> Binding.addLazy (=) >> Binding.mapModel (fun m -> m.Count))
+  member _.Increment = base.Get() (Binding.cmd Counter.Increment)
+  member _.Decrement = base.Get() (Binding.cmd Counter.Decrement)
+  member _.Reset = base.Get() (Binding.cmdIf (Counter.Reset, Counter.canReset))
 
 
 module Clock =
@@ -78,11 +78,11 @@ type [<AllowNullLiteral>] ClockViewModel (args) =
   
   new() = ClockViewModel(Clock.init () |> ViewModelArgs.simple)
 
-  member _.Time = base.Get<DateTime> () (Binding.OneWay.id >> Binding.addLazy (=) >> Binding.mapModel Clock.getTime)
-  member _.IsLocal = base.Get<bool> () (Binding.OneWay.id >> Binding.addLazy (=) >> Binding.mapModel (fun m -> m.TimeType = Clock.Local))
-  member _.SetLocal = base.Get () (Binding.cmd (Clock.SetTimeType Clock.Local))
-  member _.IsUtc = base.Get<bool> () (Binding.OneWay.id >> Binding.addLazy (=) >> Binding.mapModel (fun m -> m.TimeType = Clock.Utc))
-  member _.SetUtc = base.Get () (Binding.cmd (Clock.SetTimeType Clock.Utc))
+  member _.Time = base.Get() (Binding.OneWayT.id >> Binding.addLazy (=) >> Binding.mapModel Clock.getTime)
+  member _.IsLocal = base.Get() (Binding.OneWayT.id >> Binding.addLazy (=) >> Binding.mapModel (fun m -> m.TimeType = Clock.Local))
+  member _.SetLocal = base.Get() (Binding.cmd (Clock.SetTimeType Clock.Local))
+  member _.IsUtc = base.Get() (Binding.OneWayT.id >> Binding.addLazy (=) >> Binding.mapModel (fun m -> m.TimeType = Clock.Utc))
+  member _.SetUtc = base.Get() (Binding.cmd (Clock.SetTimeType Clock.Utc))
 
 
 module CounterWithClock =
@@ -115,8 +115,8 @@ type [<AllowNullLiteral>] CounterWithClockViewModel (args) =
   
   new() = CounterWithClockViewModel(CounterWithClock.init () |> ViewModelArgs.simple)
 
-  member _.Counter = base.Get<CounterViewModel> () (Binding.SubModelT.req CounterViewModel >> Binding.mapModel CounterWithClock.ModelM.Counter.get >> Binding.mapMsg CounterWithClock.CounterMsg)
-  member _.Clock = base.Get<ClockViewModel> () (Binding.SubModelT.req ClockViewModel >> Binding.mapModel CounterWithClock.ModelM.Clock.get >> Binding.mapMsg CounterWithClock.ClockMsg)
+  member _.Counter = base.Get() (Binding.SubModelT.req CounterViewModel >> Binding.mapModel CounterWithClock.ModelM.Counter.get >> Binding.mapMsg CounterWithClock.CounterMsg)
+  member _.Clock = base.Get() (Binding.SubModelT.req ClockViewModel >> Binding.mapModel CounterWithClock.ModelM.Clock.get >> Binding.mapMsg CounterWithClock.ClockMsg)
 
 
 module App2 =
@@ -151,8 +151,8 @@ type [<AllowNullLiteral>] AppViewModel (args) =
   
   new() = AppViewModel(App2.init () |> ViewModelArgs.simple)
 
-  member _.ClockCounter1 = base.Get<CounterWithClockViewModel> () (Binding.SubModelT.req CounterWithClockViewModel >> Binding.mapModel App2.ModelM.ClockCounter1.get >> Binding.mapMsg App2.ClockCounter1Msg)
-  member _.ClockCounter2 = base.Get<CounterWithClockViewModel> () (Binding.SubModelT.req CounterWithClockViewModel >> Binding.mapModel App2.ModelM.ClockCounter2.get >> Binding.mapMsg App2.ClockCounter2Msg)
+  member _.ClockCounter1 = base.Get() (Binding.SubModelT.req CounterWithClockViewModel >> Binding.mapModel App2.ModelM.ClockCounter1.get >> Binding.mapMsg App2.ClockCounter1Msg)
+  member _.ClockCounter2 = base.Get() (Binding.SubModelT.req CounterWithClockViewModel >> Binding.mapModel App2.ModelM.ClockCounter2.get >> Binding.mapMsg App2.ClockCounter2Msg)
 
 module Program =
 
@@ -179,7 +179,7 @@ module Program =
         .WriteTo.Console()
         .CreateLogger()
 
-    WpfProgram.mkSimple App2.init App2.update (fun () -> [ "Main" |> Binding.SubModelT.req AppViewModel ])
+    WpfProgram.mkSimple App2.init App2.update (fun () -> [ "Main" |> Binding.SubModelT.req AppViewModel |> Binding.boxT ])
     |> WpfProgram.withSubscription (fun _ -> Cmd.ofSub timerTick)
     |> WpfProgram.withLogger (new SerilogLoggerFactory(logger))
     |> WpfProgram.startElmishLoop window


### PR DESCRIPTION
Need this in Getter and Setter helpers where you need to keep the type around longer, but box/unbox it before storing/retrieving it from the static type's storage.

Implements full feature that allows for static type of binding specifiers to bubble all the way up to the property.

~~Merge after #511 and #475~~(Merged)

~~Should wait until after #522 so that it can include the actual usages (as explained below).~~

~~EDIT: this *may* not be necessary, as we may always be able to just unbox things on their way out once #512 is merged in in those getters.~~ Combined with #512 