### PR TITLE
Make so elmish update and cmd loop can run on non-ui thread

### DIFF
--- a/src/Elmish.WPF.sln
+++ b/src/Elmish.WPF.sln
@@ -83,6 +83,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SubModelStatic", "Samples\S
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "SubModelStatic.Core", "Samples\SubModelStatic.Core\SubModelStatic.Core.fsproj", "{F0064852-8E7F-437B-A414-72EB0FA46711}"
 EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Threading.Core", "Samples\Threading.Core\Threading.Core.fsproj", "{B5029D1D-73A0-4C08-A4A0-1BF52CE919C4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Threading", "Samples\Threading\Threading.csproj", "{36565661-EA23-4965-97A0-2F4FDA0B4B67}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -229,6 +233,14 @@ Global
 		{F0064852-8E7F-437B-A414-72EB0FA46711}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F0064852-8E7F-437B-A414-72EB0FA46711}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F0064852-8E7F-437B-A414-72EB0FA46711}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5029D1D-73A0-4C08-A4A0-1BF52CE919C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5029D1D-73A0-4C08-A4A0-1BF52CE919C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5029D1D-73A0-4C08-A4A0-1BF52CE919C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5029D1D-73A0-4C08-A4A0-1BF52CE919C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36565661-EA23-4965-97A0-2F4FDA0B4B67}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36565661-EA23-4965-97A0-2F4FDA0B4B67}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36565661-EA23-4965-97A0-2F4FDA0B4B67}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36565661-EA23-4965-97A0-2F4FDA0B4B67}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -266,6 +278,8 @@ Global
 		{DFF15AD9-337E-4301-9A05-5CFA147C457E} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
 		{3F50DF04-DE1F-4368-9584-E318FE41AC2C} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
 		{F0064852-8E7F-437B-A414-72EB0FA46711} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
+		{B5029D1D-73A0-4C08-A4A0-1BF52CE919C4} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
+		{36565661-EA23-4965-97A0-2F4FDA0B4B67} = {BBAFEB1E-93C0-4C7E-8E0A-026BB05C88EC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3125D461-08F4-4071-AAE5-1038EF84A360}

--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -174,7 +174,7 @@ module WpfProgram =
        * This avoids race conditions like those that can occur when shutting down.
        * https://github.com/elmish/Elmish.WPF/issues/353
        *)
-      fun msg -> elmishDispatcher.InvokeAsync(fun () -> innerDispatch msg) |> ignore
+      fun msg -> elmishDispatcher.InvokeAsync(fun () -> dispatch msg) |> ignore
 
     let logMsgAndModel (msg: 'msg) (model: 'model) =
       updateLogger.LogTrace("New message: {Message}\nUpdated state:\n{Model}", msg, model)

--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -90,9 +90,31 @@ module WpfProgram =
   | Threaded_PendingUIDispatch of pending: System.Threading.Tasks.TaskCompletionSource<unit -> unit>
   | Threaded_UIDispatch of active: System.Threading.Tasks.TaskCompletionSource<unit -> unit>
 
-  /// Starts an Elmish dispatch loop, setting the bindings as the DataContext for the
+  /// <summary>Starts an Elmish dispatch loop, setting the bindings as the DataContext for the
   /// specified FrameworkElement. Non-blocking. If you have an explicit entry point where
   /// you control app/window instantiation, runWindowWithConfig might be a better option.
+  ///
+  /// If you execute this from a thread other than the thread owning element.Dispatcher (UI Thread),
+  /// Elmish.WPF will use that background thread to run updates rather than the main UI thread.</summary>
+  /// <remarks>Example multithreaded use:
+  /// <code><![CDATA[
+  /// let elmishThread =
+  ///   Thread(
+  ///     ThreadStart(fun () ->
+  ///       WpfProgram.startElmishLoop window program
+  ///       Dispatcher.Run()))
+  /// elmishThread.Name <- "ElmishDispatchThread"
+  /// elmishThread.Run()
+  ///
+  /// mainWindow.Show()
+  /// let result = Application.Current.Run mainWindow
+  ///
+  /// Threading.Dispatcher.FromThread(elmishThread).InvokeShutdown()
+  /// elmishThread.Join()
+  /// ]]></code></remarks>
+  /// <param name="element"></param>
+  /// <param name="program"></param>
+  /// <returns></returns>
   let startElmishLoop
       (element: FrameworkElement)
       (program: WpfProgram<'model, 'msg, 'viewModel>) =

--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -139,7 +139,7 @@ module WpfProgram =
                   dispatch msg
                   threader <- Threaded_NoUIDispatch
 
-                elmishDispatcher.InvokeAsync(synchronizedUiDispatch, Threading.DispatcherPriority.Input) |> ignore
+                elmishDispatcher.InvokeAsync(synchronizedUiDispatch) |> ignore
                 uiWaiter.Task.Result()
               | Threaded_PendingUIDispatch uiWaiter
               | Threaded_UIDispatch uiWaiter ->

--- a/src/Samples/Threading.Core/Program.fs
+++ b/src/Samples/Threading.Core/Program.fs
@@ -1,0 +1,77 @@
+﻿module Elmish.WPF.Samples.Threading.Program
+
+open System.Threading
+open System.Windows.Threading
+
+open Serilog
+open Serilog.Extensions.Logging
+
+open Elmish.WPF
+
+
+
+type Model =
+  { Pings: int
+    Message: string }
+
+type Msg =
+  | IncrementPings
+  | UpdateMessage of string
+
+type Cmd =
+  | DelayThenIncrementPings
+
+
+module Program =
+  module Pings =
+    let get m = m.Pings
+    let set v m = { m with Pings = v }
+    let map f m = m |> get |> f |> set <| m
+
+  module Message =
+    let get m = m.Message
+    let set v m = { m with Message = v }
+
+  let init =
+    { Pings = 0; Message = "" }, [ DelayThenIncrementPings ]
+
+  let update msg m =
+    match msg with
+    | IncrementPings -> m |> Pings.map ((+) 1), [ DelayThenIncrementPings ]
+    | UpdateMessage message -> m |> Message.set message, [ ]
+
+  let bindings () = [
+    "Pings" |> Binding.oneWay Pings.get
+    "Message" |> Binding.twoWay (Message.get, UpdateMessage)
+  ]
+
+  let toCmd =
+    function
+    | DelayThenIncrementPings ->
+      Elmish.Cmd.OfAsyncImmediate.perform (fun () -> Async.Sleep 1000) () (fun () -> IncrementPings)
+
+let designVm =  ViewModel.designInstance { Pings = 2; Message = "Hello" } (Program.bindings ())
+
+let main window =
+
+  let logger =
+    LoggerConfiguration()
+      .MinimumLevel.Override("Elmish.WPF.Update", Events.LogEventLevel.Verbose)
+      .MinimumLevel.Override("Elmish.WPF.Bindings", Events.LogEventLevel.Verbose)
+      .MinimumLevel.Override("Elmish.WPF.Performance", Events.LogEventLevel.Verbose)
+      .WriteTo.Console()
+      .CreateLogger()
+
+  let program =
+    WpfProgram.mkProgramWithCmdMsg (fun () -> Program.init) Program.update Program.bindings Program.toCmd
+    |> WpfProgram.withLogger (new SerilogLoggerFactory(logger))
+
+  let elmishThread =
+    Thread(
+      ThreadStart(fun () ->
+        WpfProgram.startElmishLoop window program
+        Dispatcher.Run()))
+  elmishThread.Name <- "ElmishDispatchThread"
+  elmishThread.Start()
+
+  elmishThread

--- a/src/Samples/Threading.Core/Threading.Core.fsproj
+++ b/src/Samples/Threading.Core/Threading.Core.fsproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup Condition="'$(Configuration)' != 'Debug'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net6.0-windows</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Elmish.WPF\Elmish.WPF.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Samples/Threading/App.xaml
+++ b/src/Samples/Threading/App.xaml
@@ -1,0 +1,6 @@
+﻿<Application x:Class="Threading.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+  <Application.Resources/>
+</Application>

--- a/src/Samples/Threading/App.xaml.cs
+++ b/src/Samples/Threading/App.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Threading;
+using System.Windows;
+using System.Windows.Threading;
+using Elmish.WPF.Samples.Threading;
+
+#nullable enable
+namespace Threading {
+  public partial class App : Application {
+    Thread? ElmishThread { get; set; } = null;
+
+    public App() {
+      this.Activated += StartElmish;
+      this.Exit += StopElmish;
+    }
+
+    private void StopElmish(object? sender, ExitEventArgs e)
+    {
+      Dispatcher.FromThread(ElmishThread)?.InvokeShutdown();
+      ElmishThread?.Join();
+    }
+
+    private void StartElmish(object? _1, EventArgs _2) {
+      this.Activated -= StartElmish;
+      ElmishThread = Program.main(MainWindow);
+    }
+  }
+}

--- a/src/Samples/Threading/MainWindow.xaml
+++ b/src/Samples/Threading/MainWindow.xaml
@@ -1,0 +1,20 @@
+﻿<Window x:Class="Elmish.WPF.Samples.Threading.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:Elmish.WPF.Samples.Threading;assembly=Threading.Core"
+        mc:Ignorable="d"
+        Title="Threading" Height="450" Width="800"
+        d:DataContext="{x:Static vm:Program.designVm}">
+  <Grid>
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition Width="300"/>
+    </Grid.ColumnDefinitions>
+    <StackPanel Grid.Column="0" Orientation="Vertical" Margin="12">
+      <TextBlock Text="{Binding Pings, StringFormat='Seconds Since Startup: {0}'}" />
+      <TextBox Text="{Binding Message, UpdateSourceTrigger=PropertyChanged}" TextWrapping="Wrap" AcceptsReturn="True" Height="80" />
+      <Button Click="Button_Click" Content="Freeze UI 5 seconds"/>
+    </StackPanel>
+  </Grid>
+</Window>

--- a/src/Samples/Threading/MainWindow.xaml
+++ b/src/Samples/Threading/MainWindow.xaml
@@ -15,6 +15,7 @@
       <TextBlock Text="{Binding Pings, StringFormat='Seconds Since Startup: {0}'}" />
       <TextBox Text="{Binding Message, UpdateSourceTrigger=PropertyChanged}" TextWrapping="Wrap" AcceptsReturn="True" Height="80" />
       <Button Click="Button_Click" Content="Freeze UI 5 seconds"/>
+      <Button Click="Button2_Click" Content="Append number of seconds in 5 seconds"/>
     </StackPanel>
   </Grid>
 </Window>

--- a/src/Samples/Threading/MainWindow.xaml.cs
+++ b/src/Samples/Threading/MainWindow.xaml.cs
@@ -13,5 +13,11 @@ namespace Elmish.WPF.Samples.Threading
     {
       System.Threading.Tasks.Task.Delay(5000).Wait();
     }
+
+    private void Button2_Click(object sender, RoutedEventArgs e)
+    {
+      dynamic viewModel = DataContext;
+      System.Threading.Tasks.Task.Delay(5000).ContinueWith(t => viewModel.Message = $"{viewModel.Message}{viewModel.Pings}");
+    }
   }
 }

--- a/src/Samples/Threading/MainWindow.xaml.cs
+++ b/src/Samples/Threading/MainWindow.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System.Windows;
+
+namespace Elmish.WPF.Samples.Threading
+{
+  public partial class MainWindow : Window
+  {
+    public MainWindow()
+    {
+      InitializeComponent();
+    }
+
+    private void Button_Click(object sender, RoutedEventArgs e)
+    {
+      System.Threading.Tasks.Task.Delay(5000).Wait();
+    }
+  }
+}

--- a/src/Samples/Threading/Threading.csproj
+++ b/src/Samples/Threading/Threading.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <OutputType>Exe</OutputType>
+    <DisableWinExeOutputInference>true</DisableWinExeOutputInference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Threading.Core\Threading.Core.fsproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
The basic implementation of this PR would be to invoke all calls to the underlying dispatch on one thread, then invoke all calls to `UpdateViewModel` on the UI thread associated with the window.

However, WPF expects events to raise `NotifyPropertyChanged` events before they exit, otherwise things like textboxes will "reset" following the disconnected update coming from the elmish update thread. This causes, for instance, the cursor to jump to a different location as you are typing. This means that we cannot simply invoke the dispatch calls coming from WPF in an async manner - we must block that call until the elmish update thread has processed that update and generated `NotifyPropertyChanged` events. This block is ok, because any dispatch calls from the non-ui thread will dispatch the UI update asyncronously.

One of the optimizations is to skip `UpdateViewModel` invocations if there is a pending UI update. This is ok, because calls to this function are transitive (skipping one in the middle still results in the same final state).

EDIT: Added a sample project that illustrates the threading capability and how to use it.