### PR TITLE
Improve threading behavior

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 4.0.0-beta-51
+* Allow skipping intermediate updates when they pile up on UI Thread.
+* Notify Property Changed directly on Set rather than waiting around for the next update. Set value is now cached until the next time update/dispatch is called.
+
 #### 4.0.0-beta-50
 * Upgraded to Elmish v4
   * **BREAKING:** Changed syntax of `WpfProgram.withSubscription` to now take named list of `Subscribe<'msg> = Dispatch<'msg> -> IDisposable` (note the `IDisposable` return). This function now gets called every time `'model` updates (previously it was only called on startup). This allows starting and stopping of subscriptions from this function by the given string list identifier.

--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -18,7 +18,7 @@
     <PackageProjectUrl>https://github.com/elmish/Elmish.WPF</PackageProjectUrl>
     <PackageTags>WPF F# fsharp Elmish Elm</PackageTags>
     <PackageIcon>elmish-wpf-logo-128x128.png</PackageIcon>
-    <Version>4.0.0-beta-50</Version>
+    <Version>4.0.0-beta-51</Version>
     <PackageReleaseNotes>https://github.com/elmish/Elmish.WPF/blob/master/RELEASE_NOTES.md</PackageReleaseNotes>
     <!--Turn on warnings for unused values (arguments and let bindings) -->
     <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>


### PR DESCRIPTION
Adds a caching feature for setters which allows us to notify property changed within the setter rather than waiting for UpdateModel to be called (which is more idiomatic within MVVM).

With this in play, the threaded behavior no longer has to block on potentially expensive ViewModel Updates in order to guarantee well-behaved TwoWay bindings on TextBoxes. Instead, we can schedule ViewModel Updates so that they "drop" intermediate Updates when they start piling up. This is possible because ViewModel Updates are fundamentally transitive with MVU. So for example, `vm.Update(model1); vm.Update(model2); vm.Update(model3);` always results in the same final view state as `vm.Update(model1); vm.Update(model3);`

This latter behavior only applies to Elmish in multithreaded mode. It does not change the normal singlethreaded behavior at all.