### PR TITLE
Make WpfProgram more flexible

### DIFF
--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -17,6 +17,8 @@ type WpfProgram<'model, 'msg, 'viewModel> =
     PerformanceLogThreshold: int
   }
 
+type WpfProgram<'model, 'msg> = WpfProgram<'model, 'msg, obj>
+
 
 [<RequireQualifiedAccess>]
 module WpfProgram =

--- a/src/Samples/SubModelStatic.Core/Program.fs
+++ b/src/Samples/SubModelStatic.Core/Program.fs
@@ -179,7 +179,7 @@ module Program =
         .WriteTo.Console()
         .CreateLogger()
 
-    WpfProgram.mkSimple App2.init App2.update (fun () -> [ "Main" |> Binding.SubModelT.req AppViewModel |> Binding.boxT ])
+    WpfProgram.mkSimpleT App2.init App2.update AppViewModel
     |> WpfProgram.withSubscription (fun _ -> Cmd.ofSub timerTick)
     |> WpfProgram.withLogger (new SerilogLoggerFactory(logger))
     |> WpfProgram.startElmishLoop window

--- a/src/Samples/SubModelStatic/MainWindow.xaml
+++ b/src/Samples/SubModelStatic/MainWindow.xaml
@@ -11,7 +11,7 @@
         WindowStartupLocation="CenterScreen"
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance Type=vm:AppViewModel, IsDesignTimeCreatable=True}">
-  <StackPanel DataContext="{Binding Main}" d:DataContext="{Binding}">
+  <StackPanel>
     <TextBlock Text="Counter with clock 1" FontSize="18" FontWeight="Bold" Margin="0,25,0,0" HorizontalAlignment="Center" />
     <local:CounterWithClock DataContext="{Binding ClockCounter1}" />
     <TextBlock Text="Counter with clock 2" FontSize="18" FontWeight="Bold" Margin="0,25,0,0" HorizontalAlignment="Center" />


### PR DESCRIPTION
Should wait until after #522 so that it can include the extra helpers for having a static view model at the very top level.

Makes WpfProgram more flexible from the top level (very similar to `SubModel`)