### PR TITLE
Adding fully specified parameter lists to NewWindow.Core and FileDialogsCmdMsg.Core

### DIFF
--- a/src/Samples/NewWindow.Core/App.fs
+++ b/src/Samples/NewWindow.Core/App.fs
@@ -21,34 +21,42 @@ type AppMsg =
   | Window2Close
   | Window2Msg of Window2Msg
 
-
 module App =
-  module Window1 =
-    let get m = m.Window1
-    let set v m = { m with Window1 = v }
-    let map = map get set
-  module Window2 =
-    let get m = m.Window2
-    let set v m = { m with Window2 = v }
-    let map = map get set
-    let mapOutMsg = function
+  module App_Window1 =
+    let get_Window1State (m: App) : WindowState<string> =
+      m.Window1
+    let set_Window1State (v: WindowState<string>) (m: App) : App =
+      { m with Window1 = v }
+    let map_Window1State : ((WindowState<string> -> WindowState<string>) -> App -> App) =
+      map get_Window1State set_Window1State
+  module App_Window2 =
+    let get_Window2 (m: App) : Window2 option =
+      m.Window2
+    let set_Window2 (v: Window2 option) (m: App) : App =
+      { m with Window2 = v }
+    let map_Window2 : ((Window2 option -> Window2 option) -> App -> App) =
+      map get_Window2 set_Window2
+    let mapOutMsg (msg: Window2OutMsg) : AppMsg =
+      match msg with
       | Window2OutMsg.Close -> Window2Close
-    let mapInOutMsg = InOut.cata Window2Msg mapOutMsg
+    let mapInOutMsg : InOut<Window2Msg,Window2OutMsg> -> AppMsg =
+      InOut.cata Window2Msg mapOutMsg
 
   let init =
     { Window1 = WindowState.Closed
       Window2 = None }
 
-  let update = function
-    | Window1Show -> "" |> WindowState.toVisible |> Window1.map
-    | Window1Hide -> "" |> WindowState.toHidden  |> Window1.map
-    | Window1Close -> WindowState.Closed |> Window1.set
-    | Window1SetInput s -> s |> WindowState.set |> Window1.map
-    | Window2Show -> Window2.init |> Some |> Window2.set
-    | Window2Close -> None |> Window2.set
-    | Window2Msg msg -> msg |> Window2.update |> Option.map |> Window2.map
+  let update (msg: AppMsg) : (App -> App) =
+    match msg with
+    | Window1Show -> "" |> WindowState.toVisible |> App_Window1.map_Window1State
+    | Window1Hide -> "" |> WindowState.toHidden  |> App_Window1.map_Window1State
+    | Window1Close -> WindowState.Closed |> App_Window1.set_Window1State
+    | Window1SetInput s -> s |> WindowState.set |> App_Window1.map_Window1State
+    | Window2Show -> Window2.init |> Some |> App_Window2.set_Window2
+    | Window2Close -> None |> App_Window2.set_Window2
+    | Window2Msg msg -> msg |> Window2.update |> Option.map |> App_Window2.map_Window2
 
-  let bindings (createWindow1: unit -> #Window) (createWindow2: unit -> #Window) () = [
+  let bindings (createWindow1: unit -> #Window) (createWindow2: unit -> #Window) unit : Binding<App,AppMsg> list = [
     "Window1Show" |> Binding.cmd Window1Show
     "Window1Hide" |> Binding.cmd Window1Hide
     "Window1Close" |> Binding.cmd Window1Close
@@ -60,13 +68,13 @@ module App =
       Window1.bindings >> Bindings.mapMsg Window1SetInput,
       createWindow1)
     "Window2" |> Binding.subModelWin(
-      Window2.get >> WindowState.ofOption,
+      App_Window2.get_Window2 >> WindowState.ofOption,
       snd,
-      Window2.mapInOutMsg,
+      App_Window2.mapInOutMsg,
       Window2.bindings,
       createWindow2,
       isModal = true)
   ]
 
 let private fail _ = failwith "never called"
-let designVm = ViewModel.designInstance App.init (App.bindings fail fail ())
+let designVm : obj = ViewModel.designInstance App.init (App.bindings fail fail ())

--- a/src/Samples/NewWindow.Core/AutoOpen.fs
+++ b/src/Samples/NewWindow.Core/AutoOpen.fs
@@ -11,7 +11,8 @@ let map get set f a =
 [<RequireQualifiedAccess>]
 module Bool =
   open System.Windows
-  let toVisibilityCollapsed = function
+  let toVisibilityCollapsed (b: bool) : Visibility =
+    match b with
     | true  -> Visibility.Visible
     | false -> Visibility.Collapsed
 
@@ -27,6 +28,7 @@ module InOutModule =
   [<RequireQualifiedAccess>]
   module InOut =
 
-    let cata f g = function
+    let cata (f: 'a -> 'b) (g: 'a0 -> 'b) (inOut: InOut<'a,'a0>) : 'b =
+      match inOut with
       | InOut.In  msg -> msg |> f
       | InOut.Out msg -> msg |> g

--- a/src/Samples/NewWindow.Core/Program.fs
+++ b/src/Samples/NewWindow.Core/Program.fs
@@ -11,7 +11,7 @@ open Elmish.WPF
 open AppModule
 
 
-let main mainWindow (createWindow1: Func<#Window>) (createWindow2: Func<#Window>) =
+let main (mainWindow: Window) (createWindow1: Func<#Window>) (createWindow2: Func<#Window>) : unit =
   let logger =
     LoggerConfiguration()
       .MinimumLevel.Override("Elmish.WPF.Update", Events.LogEventLevel.Verbose)
@@ -19,14 +19,14 @@ let main mainWindow (createWindow1: Func<#Window>) (createWindow2: Func<#Window>
       .MinimumLevel.Override("Elmish.WPF.Performance", Events.LogEventLevel.Verbose)
       .WriteTo.Console()
       .CreateLogger()
-  let createWindow1 () = createWindow1.Invoke()
-  let createWindow2 () =
+  let createWindow1 unit : #Window = createWindow1.Invoke()
+  let createWindow2 unit : #Window =
     let window = createWindow2.Invoke()
     window.Owner <- mainWindow
     window
 
-  let init () = App.init
-  let bindings = App.bindings createWindow1 createWindow2
+  let init unit : App = App.init
+  let bindings : (unit -> Binding<App,AppMsg> list) = App.bindings createWindow1 createWindow2
   WpfProgram.mkSimple init App.update bindings
   |> WpfProgram.withLogger (new SerilogLoggerFactory(logger))
   |> WpfProgram.startElmishLoop mainWindow

--- a/src/Samples/NewWindow.Core/Window1.fs
+++ b/src/Samples/NewWindow.Core/Window1.fs
@@ -4,10 +4,10 @@ open Elmish.WPF
 
 
 module Window1 =
-  let init = ""
+  let init : string = ""
 
-  let bindings () = [
+  let bindings unit : Binding<'b,'b> list = [
     "Input" |> Binding.twoWay (id, id)
   ]
 
-let designVm = ViewModel.designInstance Window1.init (Window1.bindings ())
+let designVm : obj = ViewModel.designInstance Window1.init (Window1.bindings ())

--- a/src/Samples/NewWindow.Core/Window2.fs
+++ b/src/Samples/NewWindow.Core/Window2.fs
@@ -28,37 +28,38 @@ type Window2OutMsg =
 
 module Window2 =
   module Input =
-    let get m = m.Input
-    let set v m = { m with Input = v }
+    let get (m: Window2) : string = m.Input
+    let set (v: string) (m: Window2) : Window2 = { m with Input = v }
   module IsChecked =
-    let get m = m.IsChecked
-    let set v m = { m with IsChecked = v }
+    let get (m: Window2) : bool = m.IsChecked
+    let set (v: bool) (m:Window2) : Window2 = { m with IsChecked = v }
   module ConfirmState =
-    let set v m = { m with ConfirmState = v }
+    let set (v: ConfirmState option) (m: Window2) : Window2 = { m with ConfirmState = v }
 
-  let init =
+  let init : Window2 =
     { Input = ""
       IsChecked = false
       ConfirmState = None }
 
-  let update = function
+  let update (msg: Window2Msg) : (Window2 -> Window2) =
+    match msg with
     | SetInput s -> s |> Input.set
     | SetChecked b -> b |> IsChecked.set
     | Submit -> ConfirmState.Submit |> Some |> ConfirmState.set
     | Cancel -> ConfirmState.Cancel |> Some |> ConfirmState.set
     | Close  -> ConfirmState.Close  |> Some |> ConfirmState.set
 
-  let private confirmStateVisibilityBinding confirmState =
+  let private confirmStateVisibilityBinding (confirmState: ConfirmState) : (string -> Binding<Window2,'a>) =
     fun m -> m.ConfirmState = Some confirmState
     >> Bool.toVisibilityCollapsed
     |> Binding.oneWay
 
-  let private confirmStateToMsg confirmState msg m =
+  let private confirmStateToMsg (confirmState: ConfirmState) (msg: 'a) (m: Window2) : InOut<'a,Window2OutMsg> =
     if m.ConfirmState = Some confirmState
     then InOut.Out Window2OutMsg.Close
     else InOut.In msg
 
-  let bindings () =
+  let bindings unit : Binding<Window2,InOut<Window2Msg,Window2OutMsg>,obj> list =
     let inBindings =
       [ "Input" |> Binding.twoWay (Input.get, SetInput)
         "IsChecked" |> Binding.twoWay (IsChecked.get, SetChecked)
@@ -72,4 +73,4 @@ module Window2 =
         "Close"  |> Binding.cmd (confirmStateToMsg ConfirmState.Close  Close) ]
     inBindings @ inOutBindings
 
-let designVm = ViewModel.designInstance Window2.init (Window2.bindings ())
+let designVm : obj = ViewModel.designInstance Window2.init (Window2.bindings ())


### PR DESCRIPTION
I found Sample/NewWindow.Core/App.fs hard to read. I have a version in [my fork](https://github.com/rfreytag/Elmish.WPF/tree/Adding_fully-specified_parameter_lists), branch: Adding_fully-specified_parameter_lists that I find more readable with the following changes:

    Every function has fully-specified parameter lists and return values. Readability is improved by not having to hover over function names to see what the function manipulates.

    module App, module Window1 and module Window2 have been renamed module App_Window1 and module App_Window2 so their usage in App.bindings is not confused with the actual references to Window2 in App.bindings.

    Clarified module App, module Window1 and module Window2: get, set, and map so they specify the type on which they operate for readability. They are now respectively:
        module App, module Window1: get_Window1State1, set_Window1State1, and map_Window1State1 and
        module App, module Window2: get_Window2, set_Window2, map_Window2.

    Replaced all usage of function with explicit match <parameter name> with to support with the explicit parameter lists.

I added fully-specified parameter lists to the remaining Sample/NewWindow.Core F# files while I was at it.  And then for good measure I did the same to FileDialogsCmdMsg.Core.

Doing this helped me understand what was going on. I hope it will help others adopt Elmish.WPF. I will issue a pull request if you like where I'm going.