### PR TITLE
Add SubModelT.seq

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 4.0.0-beta-49
+* Added `Binding.SubModelT.seq` that allows a `seq` of static sub models that are all properly updated when there is a dispatch.
+
 #### 4.0.0-beta-48
 * Added ability to run elmish update loop on a background thread rather than only on the main UI thread.
 * Added a `Threading` sample project demonstrating above feature.

--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -358,6 +358,14 @@ module Binding =
       |> createBindingT
       >> mapModel ValueSome
 
+    let seq
+      (createVm: ViewModelArgs<'bindingModel, 'msg> -> #seq<#IViewModel<'bindingModel, 'msg>>)
+      : (string -> Binding<'bindingModel, 'msg, #seq<#IViewModel<'bindingModel, 'msg>>>)
+      =
+      SubModel.create createVm (fun (vms, m) -> vms |> Seq.map (fun vm -> vm, m) |> Seq.iter IViewModel.updateModel)
+      |> createBindingT
+      >> mapModel ValueSome
+
   module SubModelSeqUnkeyedT =
 
     let id

--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -18,7 +18,7 @@
     <PackageProjectUrl>https://github.com/elmish/Elmish.WPF</PackageProjectUrl>
     <PackageTags>WPF F# fsharp Elmish Elm</PackageTags>
     <PackageIcon>elmish-wpf-logo-128x128.png</PackageIcon>
-    <Version>4.0.0-beta-48</Version>
+    <Version>4.0.0-beta-49</Version>
     <PackageReleaseNotes>https://github.com/elmish/Elmish.WPF/blob/master/RELEASE_NOTES.md</PackageReleaseNotes>
     <!--Turn on warnings for unused values (arguments and let bindings) -->
     <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>


### PR DESCRIPTION
This is useful if you want to have a list of view models that all share the same model and msg. This list is maintained outside of the elmish loop, and is usually static.