### PR TITLE
Fix threading issue

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 4.0.0-beta-53
+* Corrected the threaded dispatch case when an immediate UI update was needed. Done by adding an unschedule `Dispatcher` job at the same priority as the other scheduler jobs, which will force it to run in the correct order before any of the execute update jobs arrive to the queue, thus preventing any of the old scheduler jobs from getting executed _after_ this immediate UI update.
+* Added debug logging with counters to represent the increasing sequence of `setUiState` being called and scheduled on other threads (to ensure proper ordering).
+
 #### 4.0.0-beta-52
 * Fixed a bug in the threaded dispatch case that could result in an out-of-date model being updated.
 * Skip intermediate updates to view model when they queue up in the threaded case.

--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -18,7 +18,7 @@
     <PackageProjectUrl>https://github.com/elmish/Elmish.WPF</PackageProjectUrl>
     <PackageTags>WPF F# fsharp Elmish Elm</PackageTags>
     <PackageIcon>elmish-wpf-logo-128x128.png</PackageIcon>
-    <Version>4.0.0-beta-52</Version>
+    <Version>4.0.0-beta-53</Version>
     <PackageReleaseNotes>https://github.com/elmish/Elmish.WPF/blob/master/RELEASE_NOTES.md</PackageReleaseNotes>
     <!--Turn on warnings for unused values (arguments and let bindings) -->
     <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>

--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -196,8 +196,13 @@ module WpfProgram =
       | Some vm -> // view model exists, so update
           match threader with
           | Threaded_UIDispatch uiWaiter -> // We are in the specific dispatch call from the UI thread (see `synchronizedUiDispatch` in `dispatchFromViewModel`)
-            uiWaiter.SetResult(fun () -> program.UpdateViewModel (vm, model); pendingModel <- ValueNone) // execute `UpdateViewModel` on UI thread
             updateLogger.LogDebug("SetUIState {i} UIDISPATCH", i);
+
+            let executeJobImmediately () =
+              program.UpdateViewModel (vm, model)
+              updateLogger.LogDebug("Update done from main thread {i}", i)
+
+            uiWaiter.SetResult(executeJobImmediately) // execute `UpdateViewModel` on UI thread
           | Threaded_PendingUIDispatch _ // We are in a non-UI dispatch that updated the model before the UI got its update in, but after the user interacted
           | Threaded_NoUIDispatch -> // We are in a non-UI dispatch with no pending user interactions known
             updateLogger.LogDebug("SetUIState {i} NOUIDISPATCH {threader}", i, threader);

--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -194,8 +194,7 @@ module WpfProgram =
           match threader with
           | Threaded_UIDispatch uiWaiter -> // We are in the specific dispatch call from the UI thread (see `synchronizedUiDispatch` in `dispatchFromViewModel`)
             uiWaiter.SetResult(fun () -> program.UpdateViewModel (vm, model); pendingModel <- ValueNone) // execute `UpdateViewModel` on UI thread
-          | Threaded_PendingUIDispatch _ -> // We are in a non-UI dispatch that updated the model before the UI got its update in, but after the user interacted
-            () // Skip updating the UI since the screen is frozen anyways, and `program.UpdateViewModel` is fully transitive
+          | Threaded_PendingUIDispatch _ // We are in a non-UI dispatch that updated the model before the UI got its update in, but after the user interacted
           | Threaded_NoUIDispatch -> // We are in a non-UI dispatch with no pending user interactions known
             let scheduleJob () =
               pendingModel <- ValueSome model

--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -173,7 +173,10 @@ module WpfProgram =
     // Core Elmish calls this from `dispatch`, which means this is always called from `elmishDispatcher`
     // (which is UI thread in single-threaded case)
     let mutable pendingModel = ValueNone
+    let mutable ct = 0
     let setUiState model _syncDispatch =
+      let i = ct
+      ct <- ct + 1
       let scheduleJobThreadPriority = Threading.DispatcherPriority.Send
       let executeJobThreadPriority = Threading.DispatcherPriority.Background
 
@@ -194,18 +197,23 @@ module WpfProgram =
           match threader with
           | Threaded_UIDispatch uiWaiter -> // We are in the specific dispatch call from the UI thread (see `synchronizedUiDispatch` in `dispatchFromViewModel`)
             uiWaiter.SetResult(fun () -> program.UpdateViewModel (vm, model); pendingModel <- ValueNone) // execute `UpdateViewModel` on UI thread
+            updateLogger.LogDebug("SetUIState {i} UIDISPATCH", i);
           | Threaded_PendingUIDispatch _ // We are in a non-UI dispatch that updated the model before the UI got its update in, but after the user interacted
           | Threaded_NoUIDispatch -> // We are in a non-UI dispatch with no pending user interactions known
+            updateLogger.LogDebug("SetUIState {i} NOUIDISPATCH {threader}", i, threader);
+
             let scheduleJob () =
               pendingModel <- ValueSome model
+              updateLogger.LogDebug("Scheduled new job {i}", i)
 
             let executeJob () =
               match pendingModel with
               | ValueSome m ->
                 program.UpdateViewModel (vm, m)
                 pendingModel <- ValueNone
+                updateLogger.LogDebug("Job was full - Update done {i}", i)
               | ValueNone ->
-                bindingsLogger.LogDebug("Job was empty - No update done.")
+                updateLogger.LogDebug("Job was empty - No update done {i}", i)
 
             element.Dispatcher.InvokeAsync(scheduleJob, scheduleJobThreadPriority) |> ignore // Schedule update
             element.Dispatcher.InvokeAsync(executeJob, executeJobThreadPriority) |> ignore // Execute Update

--- a/src/Elmish.WPF/WpfProgram.fs
+++ b/src/Elmish.WPF/WpfProgram.fs
@@ -174,6 +174,9 @@ module WpfProgram =
     // (which is UI thread in single-threaded case)
     let mutable pendingModel = ValueNone
     let setUiState model _syncDispatch =
+      let scheduleJobThreadPriority = Threading.DispatcherPriority.Send
+      let executeJobThreadPriority = Threading.DispatcherPriority.Background
+
       match viewModel with
       | None -> // no view model yet, so create one
           let args =
@@ -205,8 +208,8 @@ module WpfProgram =
               | ValueNone ->
                 bindingsLogger.LogDebug("Job was empty - No update done.")
 
-            element.Dispatcher.InvokeAsync(scheduleJob, Threading.DispatcherPriority.Normal) |> ignore // Schedule update
-            element.Dispatcher.InvokeAsync(executeJob, Threading.DispatcherPriority.Background) |> ignore // Execute Update
+            element.Dispatcher.InvokeAsync(scheduleJob, scheduleJobThreadPriority) |> ignore // Schedule update
+            element.Dispatcher.InvokeAsync(executeJob, executeJobThreadPriority) |> ignore // Execute Update
           | SingleThreaded -> // If we aren't using different threads, always process normally
             element.Dispatcher.Invoke(fun () -> program.UpdateViewModel (vm, model))
 


### PR DESCRIPTION
Ensures that `program.UpdateViewModel(vm, m)` is always run in the correct order, even when an immediate UI update is requested. This is done by scheduling a job cleanup in order with the other scheduled job adds, which will always execute before any jobs are executed (because of dispatcher priority)