### PR TITLE
Box BindingData output type separate from minor types

### DIFF
--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -12,6 +12,12 @@ module Binding =
     { Name = binding.Name
       Data = binding.Data |> f }
 
+  /// Boxes the output parameter
+  let boxT (binding: Binding<'b, 'msg, 't>) = BindingData.boxT |> mapData <| binding
+
+  /// Unboxes the output parameter
+  let unboxT (binding: Binding<'b, 'msg>): Binding<'b, 'msg, 't> = BindingData.unboxT |> mapData <| binding
+
   /// Maps the model of a binding via a contravariant mapping.
   let mapModel (f: 'a -> 'b) (binding: Binding<'b, 'msg>) = f |> mapModel |> mapData <| binding
 

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -91,7 +91,6 @@ module Binding =
     /// Elemental instance of a one-way binding.
     let id<'a, 'msg> : string -> Binding<'a, 'msg> =
       OneWay.id
-      |> BindingData.mapModel box
       |> createBinding
 
     /// Creates a one-way binding to an optional value. The binding
@@ -114,7 +113,6 @@ module Binding =
     /// Elemental instance of a one-way-to-source binding.
     let id<'model, 'a> : string -> Binding<'model, 'a> =
       OneWayToSource.id
-      |> BindingData.mapMsg unbox
       |> createBinding
 
     /// Creates a one-way-to-source binding to an optional value. The binding
@@ -137,8 +135,6 @@ module Binding =
     /// Elemental instance of a two-way binding.
     let id<'a> : string -> Binding<'a, 'a> =
       TwoWay.id
-      |> BindingData.mapModel box
-      |> BindingData.mapMsg unbox
       |> createBinding
 
     /// Creates a one-way-to-source binding to an optional value. The binding

--- a/src/Elmish.WPF/BindingData.fs
+++ b/src/Elmish.WPF/BindingData.fs
@@ -245,6 +245,7 @@ module BindingData =
         }
 
   let boxT b = MapT.recursiveCase box unbox b
+  let unboxT b = MapT.recursiveCase unbox box b
 
   let mapModel f =
     let binaryHelper binary x m = binary x (f m)

--- a/src/Elmish.WPF/BindingData.fs
+++ b/src/Elmish.WPF/BindingData.fs
@@ -3,6 +3,7 @@ module internal Elmish.WPF.BindingData
 
 open System.Collections.ObjectModel
 open System.Windows
+open System.Windows.Input
 
 open Elmish
 
@@ -552,7 +553,7 @@ module BindingData =
 
   module Cmd =
 
-    let createWithParam exec canExec autoRequery : BindingData<'model, 'msg, 't> =
+    let createWithParam exec canExec autoRequery : BindingData<'model, 'msg, ICommand> =
       { Exec = exec
         CanExec = canExec
         AutoRequery = autoRequery }

--- a/src/Elmish.WPF/DynamicViewModel.fs
+++ b/src/Elmish.WPF/DynamicViewModel.fs
@@ -9,10 +9,12 @@ open Microsoft.Extensions.Logging
 open BindingVmHelpers
 
 /// Represents all necessary data used to create a binding.
-type Binding<'model, 'msg> =
+type Binding<'model, 'msg, 't> =
   internal
     { Name: string
-      Data: BindingData<'model, 'msg, obj> }
+      Data: BindingData<'model, 'msg, 't> }
+
+type Binding<'model, 'msg> = Binding<'model, 'msg, obj>
 
 
 [<AutoOpen>]
@@ -21,6 +23,10 @@ module internal Helpers =
   let createBinding data name =
     { Name = name
       Data = data |> BindingData.boxT }
+
+  let createBindingT data name =
+    { Name = name
+      Data = data }
 
   type SubModelSelectedItemLast with
     member this.CompareBindings() : Binding<'model, 'msg> -> Binding<'model, 'msg> -> int =

--- a/src/Elmish.WPF/DynamicViewModel.fs
+++ b/src/Elmish.WPF/DynamicViewModel.fs
@@ -20,7 +20,7 @@ module internal Helpers =
 
   let createBinding data name =
     { Name = name
-      Data = data }
+      Data = data |> BindingData.boxT }
 
   type SubModelSelectedItemLast with
     member this.CompareBindings() : Binding<'model, 'msg> -> Binding<'model, 'msg> -> int =

--- a/src/Elmish.WPF/Merge.fs
+++ b/src/Elmish.WPF/Merge.fs
@@ -42,7 +42,7 @@ module CollectionTarget =
       Enumerate = fun () -> upcast oc
       GetCollection = fun () -> oc }
 
-  let private mapA (fOut: 'a0 -> 'a1) (fIn: 'a1 -> 'a0) (ct: CollectionTarget<'a0, 'aCollection>) : CollectionTarget<'a1, 'aCollection> =
+  let mapA (fOut: 'a0 -> 'a1) (fIn: 'a1 -> 'a0) (ct: CollectionTarget<'a0, 'aCollection>) : CollectionTarget<'a1, 'aCollection> =
     { GetLength = ct.GetLength
       GetAt = ct.GetAt >> fOut
       Append = fIn >> ct.Append
@@ -54,7 +54,7 @@ module CollectionTarget =
       Enumerate = ct.Enumerate >> Seq.map fOut
       GetCollection = ct.GetCollection }
 
-  let private mapCollection (fOut: 'aCollection0 -> 'aCollection1) (ct: CollectionTarget<'a, 'aCollection0>) : CollectionTarget<'a, 'aCollection1> =
+  let mapCollection (fOut: 'aCollection0 -> 'aCollection1) (ct: CollectionTarget<'a, 'aCollection0>) : CollectionTarget<'a, 'aCollection1> =
     { GetLength = ct.GetLength
       GetAt = ct.GetAt
       Append = ct.Append
@@ -65,10 +65,6 @@ module CollectionTarget =
       Clear = ct.Clear
       Enumerate = ct.Enumerate
       GetCollection = ct.GetCollection >> fOut }
-
-  let map outMapA outMapCollection inMapA =
-    mapA outMapA inMapA
-    >> mapCollection outMapCollection
 
 
 


### PR DESCRIPTION
## *COMBINED WITH #508*

Conflicts with #506 because of the moved `createBinding` function.

Box the output type T of `BindingData` separately from `boxMinorTypes` methods (and `Binding.fs` helpers). Currently, all functions in `Binding.fs` box it together, but this change allows for other constructs that don't box it.