### PR TITLE
Don't call getCurrentModel on initialization

### DIFF
--- a/src/Elmish.WPF.Tests/BindingVmHelpersTests.fs
+++ b/src/Elmish.WPF.Tests/BindingVmHelpersTests.fs
@@ -15,6 +15,20 @@ let name = "name"
 let noGetSelectedItemCall _ = failwith "Should not call get selected item"
 
 
+module Initialize =
+
+  [<Fact>]
+  let ``Initialize doesn't call getCurrentModel`` () =
+    let binding =
+      BindingData.OneWay.id<string, string>
+      |> BindingData.addValidation List.singleton
+
+    let vmBinding =
+      Initialize(LoggingViewModelArgs.none, name, noGetSelectedItemCall)
+        .Recursive("", ignore, (fun _ -> failwith "Should not call getCurrentModel on initialize"), binding)
+
+    test <@ vmBinding.IsSome @>
+
 module Get =
 
   let check<'a when 'a : equality> (g: Gen<'a>) =

--- a/src/Elmish.WPF/BindingVmHelpers.fs
+++ b/src/Elmish.WPF/BindingVmHelpers.fs
@@ -438,7 +438,7 @@ type Initialize<'t>
       | ValidationData d ->
           let d = d |> BindingData.Validation.measureFunctions measure
           let! b = this.Recursive(initialModel, dispatch, getCurrentModel, d.BindingData)
-          return b.AddValidation (getCurrentModel ()) d.Validate
+          return b.AddValidation initialModel d.Validate
       | LazyData d ->
           let initialModel' : obj = d.Get initialModel
           let getCurrentModel' : unit -> obj = getCurrentModel >> d.Get


### PR DESCRIPTION
It always returns the same thing as `initialModel` at that point, and there are cases where this doesn't work (for example, if you are initializing all of the bindings and `getCurrentModel` uses a member access).