### PR TITLE
[Samples] from dynamic bindings to static VM ("SubModelOpt" sample)

### DIFF
--- a/src/Samples/SubModelOpt.Core/Program.fs
+++ b/src/Samples/SubModelOpt.Core/Program.fs
@@ -1,6 +1,5 @@
 ﻿namespace Program
 
-
 open Serilog
 open Serilog.Extensions.Logging
 open Elmish.WPF

--- a/src/Samples/SubModelOpt.Core/Program.fs
+++ b/src/Samples/SubModelOpt.Core/Program.fs
@@ -1,4 +1,5 @@
-﻿module Elmish.WPF.Samples.SubModelOpt.Program
+﻿namespace Program
+
 
 open Serilog
 open Serilog.Extensions.Logging
@@ -7,128 +8,190 @@ open Elmish.WPF
 
 module Form1 =
 
-  type Model =
-    { Text: string }
+    type Model = { Text: string }
 
-  type Msg =
-    | SetText of string
-    | Submit
+    type Msg =
+        | SetText of string
+        | Submit
 
-  let init =
-    { Text = "" }
+    let init = { Text = "" }
 
-  let update msg m =
-    match msg with
-    | SetText s -> { m with Text = s }
-    | Submit -> m  // handled by parent
+    let update msg m =
+        match msg with
+        | SetText s -> { m with Text = s }
+        | Submit -> m // handled by parent
 
-  let bindings () : Binding<Model, Msg> list = [
-    "Text" |> Binding.twoWay ((fun m -> m.Text), SetText)
-    "Submit" |> Binding.cmd Submit
-  ]
+
+[<AllowNullLiteral>]
+type Form1_ViewModel(args) =
+    inherit ViewModelBase<Form1.Model, Form1.Msg>(args)
+
+    let text_Binding =
+        Binding.TwoWayT.id
+        >> Binding.mapModel (fun (m: Form1.Model) -> m.Text)
+        >> Binding.mapMsg Form1.SetText
+
+
+    member _.Text
+        with get() = base.Get() (text_Binding)
+        and set(v) = base.Set(v) (text_Binding)
+
+    member _.Submit = base.Get () (Binding.CmdT.setAlways Form1.Submit)
+
 
 
 module Form2 =
 
-  type Model =
-    { Text1: string
-      Text2: string }
+    type Model = { Text1: string; Text2: string }
 
-  type Msg =
-    | SetText1 of string
-    | SetText2 of string
-    | Submit
+    type Msg =
+        | SetText1 of string
+        | SetText2 of string
+        | Submit
 
-  let init =
-    { Text1 = ""
-      Text2 = "" }
+    let init = { Text1 = ""; Text2 = "" }
 
-  let update msg m =
-    match msg with
-    | SetText1 s -> { m with Text1 = s }
-    | SetText2 s -> { m with Text2 = s }
-    | Submit -> m  // handled by parent
+    let update msg m =
+        match msg with
+        | SetText1 s -> { m with Text1 = s }
+        | SetText2 s -> { m with Text2 = s }
+        | Submit -> m // handled by parent
 
-  let bindings () : Binding<Model, Msg> list = [
-    "Text1" |> Binding.twoWay ((fun m -> m.Text1), SetText1)
-    "Text2" |> Binding.twoWay ((fun m -> m.Text2), SetText2)
-    "Submit" |> Binding.cmd Submit
-  ]
+
+[<AllowNullLiteral>]
+type Form2_ViewModel(args) =
+    inherit ViewModelBase<Form2.Model, Form2.Msg>(args)
+
+    let text1_Binding =
+        Binding.TwoWayT.id
+        >> Binding.mapModel (fun (m: Form2.Model) -> m.Text1)
+        >> Binding.mapMsg Form2.SetText1
+
+    let text2_Binding =
+        Binding.TwoWayT.id
+        >> Binding.mapModel (fun (m: Form2.Model) -> m.Text2)
+        >> Binding.mapMsg Form2.SetText2
+
+
+    member _.Text1
+        with get () = base.Get () (text1_Binding)
+        and set (v) = base.Set (v) (text1_Binding)
+
+    member _.Text2
+        with get () = base.Get () (text2_Binding)
+        and set (v) = base.Set (v) (text2_Binding)
+
+    member _.Submit = base.Get () (Binding.CmdT.setAlways Form2.Submit)
+
 
 
 module App =
 
-  type Dialog =
-    | Form1 of Form1.Model
-    | Form2 of Form2.Model
+    type Dialog =
+        | Form1 of Form1.Model
+        | Form2 of Form2.Model
 
-  type Model =
-    { Dialog: Dialog option }
+    type Model = { Dialog: Dialog option }
 
-  let init () =
-    { Dialog = None }
+    let init () = { Dialog = None  }
 
-  type Msg =
-    | ShowForm1
-    | ShowForm2
-    | Form1Msg of Form1.Msg
-    | Form2Msg of Form2.Msg
+    type Msg =
+        | ShowForm1
+        | ShowForm2
+        | Form1Msg of Form1.Msg
+        | Form2Msg of Form2.Msg
 
-  let update msg m =
-    match msg with
-    | ShowForm1 -> { m with Dialog = Some <| Form1 Form1.init }
-    | ShowForm2 -> { m with Dialog = Some <| Form2 Form2.init }
-    | Form1Msg Form1.Submit -> { m with Dialog = None }
-    | Form1Msg msg' ->
-        match m.Dialog with
-        | Some (Form1 m') -> { m with Dialog = Form1.update msg' m' |> Form1 |> Some }
-        | _ -> m
-    | Form2Msg Form2.Submit -> { m with Dialog = None }
-    | Form2Msg msg' ->
-        match m.Dialog with
-        | Some (Form2 m') -> { m with Dialog = Form2.update msg' m' |> Form2 |> Some }
-        | _ -> m
-
-  let bindings () : Binding<Model, Msg> list = [
-    "ShowForm1" |> Binding.cmd ShowForm1
-
-    "ShowForm2" |> Binding.cmd ShowForm2
-
-    "DialogVisible" |> Binding.oneWay (fun m -> m.Dialog.IsSome)
-
-    "Form1Visible" |> Binding.oneWay
-      (fun m -> match m.Dialog with Some (Form1 _) -> true | _ -> false)
-
-    "Form2Visible" |> Binding.oneWay
-      (fun m -> match m.Dialog with Some (Form2 _) -> true | _ -> false)
-
-    "Form1"
-      |> Binding.SubModel.opt Form1.bindings
-      |> Binding.mapModel (fun m -> match m.Dialog with Some (Form1 m') -> Some m' | _ -> None)
-      |> Binding.mapMsg Form1Msg
-
-    "Form2"
-      |> Binding.SubModel.opt Form2.bindings
-      |> Binding.mapModel (fun m -> match m.Dialog with Some (Form2 m') -> Some m' | _ -> None)
-      |> Binding.mapMsg Form2Msg
-  ]
+    let update msg m =
+        match msg with
+        | ShowForm1 -> { m with Dialog = Some <| Form1 Form1.init }
+        | ShowForm2 -> { m with Dialog = Some <| Form2 Form2.init }
+        | Form1Msg Form1.Submit -> { m with Dialog = None }
+        | Form1Msg msg' ->
+            match m.Dialog with
+            | Some (Form1 m') -> { m with Dialog = Form1.update msg' m' |> Form1 |> Some }
+            | _ -> m
+        | Form2Msg Form2.Submit -> { m with Dialog = None }
+        | Form2Msg msg' ->
+            match m.Dialog with
+            | Some (Form2 m') -> { m with Dialog = Form2.update msg' m' |> Form2 |> Some }
+            | _ -> m
 
 
-let form1DesignVm = ViewModel.designInstance Form1.init (Form1.bindings ())
-let form2DesignVm = ViewModel.designInstance Form2.init (Form2.bindings ())
-let mainDesignVm = ViewModel.designInstance (App.init ()) (App.bindings ())
+[<AllowNullLiteral>] 
+type App_ViewModel (args) =
+    inherit ViewModelBase<App.Model, App.Msg>(args)
+
+    // bindings
+    let form1Visible_Binding =
+        Binding.OneWayT.id
+        >> Binding.mapModel (fun (m: App.Model) ->
+            match m.Dialog with
+            | Some (App.Dialog.Form1 _) -> true
+            | _ -> false)
 
 
-let main window =
+    let form2Visible_Binding =
+        Binding.OneWayT.id
+        >> Binding.mapModel (fun (m: App.Model) ->
+            match m.Dialog with
+            | Some (App.Dialog.Form2 _) -> true
+            | _ -> false)
 
-  let logger =
-    LoggerConfiguration()
-      .MinimumLevel.Override("Elmish.WPF.Update", Events.LogEventLevel.Verbose)
-      .MinimumLevel.Override("Elmish.WPF.Bindings", Events.LogEventLevel.Verbose)
-      .MinimumLevel.Override("Elmish.WPF.Performance", Events.LogEventLevel.Verbose)
-      .WriteTo.Console()
-      .CreateLogger()
 
-  WpfProgram.mkSimple App.init App.update App.bindings
-  |> WpfProgram.withLogger (new SerilogLoggerFactory(logger))
-  |> WpfProgram.startElmishLoop window
+    let form1_Binding =
+        Binding.SubModelT.opt Form1_ViewModel
+        >> Binding.mapModel (fun (m: App.Model) ->
+            match m.Dialog with
+            | Some (App.Dialog.Form1 m') -> ValueSome m'
+            | _ -> ValueNone)
+        >> Binding.mapMsg (fun msg -> App.Form1Msg msg)
+
+
+    let form2_Binding =
+        Binding.SubModelT.opt Form2_ViewModel
+        >> Binding.mapModel (fun (m: App.Model) ->
+            match m.Dialog with
+            | Some (App.Dialog.Form2 m') -> ValueSome m'
+            | _ -> ValueNone)
+        >> Binding.mapMsg (fun msg -> App.Form2Msg msg)
+
+
+    new() = App_ViewModel(App.init () |> ViewModelArgs.simple)
+
+
+    // members
+    member _.ShowForm1 = base.Get () (Binding.CmdT.setAlways App.ShowForm1)
+
+    member _.ShowForm2 = base.Get () (Binding.CmdT.setAlways App.ShowForm2)
+
+    member _.DialogVisible =
+        base.Get
+            ()
+            (Binding.OneWayT.id
+                >> Binding.mapModel (fun m -> m.Dialog.IsSome))
+
+
+    member _.Form1Visible = base.Get () (form1Visible_Binding)
+
+    member _.Form2Visible = base.Get () (form2Visible_Binding)
+
+    member _.Form1 = base.Get () (form1_Binding)
+
+    member _.Form2 = base.Get () (form2_Binding)
+
+
+
+module Program =
+    let main window =
+
+        let logger =
+            LoggerConfiguration()
+                .MinimumLevel.Override("Elmish.WPF.Update", Events.LogEventLevel.Verbose)
+                .MinimumLevel.Override("Elmish.WPF.Bindings", Events.LogEventLevel.Verbose)
+                .MinimumLevel.Override("Elmish.WPF.Performance", Events.LogEventLevel.Verbose)
+                .WriteTo.Console()
+                .CreateLogger()
+
+        WpfProgram.mkSimpleT App.init App.update App_ViewModel
+        |> WpfProgram.withLogger (new SerilogLoggerFactory(logger))
+        |> WpfProgram.startElmishLoop window

--- a/src/Samples/SubModelOpt/App.xaml.cs
+++ b/src/Samples/SubModelOpt/App.xaml.cs
@@ -1,20 +1,19 @@
 ﻿using System;
 using System.Windows;
 
-namespace Elmish.WPF.Samples.SubModelOpt
+namespace Elmish.WPF.Samples.SubModelOpt;
+
+public partial class App
 {
-  public partial class App : Application
-  {
     public App()
     {
-      this.Activated += StartElmish;
+        this.Activated += StartElmish;
     }
 
     private void StartElmish(object sender, EventArgs e)
     {
-      this.Activated -= StartElmish;
-      Program.main(MainWindow);
+        this.Activated -= StartElmish;
+        Program.Program.main(MainWindow);
     }
 
-  }
 }

--- a/src/Samples/SubModelOpt/Form1.xaml
+++ b/src/Samples/SubModelOpt/Form1.xaml
@@ -1,15 +1,30 @@
-﻿<UserControl x:Class="Elmish.WPF.Samples.SubModelOpt.Form1"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelOpt;assembly=SubModelOpt.Core"
-             Padding="10"
-             mc:Ignorable="d"
-             d:DataContext="{x:Static vm:Program.form1DesignVm}">
-  <StackPanel Width="300">
-    <TextBlock Text="Form 1" FontSize="18" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,5" />
-    <TextBox Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}" TextWrapping="Wrap" AcceptsReturn="True" Height="80" Margin="0,5,0,5" />
-    <Button Command="{Binding Submit}" Content="Submit" />
-  </StackPanel>
+﻿<UserControl
+    x:Class="Elmish.WPF.Samples.SubModelOpt.Form1"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:vm="clr-namespace:Program;assembly=SubModelOpt.Core"
+    Padding="10"
+    d:DataContext="{d:DesignInstance Type=vm:Form1_ViewModel,
+                                     IsDesignTimeCreatable=True}"
+    mc:Ignorable="d">
+    <StackPanel
+        Width="300">
+        <TextBlock
+            Margin="0,0,0,5"
+            HorizontalAlignment="Center"
+            FontSize="18"
+            FontWeight="Bold"
+            Text="Form 1" />
+        <TextBox
+            Height="80"
+            Margin="0,5,0,5"
+            AcceptsReturn="True"
+            Text="{Binding Text, UpdateSourceTrigger=PropertyChanged}"
+            TextWrapping="Wrap" />
+        <Button
+            Command="{Binding Submit}"
+            Content="Submit" />
+    </StackPanel>
 </UserControl>

--- a/src/Samples/SubModelOpt/Form2.xaml
+++ b/src/Samples/SubModelOpt/Form2.xaml
@@ -1,16 +1,30 @@
-﻿<UserControl x:Class="Elmish.WPF.Samples.SubModelOpt.Form2"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelOpt;assembly=SubModelOpt.Core"
-             Padding="10"
-             mc:Ignorable="d"
-             d:DataContext="{x:Static vm:Program.form2DesignVm}">
-  <StackPanel Width="300">
-    <TextBlock Text="Form 2" FontSize="18" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,5" />
-    <TextBox Text="{Binding Text1, UpdateSourceTrigger=PropertyChanged}" Margin="0,5,0,5" />
-    <TextBox Text="{Binding Text2, UpdateSourceTrigger=PropertyChanged}" Margin="0,5,0,5" />
-    <Button Command="{Binding Submit}" Content="Submit" />
-  </StackPanel>
+﻿<UserControl
+    x:Class="Elmish.WPF.Samples.SubModelOpt.Form2"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:vm="clr-namespace:Program;assembly=SubModelOpt.Core"
+    Padding="10"
+    d:DataContext="{d:DesignInstance Type=vm:Form2_ViewModel,
+                                     IsDesignTimeCreatable=True}"
+    mc:Ignorable="d">
+    <StackPanel
+        Width="300">
+        <TextBlock
+            Margin="0,0,0,5"
+            HorizontalAlignment="Center"
+            FontSize="18"
+            FontWeight="Bold"
+            Text="Form 2" />
+        <TextBox
+            Margin="0,5,0,5"
+            Text="{Binding Text1, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox
+            Margin="0,5,0,5"
+            Text="{Binding Text2, UpdateSourceTrigger=PropertyChanged}" />
+        <Button
+            Command="{Binding Submit}"
+            Content="Submit" />
+    </StackPanel>
 </UserControl>

--- a/src/Samples/SubModelOpt/MainWindow.xaml
+++ b/src/Samples/SubModelOpt/MainWindow.xaml
@@ -1,50 +1,61 @@
-﻿<Window x:Class="Elmish.WPF.Samples.SubModelOpt.MainWindow"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:vm="clr-namespace:Elmish.WPF.Samples.SubModelOpt;assembly=SubModelOpt.Core"
-        xmlns:local="clr-namespace:Elmish.WPF.Samples.SubModelOpt"
-        Title="Sub-model"
-        Height="350"
-        Width="500"
-        WindowStartupLocation="CenterScreen"
-        mc:Ignorable="d"
-        d:DataContext="{x:Static vm:Program.mainDesignVm}">
-  <Window.Resources>
-    <ResourceDictionary>
-      <BooleanToVisibilityConverter x:Key="VisibilityConverter" />
-    </ResourceDictionary>
-  </Window.Resources>
-  <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-    <StackPanel Margin="0,15,0,0">
-      <Button Command="{Binding ShowForm1}" Content="Show form 1" Width="200" Margin="0,5,0,5" />
-      <Button Command="{Binding ShowForm2}" Content="Show form 2" Width="200" Margin="0,5,0,5" />
-    </StackPanel>
-    <Rectangle
-        Fill="Black"
-        Opacity="0.6"
-        Visibility="{Binding DialogVisible, Converter={StaticResource VisibilityConverter}}" />
-    <Border
-        BorderBrush="Black"
-        BorderThickness="2"
-        Width="350"
-        Height="200"
-        Visibility="{Binding DialogVisible, Converter={StaticResource VisibilityConverter}}">
-      <StackPanel Background="White">
-        <local:Form1
-            DataContext="{Binding Form1}"
-            d:DataContext="{Binding DataContext.Form1, RelativeSource={RelativeSource AncestorType=StackPanel}}"
-            Visibility="{Binding DataContext.Form1Visible,
-                         RelativeSource={RelativeSource AncestorType=StackPanel},
-                         Converter={StaticResource VisibilityConverter}}" />
-        <local:Form2
-            DataContext="{Binding Form2}"
-            d:DataContext="{Binding DataContext.Form2, RelativeSource={RelativeSource AncestorType=StackPanel}}"
-            Visibility="{Binding DataContext.Form2Visible,
-                         RelativeSource={RelativeSource AncestorType=StackPanel},
-                         Converter={StaticResource VisibilityConverter}}" />
-      </StackPanel>
-    </Border>
-  </Grid>
+﻿<Window
+    x:Class="Elmish.WPF.Samples.SubModelOpt.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:Elmish.WPF.Samples.SubModelOpt"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:vm="clr-namespace:Program;assembly=SubModelOpt.Core"
+    Title="Sub-model"
+    Width="500"
+    Height="350"
+    d:DataContext="{d:DesignInstance Type=vm:App_ViewModel,
+                                     IsDesignTimeCreatable=True}"
+    WindowStartupLocation="CenterScreen"
+    mc:Ignorable="d">
+    <Window.Resources>
+        <ResourceDictionary>
+            <BooleanToVisibilityConverter
+                x:Key="VisibilityConverter" />
+        </ResourceDictionary>
+    </Window.Resources>
+    <Grid
+        HorizontalAlignment="Stretch"
+        VerticalAlignment="Stretch">
+        <StackPanel
+            Margin="0,15,0,0">
+            <Button
+                Width="200"
+                Margin="0,5,0,5"
+                Command="{Binding ShowForm1}"
+                Content="Show form 1" />
+            <Button
+                Width="200"
+                Margin="0,5,0,5"
+                Command="{Binding ShowForm2}"
+                Content="Show form 2" />
+        </StackPanel>
+        <Rectangle
+            Fill="Black"
+            Opacity="0.6"
+            Visibility="{Binding DialogVisible, Converter={StaticResource VisibilityConverter}}" />
+        <Border
+            Width="350"
+            Height="200"
+            BorderBrush="Black"
+            BorderThickness="2"
+            Visibility="{Binding DialogVisible, Converter={StaticResource VisibilityConverter}}">
+            <StackPanel
+                Background="White">
+                <local:Form1
+                    d:DataContext="{Binding DataContext.Form1, RelativeSource={RelativeSource AncestorType=StackPanel}}"
+                    DataContext="{Binding Form1}"
+                    Visibility="{Binding DataContext.Form1Visible, RelativeSource={RelativeSource AncestorType=StackPanel}, Converter={StaticResource VisibilityConverter}}" />
+                <local:Form2
+                    d:DataContext="{Binding DataContext.Form2, RelativeSource={RelativeSource AncestorType=StackPanel}}"
+                    DataContext="{Binding Form2}"
+                    Visibility="{Binding DataContext.Form2Visible, RelativeSource={RelativeSource AncestorType=StackPanel}, Converter={StaticResource VisibilityConverter}}" />
+            </StackPanel>
+        </Border>
+    </Grid>
 </Window>


### PR DESCRIPTION
- I propose to convert all actual samples using dynamic bindings to static bindings, or make 2 folders and put appropriate samples in each: "Dynamic bindings", "Static bindings"

- I've run this new sample and everything works as expected, but I don't have enough knowledge to know if I've overlooked anything (e.g., not using the right helpers for better performance, missing relevant “>> Binding.x” (e.g., boxT, addLazy, etc.).

- I've converted 2-space indentation to 4-space idiomatic indentation (in fact, why do all samples use 2-space indentation? it's not practical to refactor everything to 4-space if you need to explore/reuse/etc. the sample).

- I suggest using (not idiomatic I know) “_Binding” for the binding helpers and “_ViewModel” for the static VM to improve readability and intellisense experience (i.e. writing “_V” filters automatically to get all static VMs; I do the same in WPF for "_Behaviors", "_Converter", "_ResourceDict" etc. which helps a lot IMO).

- I suggest skipping 2 lines between the module and the associated ViewModel, and 3 between the previous ViewModel and a new module; I suppose this too is not idiomatic, but IME it helps a lot with readability/navigation.

- I can do this kind of conversion from dyamic to static VM for all samples if you think it's relevant, it helps me learn at the same time. (I also intend to provide samples for what I think a “basic abstract project structure” that can scale well might look like (mostly based on previous discussions) if you think it's relevant too (?); this could at least be a starting point for possible samples of this kind, since I'm not an expert. Would another folder in the sample repo named “Project Structures” be relevant then?)

---

- should: 
```fs
let form2Visible_Binding =
    Binding.OneWayT.id
    >> Binding.mapModel (fun (m: App.Model) ->
        match m.Dialog with
        | Some (App.Dialog.Form2 _) -> true
        | _ -> false)

```
be replaced by:
```
    let form2Visible_Binding =
        Binding.oneWay (fun (m: App.Model) ->
            match m.Dialog with
            | Some (App.Dialog.Form2 _) -> true
            | _ -> false)

``` 
and same for all other binding helpers?

---

- Problem: `DataContext="{Binding Form1}"` (and Form2) is the only binding unable to resolve at compile time (though at runtime it works fine):
```fs
<local:Form1
    d:DataContext="{Binding DataContext.Form1, RelativeSource={RelativeSource AncestorType=StackPanel}}"
    DataContext="{Binding Form1}"
    Visibility="{Binding DataContext.Form1Visible, RelativeSource={RelativeSource AncestorType=StackPanel}, Converter={StaticResource VisibilityConverter}}" />
```
codelens says: `(Form1_ViewModel).Path=`, is there a way to access `(App_ViewModel).Path=` here?