### PR TITLE
Do not throw NullReferenceException when ValueOption.toNull is called on ValueNone of reference type

### DIFF
--- a/src/Elmish.WPF.Tests/UtilsTests.fs
+++ b/src/Elmish.WPF.Tests/UtilsTests.fs
@@ -135,6 +135,13 @@ module ValueOption =
       testNullForNonNullable<int> ()
       testNullForNonNullable<bool> ()
 
+    type Foo = { Foo: unit }
+    type Bar = Bar of unit
+
+    [<Fact>]
+    let ``toNull does not throw NullReferenceException given reference type`` () =
+      ValueOption.toNull<Foo> ValueNone |> ignore
+      ValueOption.toNull<Bar> ValueNone |> ignore
 
   module ofNull =
 

--- a/src/Elmish.WPF.Tests/UtilsTests.fs
+++ b/src/Elmish.WPF.Tests/UtilsTests.fs
@@ -131,13 +131,13 @@ module ValueOption =
       test <@ expected = ValueOption.toNull<'a> ValueNone @>
 
     [<Fact>]
-    let ``toNull returns ValueConnotBeNull Error when given ValueNone for nonnullable type`` () =
+    let ``toNull returns ValueCannotBeNull Error when given ValueNone for non-nullable type`` () =
       testNullForNonNullable<int> ()
       testNullForNonNullable<bool> ()
 
 
   module ofNull =
-  
+
     let testNull<'a when 'a : equality> () =
       let input = Unchecked.defaultof<'a>
       test <@ ValueNone = ValueOption.ofNull input @>

--- a/src/Elmish.WPF/InternalUtils.fs
+++ b/src/Elmish.WPF/InternalUtils.fs
@@ -80,8 +80,9 @@ module ValueOption =
   let toNull<'a> = function
     | ValueSome x -> Ok x
     | ValueNone ->
-      if box Unchecked.defaultof<'a> = null then
-        Unchecked.defaultof<'a> |> Ok
+      let default' = Unchecked.defaultof<'a>
+      if box default' = null then
+        default' |> Ok
       else
         typeof<'a>.Name |> ToNullError.ValueCannotBeNull |> Error
 

--- a/src/Elmish.WPF/InternalUtils.fs
+++ b/src/Elmish.WPF/InternalUtils.fs
@@ -14,7 +14,7 @@ let ignore2 _ _ = ()
 let (|Kvp|) (kvp: KeyValuePair<_,_>) =
   Kvp (kvp.Key, kvp.Value)
 
-  
+
 [<Struct>]
 type OptionalBuilder =
   member _.Bind(ma, f) =
@@ -23,7 +23,7 @@ type OptionalBuilder =
     Some a
   member _.ReturnFrom(ma) =
     ma
-    
+
 let option = OptionalBuilder()
 
 
@@ -81,7 +81,7 @@ module ValueOption =
     | ValueSome x -> Ok x
     | ValueNone ->
       if box Unchecked.defaultof<'a> = null then
-        null |> unbox<'a> |> Ok
+        Unchecked.defaultof<'a> |> Ok
       else
         typeof<'a>.Name |> ToNullError.ValueCannotBeNull |> Error
 


### PR DESCRIPTION
`unbox null` throws a `NullReferenceException`.

Thanks to @marner2 for figuring out the solution.