### PR TITLE
Add .NET 8 to targets and remove netcoreapp3.1

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: |
-          3.1.x
+          8.0.x
           6.0.x
 
     - name: Restore

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: |
-          3.1.x
+          8.0.x
           6.0.x
 
     - name: Restore

--- a/src/Elmish.WPF.Benchmarks/Elmish.WPF.Benchmarks.fsproj
+++ b/src/Elmish.WPF.Benchmarks/Elmish.WPF.Benchmarks.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
   </PropertyGroup>
 

--- a/src/Elmish.WPF.Tests/Elmish.WPF.Tests.fsproj
+++ b/src/Elmish.WPF.Tests/Elmish.WPF.Tests.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows;netcoreapp3.1;net480</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net6.0-windows;net480</TargetFrameworks>
     <UseWpf>true</UseWpf>
     <!--Turn on warnings for unused values (arguments and let bindings) -->
     <OtherFlags>$(OtherFlags) --warnon:1182</OtherFlags>

--- a/src/Elmish.WPF/Elmish.WPF.fsproj
+++ b/src/Elmish.WPF/Elmish.WPF.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows;netcoreapp3.1;net480</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net6.0-windows;net480</TargetFrameworks>
     <UseWpf>true</UseWpf>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Samples/Capabilities.Core/Capabilities.Core.fsproj
+++ b/src/Samples/Capabilities.Core/Capabilities.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/Capabilities/Capabilities.csproj
+++ b/src/Samples/Capabilities/Capabilities.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/EventBindingsAndBehaviors.Core/EventBindingsAndBehaviors.Core.fsproj
+++ b/src/Samples/EventBindingsAndBehaviors.Core/EventBindingsAndBehaviors.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/EventBindingsAndBehaviors/EventBindingsAndBehaviors.csproj
+++ b/src/Samples/EventBindingsAndBehaviors/EventBindingsAndBehaviors.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/FileDialogs.Core/FileDialogs.Core.fsproj
+++ b/src/Samples/FileDialogs.Core/FileDialogs.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/FileDialogs/FileDialogs.csproj
+++ b/src/Samples/FileDialogs/FileDialogs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/FileDialogsCmdMsg.Core/FileDialogsCmdMsg.Core.fsproj
+++ b/src/Samples/FileDialogsCmdMsg.Core/FileDialogsCmdMsg.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/FileDialogsCmdMsg/FileDialogsCmdMsg.csproj
+++ b/src/Samples/FileDialogsCmdMsg/FileDialogsCmdMsg.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/Multiselect.Core/Multiselect.Core.fsproj
+++ b/src/Samples/Multiselect.Core/Multiselect.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/Multiselect/Multiselect.csproj
+++ b/src/Samples/Multiselect/Multiselect.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/NewWindow.Core/NewWindow.Core.fsproj
+++ b/src/Samples/NewWindow.Core/NewWindow.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/NewWindow/NewWindow.csproj
+++ b/src/Samples/NewWindow/NewWindow.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/OneWaySeq.Core/OneWaySeq.Core.fsproj
+++ b/src/Samples/OneWaySeq.Core/OneWaySeq.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/OneWaySeq/OneWaySeq.csproj
+++ b/src/Samples/OneWaySeq/OneWaySeq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/SingleCounter.Core/SingleCounter.Core.fsproj
+++ b/src/Samples/SingleCounter.Core/SingleCounter.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/SingleCounter/SingleCounter.csproj
+++ b/src/Samples/SingleCounter/SingleCounter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/Sticky.Core/Sticky.Core.fsproj
+++ b/src/Samples/Sticky.Core/Sticky.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/Sticky/Sticky.csproj
+++ b/src/Samples/Sticky/Sticky.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/SubModel.Core/SubModel.Core.fsproj
+++ b/src/Samples/SubModel.Core/SubModel.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/SubModel/SubModel.csproj
+++ b/src/Samples/SubModel/SubModel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/SubModelOpt.Core/SubModelOpt.Core.fsproj
+++ b/src/Samples/SubModelOpt.Core/SubModelOpt.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/SubModelOpt/SubModelOpt.csproj
+++ b/src/Samples/SubModelOpt/SubModelOpt.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/SubModelSelectedItem.Core/SubModelSelectedItem.Core.fsproj
+++ b/src/Samples/SubModelSelectedItem.Core/SubModelSelectedItem.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/SubModelSelectedItem/SubModelSelectedItem.csproj
+++ b/src/Samples/SubModelSelectedItem/SubModelSelectedItem.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/SubModelSeq.Core/SubModelSeq.Core.fsproj
+++ b/src/Samples/SubModelSeq.Core/SubModelSeq.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/SubModelSeq/SubModelSeq.csproj
+++ b/src/Samples/SubModelSeq/SubModelSeq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/SubModelStatic.Core/SubModelStatic.Core.fsproj
+++ b/src/Samples/SubModelStatic.Core/SubModelStatic.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/SubModelStatic/SubModelStatic.csproj
+++ b/src/Samples/SubModelStatic/SubModelStatic.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/Threading.Core/Threading.Core.fsproj
+++ b/src/Samples/Threading.Core/Threading.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/Threading/Threading.csproj
+++ b/src/Samples/Threading/Threading.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/UiBoundCmdParam.Core/UiBoundCmdParam.Core.fsproj
+++ b/src/Samples/UiBoundCmdParam.Core/UiBoundCmdParam.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/UiBoundCmdParam/UiBoundCmdParam.csproj
+++ b/src/Samples/UiBoundCmdParam/UiBoundCmdParam.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/src/Samples/Validation.Core/Validation.Core.fsproj
+++ b/src/Samples/Validation.Core/Validation.Core.fsproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Samples/Validation/Validation.csproj
+++ b/src/Samples/Validation/Validation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWpf>true</UseWpf>
     <OutputType>Exe</OutputType>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>


### PR DESCRIPTION
Move primary focus to .NET 8 instead of .NET 6. Remove netcoreapp3.1 target.