### PR TITLE
Make ToNullError carry the type information

### DIFF
--- a/src/Elmish.WPF.Tests/UtilsTests.fs
+++ b/src/Elmish.WPF.Tests/UtilsTests.fs
@@ -114,6 +114,7 @@ module ValueOption =
       testNonNull GenX.auto<obj>
       testNonNull GenX.auto<string>
       testNonNull GenX.auto<int>
+      testNonNull GenX.auto<bool>
 
     let testNullForNullable<'a when 'a : equality> () =
       test <@ Ok Unchecked.defaultof<'a> = ValueOption.toNull<'a> ValueNone @>
@@ -123,13 +124,16 @@ module ValueOption =
       testNullForNullable<obj> ()
       testNullForNullable<string> ()
       testNullForNullable<Nullable<int>> ()
+      testNullForNullable<Nullable<bool>> ()
 
     let testNullForNonNullable<'a when 'a : equality> () =
-      test <@ Error ValueOption.ToNullError.ValueCannotBeNull = ValueOption.toNull<'a> ValueNone @>
+      let expected = typeof<'a>.Name |> ValueOption.ToNullError.ValueCannotBeNull |> Error
+      test <@ expected = ValueOption.toNull<'a> ValueNone @>
 
     [<Fact>]
     let ``toNull returns ValueConnotBeNull Error when given ValueNone for nonnullable type`` () =
       testNullForNonNullable<int> ()
+      testNullForNonNullable<bool> ()
 
 
   module ofNull =

--- a/src/Elmish.WPF/InternalUtils.fs
+++ b/src/Elmish.WPF/InternalUtils.fs
@@ -70,7 +70,7 @@ module ValueOption =
 
   [<RequireQualifiedAccess>]
   type ToNullError =
-    | ValueCannotBeNull
+    | ValueCannotBeNull of string
 
   let ofNull<'a> (x: 'a) =
     match box x with
@@ -83,7 +83,7 @@ module ValueOption =
       if box Unchecked.defaultof<'a> = null then
         null |> unbox<'a> |> Ok
       else
-        ToNullError.ValueCannotBeNull |> Error
+        typeof<'a>.Name |> ToNullError.ValueCannotBeNull |> Error
 
 
 [<RequireQualifiedAccess>]


### PR DESCRIPTION
Make so that `ValueOption.ToNullError.ValueCannotBeNull` carries the name of the type that was attempted to be made null for error reporting purposes.