### PR TITLE
Use getCurrentModel from Initialize instead of Update to create new view models

### DIFF
--- a/src/Elmish.WPF.Tests/BindingVmHelpersTests.fs
+++ b/src/Elmish.WPF.Tests/BindingVmHelpersTests.fs
@@ -104,7 +104,7 @@ module Update =
 
       let updateResult =
         Update(LoggingViewModelArgs.none, name)
-          .Recursive(ValueSome initialModel, (fun () -> model.Value), newModel, vmBinding)
+          .Recursive(initialModel, newModel, vmBinding)
 
       test <@ updateResult |> List.length = 1 @>
     }

--- a/src/Elmish.WPF/DynamicViewModel.fs
+++ b/src/Elmish.WPF/DynamicViewModel.fs
@@ -98,7 +98,7 @@ type [<AllowNullLiteral>] internal DynamicViewModel<'model, 'msg>
   member internal _.UpdateModel (newModel: 'model) : unit =
     let eventsToRaise =
       bindings
-      |> Seq.collect (fun (Kvp (name, binding)) -> Update(loggingArgs, name).Recursive(ValueNone, (fun () -> currentModel), newModel, binding))
+      |> Seq.collect (fun (Kvp (name, binding)) -> Update(loggingArgs, name).Recursive(currentModel, newModel, binding))
       |> Seq.toList
     currentModel <- newModel
     eventsToRaise


### PR DESCRIPTION
Use getCurrentModel from Initialize instead of Update to create new view models

This removes need for `getCurrentModel` inside of `Update.Recursive`