### PR TITLE
Fix update timing issue

### DIFF
--- a/src/Elmish.WPF.Tests/DynamicViewModelTests.fs
+++ b/src/Elmish.WPF.Tests/DynamicViewModelTests.fs
@@ -222,6 +222,30 @@ module OneWay =
       test <@ vm.Get name = returnEven m (m + 1) @>
     }
 
+  [<Fact>]
+  let ``when model updated, event is not called before view model property is updated`` () =
+    Property.check <| property {
+      let! name = GenX.auto<string>
+      let! m1 = GenX.auto<int>
+      let! m2 = GenX.auto<int> |> GenX.notEqualTo m1
+
+      let get = string<int>
+
+      let binding = oneWay get name
+      let vm = TestVm(m1, binding)
+      let mutable eventFired = false
+
+      (vm :> INotifyPropertyChanged).PropertyChanged.Add (fun e ->
+        test <@ e.PropertyName = name @>
+        test <@ vm.Get name = get m2 @>
+        eventFired <- true
+      )
+
+      vm.UpdateModel m2
+
+      test <@ eventFired @>
+  }
+
 
 
 module OneWayLazy =


### PR DESCRIPTION
Found a bug in #523 that resulted in the events being fired too soon (before the view model's properties were updated). Also added a test that will verify this happening (tested that test fails before this PR).