### PR TITLE
Ensure that latest model is always applied in threaded case

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 4.0.0-beta-52
+* Fixed a bug in the threaded dispatch case that could result in an out-of-date model being updated.
+* Skip intermediate updates to view model when they queue up in the threaded case.
+
 #### 4.0.0-beta-50
 * Upgraded to Elmish v4
   * **BREAKING:** Changed syntax of `WpfProgram.withSubscription` to now take named list of `Subscribe<'msg> = Dispatch<'msg> -> IDisposable` (note the `IDisposable` return). This function now gets called every time `'model` updates (previously it was only called on startup). This allows starting and stopping of subscriptions from this function by the given string list identifier.

--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -18,7 +18,7 @@
     <PackageProjectUrl>https://github.com/elmish/Elmish.WPF</PackageProjectUrl>
     <PackageTags>WPF F# fsharp Elmish Elm</PackageTags>
     <PackageIcon>elmish-wpf-logo-128x128.png</PackageIcon>
-    <Version>4.0.0-beta-50</Version>
+    <Version>4.0.0-beta-52</Version>
     <PackageReleaseNotes>https://github.com/elmish/Elmish.WPF/blob/master/RELEASE_NOTES.md</PackageReleaseNotes>
     <!--Turn on warnings for unused values (arguments and let bindings) -->
     <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>


### PR DESCRIPTION
Improved implementation of #575 that doesn't result in inconsistent view model states on the UI thread.